### PR TITLE
Upgrade Kapitan to v0.27.3

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,8 +9,7 @@ autopep8 = "*"
 
 [packages]
 click = "*"
-# Until we get sane kapitan dependencies
-cookiecutter = "==1.7.0"
+cookiecutter = "*"
 GitPython = "*"
 kapitan = "*"
 requests = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c3156ad7f6624ccf79c1b2615b00912bffd5e701bebc48ce2bdd38d995df3089"
+            "sha256": "305f9308a6fa2aecd6810e6fc5d8aade40cb91518965cf595ee02fe46f127320"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -119,11 +119,11 @@
         },
         "cookiecutter": {
             "hashes": [
-                "sha256:479997e1c26c51bbbaf04097ef7d82b1d91cfb03f570cb5fb5ca265c88db04ae",
-                "sha256:910e6c423da42c45c2614d6676485d4872c4ed1bd9531cfff59280977f98fbf5"
+                "sha256:430eb882d028afb6102c084bab6cf41f6559a77ce9b18dc6802e3bc0cc5f4a30",
+                "sha256:efb6b2d4780feda8908a873e38f0e61778c23f6a2ea58215723bcceb5b515dac"
             ],
             "index": "pypi",
-            "version": "==1.7.0"
+            "version": "==1.7.2"
         },
         "cryptography": {
             "hashes": [
@@ -164,12 +164,6 @@
             ],
             "version": "==0.15.2"
         },
-        "future": {
-            "hashes": [
-                "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"
-            ],
-            "version": "==0.18.2"
-        },
         "gitdb": {
             "hashes": [
                 "sha256:91f36bfb1ab7949b3b40e23736db18231bf7593edada2ba5c3a174a7b23657ac",
@@ -177,20 +171,13 @@
             ],
             "version": "==4.0.5"
         },
-        "gitdb2": {
-            "hashes": [
-                "sha256:0986cb4003de743f2b3aba4c828edd1ab58ce98e1c4a8acf72ef02760d4beb4e",
-                "sha256:a1c974e5fab8c2c90192c1367c81cbc54baec04244bda1816e9c8ab377d1cba3"
-            ],
-            "version": "==4.0.2"
-        },
         "gitpython": {
             "hashes": [
-                "sha256:620b3c729bbc143b498cfea77e302999deedc55faec5b1067086c9ef90e101bc",
-                "sha256:a43a5d88a5bbc3cf32bb5223e4b4e68fd716db5e9996cad6e561bbfee6e5f4af"
+                "sha256:864a47472548f3ba716ca202e034c1900f197c0fb3a08f641c20c3cafd15ed94",
+                "sha256:da3b2cf819974789da34f95ac218ef99f515a928685db141327c09b73dd69c09"
             ],
             "index": "pypi",
-            "version": "==3.0.8"
+            "version": "==3.1.2"
         },
         "google-api-python-client": {
             "hashes": [
@@ -222,17 +209,17 @@
         },
         "hvac": {
             "hashes": [
-                "sha256:7e25794c6860155fa6f80420d7ac095e770c0d9088d7615048261574979267ec",
-                "sha256:f0b035f41d9fbf49a14e721b65f495f685060e870084323d1e8e0ee0eb024df5"
+                "sha256:0994e53a27d11dc344b21912f80ecd3a4a95a7a2d88f23980c21fc3182f395b2",
+                "sha256:784ea26950c6c32d471fb30536f65b139f057f4ea53e1f0bf158bbb9f5158db9"
             ],
-            "version": "==0.9.6"
+            "version": "==0.10.1"
         },
         "idna": {
             "hashes": [
-                "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
-                "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
+                "sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb",
+                "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"
             ],
-            "version": "==2.8"
+            "version": "==2.9"
         },
         "jinja2": {
             "hashes": [
@@ -270,11 +257,11 @@
         },
         "kapitan": {
             "hashes": [
-                "sha256:bb19f7d1132be1adec6420e077d239624efed8dbb781e3e0df781530c5aa2511",
-                "sha256:ce975d0fc7f3baaccf7343072e289cc877c03b1deb4894598206f746d4c3f80a"
+                "sha256:70d47a683571a2072a07b37dc4601485320e7d0dc55b0a981d694cecb0d83025",
+                "sha256:ec18884aab333d72f3dfc395510cd3bb8f175662ac637fba36690e81e7c74691"
             ],
             "index": "pypi",
-            "version": "==0.27.2"
+            "version": "==0.27.3"
         },
         "markupsafe": {
             "hashes": [
@@ -371,10 +358,16 @@
         },
         "python-gnupg": {
             "hashes": [
-                "sha256:3353e59949cd2c15efbf1fca45e347d8a22f4bed0d93e9b89b2657bda19cec05",
-                "sha256:c095a41f310ad7a4fd393406660ac9bd6c175ccaa0f072f9c18f33be8130a27a"
+                "sha256:3aa0884b3bd414652c2385b9df39e7b87272c2eca1b8fcc3089bc9e58652019a",
+                "sha256:cba3566e8a8fb7bb417d6897a6e17bfc7f9371052e57eb0057783c07d762a679"
             ],
-            "version": "==0.4.5"
+            "version": "==0.4.6"
+        },
+        "python-slugify": {
+            "hashes": [
+                "sha256:a8fc3433821140e8f409a9831d13ae5deccd0b033d4744d94b31fea141bdd84c"
+            ],
+            "version": "==4.0.0"
         },
         "pyyaml": {
             "hashes": [
@@ -394,11 +387,11 @@
         },
         "requests": {
             "hashes": [
-                "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4",
-                "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"
+                "sha256:43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee",
+                "sha256:b3f43d496c6daba4493e7c431722aeb7dbc6288f52a6e04e7b6023b0247817e6"
             ],
             "index": "pypi",
-            "version": "==2.22.0"
+            "version": "==2.23.0"
         },
         "rfc3987": {
             "hashes": [
@@ -435,6 +428,13 @@
             ],
             "version": "==3.0.4"
         },
+        "text-unidecode": {
+            "hashes": [
+                "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8",
+                "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93"
+            ],
+            "version": "==1.3"
+        },
         "uritemplate": {
             "hashes": [
                 "sha256:07620c3f3f8eed1f12600845892b0e036a2420acf513c53f7de0abd911a5894f",
@@ -464,13 +464,6 @@
                 "sha256:d735b91d6d1692a6a181f2a8c9e0238e5f6373356f561bb9dc4c7af36f452010"
             ],
             "version": "==0.57.0"
-        },
-        "whichcraft": {
-            "hashes": [
-                "sha256:acdbb91b63d6a15efbd6430d1d7b2d36e44a71697e93e19b7ded477afd9fce87",
-                "sha256:deda9266fbb22b8c64fd3ee45c050d61139cd87419765f588e37c8d23e236dd9"
-            ],
-            "version": "==0.6.1"
         },
         "yamllint": {
             "hashes": [

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,21 +20,20 @@ cryptography==2.9.2       # via kapitan
 docker==4.2.0             # via kapitan
 docutils==0.15.2          # via botocore
 future==0.18.2            # via cookiecutter
-gitdb2==4.0.2             # via gitpython
-gitdb==4.0.5              # via gitdb2
-gitpython==3.0.8          # via -r requirements.in, kapitan
+gitdb==4.0.5              # via gitpython
+gitpython==3.1.2          # via -r requirements.in, kapitan
 google-api-python-client==1.7.11  # via kapitan
 google-auth-httplib2==0.0.3  # via google-api-python-client
 google-auth==1.14.3       # via google-api-python-client, google-auth-httplib2
 httplib2==0.17.3          # via google-api-python-client, google-auth-httplib2
-hvac==0.9.6               # via kapitan
-idna==2.8                 # via requests
+hvac==0.10.1              # via kapitan
+idna==2.9                 # via requests
 jinja2-time==0.2.0        # via cookiecutter
 jinja2==2.11.2            # via cookiecutter, jinja2-time, kapitan
 jmespath==0.10.0          # via boto3, botocore
 jsonnet==0.15.0           # via kapitan
 jsonschema==3.2.0         # via kapitan
-kapitan==0.27.2           # via -r requirements.in
+kapitan==0.27.3           # via -r requirements.in
 markupsafe==1.1.1         # via jinja2
 pathspec==0.8.0           # via yamllint
 poyo==0.5.0               # via cookiecutter
@@ -44,9 +43,9 @@ pycparser==2.20           # via cffi
 pyparsing==2.4.7          # via kapitan
 pyrsistent==0.16.0        # via jsonschema
 python-dateutil==2.8.1    # via arrow, botocore
-python-gnupg==0.4.5       # via kapitan
+python-gnupg==0.4.6       # via kapitan
 pyyaml==5.3.1             # via kapitan, yamllint
-requests==2.22.0          # via -r requirements.in, cookiecutter, docker, hvac, kapitan
+requests==2.23.0          # via -r requirements.in, cookiecutter, docker, hvac, kapitan
 rfc3987==1.3.8            # via kapitan
 rsa==4.0                  # via google-auth
 s3transfer==0.3.3         # via boto3

--- a/tools/Dockerfile.kapitan
+++ b/tools/Dockerfile.kapitan
@@ -1,8 +1,8 @@
-# Pushed to docker.io/vshn/kapitan:v0.27.2
+# Pushed to docker.io/vshn/kapitan:v0.27.3
 
 FROM docker.io/alpine:3.11
 
-ENV KAPITAN_VERSION=v0.27.2
+ENV KAPITAN_VERSION=v0.27.3
 
 RUN apk add --no-cache \
         ca-certificates \


### PR DESCRIPTION
This includes among other fixes proper Vault error handling [1].

[1] https://github.com/deepmind/kapitan/pull/512

Signed-off-by: Simon Rüegg <simon@rueggs.ch>