### PR TITLE
Fix check whether API token is a file

### DIFF
--- a/commodore/config.py
+++ b/commodore/config.py
@@ -10,10 +10,14 @@ class Config:
         self.api_url = api_url
         self.api_token = None
         if api_token is not None:
-            p = P(api_token)
-            if p.is_file():
-                with open(p) as apitoken:
-                    api_token = apitoken.read()
+            try:
+                p = P(api_token)
+                if p.is_file():
+                    with open(p) as apitoken:
+                        api_token = apitoken.read()
+            except OSError:
+                # Assume token is not configured as file
+                pass
             self.api_token = api_token.strip()
         self.global_git_base = global_git
         self.customer_git_base = customer_git


### PR DESCRIPTION
While illegal characters are not a problem for checking whether the
provided API token value is a path, pathlib fails to properly handle
long tokens (e.g. JWT), and fails with the error `OSError: [Errno 36]
File name too long: '...'` when encountering such a file name.

This commit wraps the whole check whether the provided API token value
is a file name in a try-block and silently assumes that any OSError
thrown by pathlib indicates that the provided value is not a file name.