### PR TITLE
Organize global classes in folders

### DIFF
--- a/commodore/cluster.py
+++ b/commodore/cluster.py
@@ -49,9 +49,11 @@ def _full_target(cluster, components, catalog):
     customer = cluster['tenant']
     component_defaults = [f"defaults.{cn}" for cn in components if
                           (P('inventory/classes/defaults') / f"{cn}.yml").is_file()]
-    global_defaults = ['global.common', f"global.{cluster_distro}", f"global.{cloud_provider}"]
+    global_defaults = ['global.common',
+                       f"global.distribution.{cluster_distro}",
+                       f"global.cloud.{cloud_provider}"]
     if 'region' in cluster_facts:
-        global_defaults.append(f"global.{cloud_provider}.{cluster_facts['region']}")
+        global_defaults.append(f"global.cloud.{cloud_provider}.{cluster_facts['region']}")
     global_defaults.append(f"{customer}.{cluster_id}")
     target = {
         'classes': component_defaults + global_defaults,

--- a/docs/modules/ROOT/pages/writing-a-component.adoc
+++ b/docs/modules/ROOT/pages/writing-a-component.adoc
@@ -60,12 +60,12 @@ The hierarchy is as follows (starting at the lowest precedence):
 
 * Component defaults, included as `defaults.<component-name>` for each component
 * Global defaults, `global.common`
-* Kubernetes distribution defaults, `global.<kubernetes-distribution>`. The
+* Kubernetes distribution defaults, `global.distribution.<kubernetes-distribution>`. The
   intention of the hierarchy is that component classes are included in each
   distribution class separately to allow bootstrapping of new distributions in
   a multi-distribution environment easier
-* Cloud provider defaults, `global.<cloud-provider>`
-* Cloud provider region defaults, `global.<cloud-provider>.<region>`
+* Cloud provider defaults, `global.cloud.<cloud-provider>`
+* Cloud provider region defaults, `global.cloud.<cloud-provider>.<region>`
 * Cluster configuration, `<customer>.<cluster>`. The cluster configuration is
   managed in the customer's configuration repository. The customer repository
   can have any structure, the only requirement is that it contains a Kapitan
@@ -76,7 +76,7 @@ Kapitan classes is that components can be included at any point in the
 hierarchy, without having their defaults overwrite defaults defined higher up
 in the configuration hierarchy. F.e. without the split, a component included
 for a particular cloud provider would overwrite configuration values specified
-in `global.common` or `global.<kubernetes-distribution>` for which the
+in `global.common` or `global.distribution.<kubernetes-distribution>` for which the
 component provides defaults.
 
 == The component templates

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -24,8 +24,8 @@ def test_render_target():
     facts = cluster_obj['facts']
     all_classes = [f"defaults.{cn}" for cn in components] + [
         'global.common',
-        f"global.{facts['distribution']}",
-        f"global.{facts['cloud']}",
+        f"global.distribution.{facts['distribution']}",
+        f"global.cloud.{facts['cloud']}",
         f"{cluster_obj['tenant']}.{cluster_obj['id']}"]
     assert target != ""
     assert len(target['classes']) == len(all_classes), \
@@ -39,7 +39,7 @@ def test_optional_facts():
     cluster_obj['facts']['region'] = 'rma1'
     target = cluster._full_target(cluster_obj, components, catalog)
     facts = cluster_obj['facts']
-    assert f"global.{facts['cloud']}.{facts['region']}" in target['classes']
+    assert f"global.cloud.{facts['cloud']}.{facts['region']}" in target['classes']
 
 
 def test_missing_facts():
@@ -60,8 +60,8 @@ def test_reconstruct_api_response(tmp_path):
         file.write('''classes:
 - defaults.argocd
 - global.common
-- global.k3d
-- global.localdev
+- global.distribution.k3d
+- global.cloud.localdev
 - t-delicate-pine-3938.c-twilight-water-9032
 parameters:
   cloud:


### PR DESCRIPTION
Add sub folders `distribution` and `cloud` for the respective classes.

Needs to be merged with:
* https://git.vshn.net/syn/commodore-defaults/-/merge_requests/6

