### PR TITLE
Default to using Kapitan plugin on new components

### DIFF
--- a/component-template/{{ cookiecutter.project_slug }}/component/app.jsonnet
+++ b/component-template/{{ cookiecutter.project_slug }}/component/app.jsonnet
@@ -3,7 +3,7 @@ local inv = kap.inventory();
 local params = inv.parameters.{{ cookiecutter.component_param_key }};
 local argocd = import 'lib/argocd.libjsonnet';
 
-local app = argocd.App('{{ cookiecutter.component }}', params.namespace);
+local app = argocd.App('{{ cookiecutter.component }}', params.namespace, secrets=true);
 
 {
   '{{ cookiecutter.component }}': app,


### PR DESCRIPTION
If this is forgotten, secrets won't be applied correctly and it silently
fails.

