### PR TITLE
Add cluster catalog repository in Kapitan target file

### DIFF
--- a/commodore/compile.py
+++ b/commodore/compile.py
@@ -58,7 +58,7 @@ def _regular_setup(config, customer, cluster):
     except Exception as e:
         raise click.ClickException(f"While cloning git repositories: {e}") from e
 
-    target_name = update_target(config, customer, cluster)
+    target_name = update_target(config, customer, cluster, inv['catalog_repo'])
     if target_name != 'cluster':
         raise click.ClickException(
             f"Only target with name 'cluster' is supported, got {target_name}")
@@ -117,7 +117,8 @@ def compile(config, customer, cluster):
     versions = kapitan_inventory['parameters'].get('component_versions', None)
     if versions and not config.local:
         set_component_versions(config, versions)
-        update_target(config, customer, cluster)
+        update_target(config, customer, cluster,
+                list(catalog_repo.remote('origin').urls)[0])
 
     jsonnet_libs = kapitan_inventory['parameters'].get(
         'commodore', {}).get('jsonnet_libs', None)

--- a/commodore/target.py
+++ b/commodore/target.py
@@ -14,7 +14,7 @@ def fetch_target(cfg, customer, cluster):
     return api_request(cfg.api_url, 'targets', customer, cluster)
 
 
-def _full_target(customer, cluster, apidata, components):
+def _full_target(customer, cluster, apidata, components, catalog):
     cloud_provider = apidata['cloud_type']
     cloud_region = apidata['cloud_region']
     cluster_distro = apidata['cluster_distribution']
@@ -36,7 +36,8 @@ def _full_target(customer, cluster, apidata, components):
             },
             'cloud': {
                 'type': f"{cloud_provider}",
-                'region': f"{cloud_region}"
+                'region': f"{cloud_region}",
+                'catalog_repo': f"{catalog}"
             },
             'customer': {
                 'name': f"{customer}"
@@ -45,7 +46,7 @@ def _full_target(customer, cluster, apidata, components):
     }
 
 
-def update_target(cfg, customer, cluster):
+def update_target(cfg, customer, cluster, catalog):
     click.secho('Updating Kapitan target...', bold=True)
     try:
         target = fetch_target(cfg, customer, cluster)
@@ -53,7 +54,8 @@ def update_target(cfg, customer, cluster):
         raise click.ClickException(f"While fetching target: {e}") from e
 
     os.makedirs('inventory/targets', exist_ok=True)
-    yaml_dump(_full_target(customer, cluster, target, cfg.get_components().keys()),
+    yaml_dump(_full_target(customer, cluster, target,
+        cfg.get_components().keys(), catalog),
               'inventory/targets/cluster.yml')
 
     return 'cluster'


### PR DESCRIPTION
Add the cluster catalog repository URL in the Kapitan cluster target
file as parameters.cluster.catalog_repo. Note that this value will most
likely be in the format ssh://git@example.com/path/to/repo which is
Commodore's normalized repository URL format.

Signed-off-by: Simon Gerber <simon.gerber@vshn.ch>