### PR TITLE
Configure refs with dict

### DIFF
--- a/commodore/refs.py
+++ b/commodore/refs.py
@@ -150,12 +150,7 @@ class RefBuilder:
             self._ref_params = {
                 'vaultkv': {
                     'key': 'vault_params',
-                    'values': {
-                        'auth': kapitan_params['auth'],
-                        'engine': kapitan_params['engine'],
-                        'mount': kapitan_params['mount'],
-                        'VAULT_ADDR': kapitan_params['VAULT_ADDR'],
-                    }
+                    'values': kapitan_params
                 }
             }
         return self._ref_params


### PR DESCRIPTION
Instead of picking only some of the configuration options, use the whole
dict since the key names are the same anyway.

Signed-off-by: Simon Rüegg <simon.ruegg@vshn.ch>