### PR TITLE
Ensure Commodore binary version is set when pushing image

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,12 +13,14 @@ jobs:
       IMAGE: docker.io/${{ github.repository }}
     steps:
     - uses: actions/checkout@v1
-    - name: Set version latest
+    - name: Set image version latest
       if: github.ref == 'refs/heads/master'
       run: echo ::set-env name=VERSION::latest
-    - name: Set version from tag
+    - name: Set image version from tag
       if: startsWith(github.ref, 'refs/tags/v')
       run: echo ::set-env name=VERSION::$(echo ${GITHUB_REF#refs/tags/})
+    - name: Set binary version from Git
+      run: echo ::set-env name=BINARY_VERSION::$(git describe --tags --always --dirty --match=v*)
     - name: Build Image
       run: make docker
       env:
@@ -29,4 +31,4 @@ jobs:
         name: "${{ env.IMAGE }}:${{ env.VERSION }}"
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        buildargs: VERSION
+        buildargs: BINARY_VERSION


### PR DESCRIPTION
The imported Github action for pushing the docker image to DockerHub
does not run the `make docker` command and therefore the Commodore
binary version in the pushed image was not configured correctly.

This commit generates the binary version as a Github action step instead
of relying on the Makefile when building the image to be pushed.