### PR TITLE
Allow reading API token from file

### DIFF
--- a/commodore/config.py
+++ b/commodore/config.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+from pathlib import Path as P
 
 Component = namedtuple('Component', ['name', 'repo', 'version'])
 
@@ -7,7 +8,13 @@ class Config:
     # pylint: disable=too-many-arguments
     def __init__(self, api_url, api_token, global_git, customer_git, verbose):
         self.api_url = api_url
-        self.api_token = api_token
+        self.api_token = None
+        if api_token is not None:
+            p = P(api_token)
+            if p.is_file():
+                with open(p) as apitoken:
+                    api_token = apitoken.read()
+            self.api_token = api_token.strip()
         self.global_git_base = global_git
         self.customer_git_base = customer_git
         self._components = {}

--- a/commodore/helpers.py
+++ b/commodore/helpers.py
@@ -60,10 +60,10 @@ def lieutenant_query(api_url, api_token, api_endpoint, api_id):
     try:
         r.raise_for_status()
     except HTTPError as e:
-        extra_msg = ''
+        extra_msg = '.'
         if r.status_code >= 400:
             extra_msg = f": {resp['reason']}"
-            raise ApiError(f"API returned {r.status_code}. Reason: {extra_msg}") from e
+        raise ApiError(f"API returned {r.status_code}{extra_msg}") from e
     else:
         return resp
 


### PR DESCRIPTION
This commit changes Commodore to optionally read the API token from a
file. If the API token argument (command line or environment variable)
exists as a file, Commodore will read the file contents and use them as
the API token. Otherwise the value of the argument is used as the API
token. This allows using the service account's token when running
Commodore on Kubernetes.

Relates: SYN-21