### PR TITLE
Component URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,5 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+.vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ Please document all notable changes to this project in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Changed
+* Show some logs only in verbose mode ([#100])
+
+### Added
+* Allow overwriting of component git repo URLs ([#100])
+* Introduce trace log level with `-vvv` flag ([#100])
+
 ## [v0.1.5]
 
 ### Changed
@@ -65,3 +74,4 @@ Initial implementation
 [#94]: https://github.com/projectsyn/commodore/pull/94
 [#95]: https://github.com/projectsyn/commodore/pull/95
 [#99]: https://github.com/projectsyn/commodore/pull/99
+[#100]: https://github.com/projectsyn/commodore/pull/100

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ using `helm template`.
    # Lieutenant API token
    COMMODORE_API_TOKEN=<my-token>
    # Base URL for global Git repositories
-   COMMODORE_GLOBAL_GIT_BASE=ssh://git@github.com/projectsyn/
+   COMMODORE_GLOBAL_GIT_BASE=ssh://git@github.com/projectsyn
    # Your local user ID to be used in the container (optional, defaults to root)
    USER_ID=<your-user-id>
    ```

--- a/commodore/catalog.py
+++ b/commodore/catalog.py
@@ -6,8 +6,10 @@ from . import git
 from .helpers import rm_tree_contents
 
 
-def fetch_customer_catalog(repoinfo):
-    click.secho('Updating customer catalog...', bold=True)
+def fetch_customer_catalog(config, repoinfo):
+    click.secho('Updating cluster catalog...', bold=True)
+    if config.debug:
+        click.echo(f" > Cloning cluster catalog {repoinfo['url']}")
     return git.clone_repository(repoinfo['url'], 'catalog')
 
 

--- a/commodore/compile.py
+++ b/commodore/compile.py
@@ -60,24 +60,16 @@ def _regular_setup(config, cluster_id):
     customer_id = cluster['tenant']
 
     # Fetch components and config
-    try:
-        _fetch_global_config(config, cluster)
-        _fetch_customer_config(config, customer_id)
-        fetch_components(config)
-    except Exception as e:
-        raise click.ClickException(f"While cloning git repositories: {e}") from e
-
+    _fetch_global_config(config, cluster)
+    _fetch_customer_config(config, customer_id)
+    fetch_components(config)
     target_name = update_target(config, cluster)
     if target_name != 'cluster':
         raise click.ClickException(
             f"Only target with name 'cluster' is supported, got {target_name}")
 
     # Fetch catalog
-    try:
-        catalog_repo = fetch_customer_catalog(cluster['gitRepo'])
-    except Exception as e:
-        raise click.ClickException(
-            f"While cloning cluster catalog git repository: {e}") from e
+    catalog_repo = fetch_customer_catalog(cluster['gitRepo'])
 
     return cluster, target_name, catalog_repo
 

--- a/commodore/compile.py
+++ b/commodore/compile.py
@@ -14,6 +14,7 @@ from .cluster import (
     reconstruct_api_response,
     update_target,
 )
+from .config import Component
 from .dependency_mgmt import (
     fetch_components,
     fetch_jsonnet_libs,
@@ -108,7 +109,13 @@ def _local_setup(config, cluster_id):
             continue
         click.echo(f" > {c}")
         repo = git.init_repository(c)
-        config.register_component(c.name, repo)
+        component = Component(
+            name=c.name,
+            repo=repo,
+            version='master',
+            repo_url=repo.remotes.origin.url,
+        )
+        config.register_component(component)
 
     click.secho('Configuring catalog repo...', bold=True)
     catalog_repo = git.init_repository('catalog')

--- a/commodore/component_template.py
+++ b/commodore/component_template.py
@@ -31,7 +31,7 @@ def create_component(config, name, lib, pp):
     git.commit(repo, 'Initial commit')
 
     click.echo(' > Installing component')
-    create_component_symlinks(name)
+    create_component_symlinks(config, name)
 
     targetfile = P('inventory', 'targets', 'cluster.yml')
     target = yaml_load(targetfile)

--- a/commodore/config.py
+++ b/commodore/config.py
@@ -32,6 +32,10 @@ class Config:
     def debug(self):
         return self._verbose > 0
 
+    @property
+    def trace(self):
+        return self._verbose >= 3
+
     def update_verbosity(self, verbose):
         self._verbose += verbose
 

--- a/commodore/config.py
+++ b/commodore/config.py
@@ -1,7 +1,11 @@
 from collections import namedtuple
 from pathlib import Path as P
 
-Component = namedtuple('Component', ['name', 'repo', 'version'])
+
+class Component(namedtuple('Component', ['name', 'repo', 'version', 'repo_url'])):
+    @property
+    def target_directory(self):
+        return P('dependencies') / self.name
 
 
 class Config:
@@ -36,27 +40,30 @@ class Config:
     def trace(self):
         return self._verbose >= 3
 
+    @property
+    def config_file(self):
+        return 'inventory/classes/global/commodore.yml'
+
+    @property
+    def default_component_base(self):
+        return f"{self.global_git_base}/commodore-components"
+
     def update_verbosity(self, verbose):
         self._verbose += verbose
 
     def get_components(self):
         return self._components
 
-    def register_component(self, component, repo):
-        c = Component(
-            name=component,
-            repo=repo,
-            version='master',
-        )
-        self._components[component] = c
+    def register_component(self, component: Component):
+        self._components[component.name] = component
 
-    def set_component_version(self, component, version):
-        c = self._components[component]
+    def set_component_version(self, component_name, version):
+        c = self._components[component_name]
         c = c._replace(version=version)
-        self._components[component] = c
+        self._components[component_name] = c
 
-    def get_component_repo(self, component):
-        return self._components[component].repo
+    def get_component_repo(self, component_name):
+        return self._components[component_name].repo
 
     def get_configs(self):
         return self._config_repos

--- a/commodore/dependency_mgmt.py
+++ b/commodore/dependency_mgmt.py
@@ -50,7 +50,7 @@ def _discover_components(cfg, inventory_path):
     components = set()
     inventory = P(inventory_path)
     for classfile in inventory.glob('**/*.yml'):
-        if cfg.debug:
+        if cfg.trace:
             click.echo(f" > Discovering components in {classfile}")
         classyaml = yaml_load(classfile)
         if classyaml is not None:

--- a/commodore/dependency_mgmt.py
+++ b/commodore/dependency_mgmt.py
@@ -1,4 +1,3 @@
-import errno
 import os
 from pathlib import Path as P
 
@@ -17,13 +16,11 @@ def _relsymlink(srcdir, srcname, destdir, destname=None):
     link_src = os.path.relpath(P(srcdir) / srcname, start=destdir)
     link_dst = P(destdir) / destname
     try:
-        os.symlink(link_src, link_dst)
-    except OSError as e:
-        if e.errno == errno.EEXIST:
+        if link_dst.exists():
             os.remove(link_dst)
-            os.symlink(link_src, link_dst)
-        else:
-            raise click.ClickException(f"While setting up symlinks: {e}") from e
+        os.symlink(link_src, link_dst)
+    except Exception as e:
+        raise click.ClickException(f"While setting up symlinks: {e}") from e
 
 
 def create_component_symlinks(component):

--- a/commodore/git.py
+++ b/commodore/git.py
@@ -59,7 +59,11 @@ def checkout_version(repo, ref):
 
 
 def clone_repository(repository_url, directory):
-    repo = Repo.clone_from(_normalize_git_ssh(repository_url), directory)
+    try:
+        repo = Repo.clone_from(_normalize_git_ssh(repository_url), directory)
+    except Exception as e:
+        raise click.ClickException(
+            f"While cloning git repository: {e}") from e
     try:
         _ = repo.head.commit
     except ValueError as e:

--- a/commodore/postprocess/__init__.py
+++ b/commodore/postprocess/__init__.py
@@ -8,7 +8,7 @@ from .jsonnet import run_jsonnet_filter
 from .builtin_filters import run_builtin_filter
 
 
-def postprocess_components(inventory, target, components):
+def postprocess_components(config, inventory, target, components):
     click.secho('Postprocessing...', bold=True)
     for cn, c in components.items():
         if f"components.{cn}" not in inventory['classes']:
@@ -16,7 +16,8 @@ def postprocess_components(inventory, target, components):
         repodir = P(c.repo.working_tree_dir)
         filterdir = repodir / 'postprocess'
         if filterdir.is_dir():
-            click.echo(f" > {cn}...")
+            if config.debug:
+                click.echo(f" > {cn}...")
             filters = yaml_load(filterdir / 'filters.yml')
             for f in filters['filters']:
                 # old-style filters are always 'jsonnet'

--- a/commodore/refs.py
+++ b/commodore/refs.py
@@ -171,5 +171,6 @@ def update_refs(config, parameters):
     ref_params = rb.params
     # Create Kapitan references
     for r in rb.refs:
-        click.echo(f" > Creating Kapitan reffile for secret ref {r.refstr}")
+        if config.debug:
+            click.echo(f" > Creating Kapitan reffile for secret ref {r.refstr}")
         r.create_kapitan_ref(refdir, ref_params, debug=config.debug)

--- a/commodore/refs.py
+++ b/commodore/refs.py
@@ -88,8 +88,9 @@ class RefBuilder:
     Helper class to wrap recursive search for Kapitan secret references
     """
 
-    def __init__(self, debug, parameters):
+    def __init__(self, debug, trace, parameters):
         self.debug = debug
+        self.trace = trace
         self.parameters = parameters
         self._refs = {}
         self._ref_params = None
@@ -106,19 +107,19 @@ class RefBuilder:
                 if self.debug:
                     click.echo(f"    > Found secret ref {r.refstr} in {value}")
                 if r.refstr in self._refs:
-                    if self.debug:
+                    if self.trace:
                         click.echo('    > Duplicate ref, adding key to list')
                     self._refs[r.refstr].add_key(key)
                 else:
                     self._refs[r.refstr] = r
-        elif self.debug:
+        elif self.trace:
             click.echo(f"    > Ignoring leaf of type {type(value).__name__}...")
 
     def _find_refs(self, prefix, params):
         """
         Recursively search Kapitan refs, descending into dicts and lists.
         """
-        if self.debug:
+        if self.trace:
             click.echo(f" > Processing {prefix}")
 
         if isinstance(params, dict):
@@ -166,7 +167,7 @@ def update_refs(config, parameters):
     os.makedirs(refdir, exist_ok=True)
     rm_tree_contents(refdir)
     # Find references
-    rb = RefBuilder(config.debug, parameters)
+    rb = RefBuilder(config.debug, config.trace, parameters)
     rb.find_refs()
     ref_params = rb.params
     # Create Kapitan references

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -19,4 +19,4 @@ def test_no_customer_repo(test_patch):
     }
     with pytest.raises(click.ClickException) as excinfo:
         compile._fetch_customer_config(config, customer_id)
-    assert customer_id in str(excinfo.value)
+    assert customer_id in str(excinfo)

--- a/tests/test_dependency_mgmt.py
+++ b/tests/test_dependency_mgmt.py
@@ -3,7 +3,6 @@ Unit-tests for dependency management
 """
 
 import click
-import os
 import pytest
 
 from commodore import dependency_mgmt
@@ -22,3 +21,37 @@ def test_override_symlink(tmp_path: Path):
     assert not test_file.is_symlink()
     dependency_mgmt._relsymlink("./", test_file.name, tmp_path)
     assert test_file.is_symlink()
+
+
+def test_create_component_symlinks_fails():
+    component_name = "my-component"
+    with pytest.raises(click.ClickException) as excinfo:
+        dependency_mgmt.create_component_symlinks(component_name)
+    assert component_name in str(excinfo)
+
+
+def test_create_legacy_component_symlinks(capsys):
+    component_name = "my-component"
+    target_dir = Path('inventory/classes/components')
+    target_dir.mkdir(parents=True, exist_ok=True)
+    dependency_mgmt.create_component_symlinks(component_name)
+    capture = capsys.readouterr()
+    assert (target_dir / f"{component_name}.yml").is_symlink()
+    assert "Old-style component detected." in capture.out
+
+
+def test_create_component_symlinks(capsys):
+    component_name = "my-component"
+    class_dir = Path('dependencies') / component_name / "class"
+    class_dir.mkdir(parents=True, exist_ok=True)
+    (class_dir / f"{component_name}.yml").touch()
+    (class_dir / 'defaults.yml').touch()
+    target_dir = Path('inventory/classes/components')
+    target_dir.mkdir(parents=True, exist_ok=True)
+    target_defaults = Path('inventory/classes/defaults')
+    target_defaults.mkdir(parents=True, exist_ok=True)
+    dependency_mgmt.create_component_symlinks(component_name)
+    capture = capsys.readouterr()
+    assert (target_dir / f"{component_name}.yml").is_symlink()
+    assert (target_defaults / f"{component_name}.yml").is_symlink()
+    assert capture.out == ""

--- a/tests/test_dependency_mgmt.py
+++ b/tests/test_dependency_mgmt.py
@@ -1,0 +1,24 @@
+"""
+Unit-tests for dependency management
+"""
+
+import click
+import os
+import pytest
+
+from commodore import dependency_mgmt
+from pathlib import Path
+
+
+def test_symlink(tmp_path: Path):
+    test_file = tmp_path / "test1"
+    dependency_mgmt._relsymlink("./", test_file.name, tmp_path)
+    assert test_file.is_symlink()
+
+
+def test_override_symlink(tmp_path: Path):
+    test_file = tmp_path / "test2"
+    test_file.touch()
+    assert not test_file.is_symlink()
+    dependency_mgmt._relsymlink("./", test_file.name, tmp_path)
+    assert test_file.is_symlink()

--- a/tests/test_dependency_mgmt.py
+++ b/tests/test_dependency_mgmt.py
@@ -6,7 +6,18 @@ import click
 import pytest
 
 from commodore import dependency_mgmt
+from commodore.config import Config
+
 from pathlib import Path
+
+
+@pytest.fixture
+def data():
+    """
+    Setup test data
+    """
+
+    return Config("https://syn.example.com", "token", "ssh://git@git.example.com", False)
 
 
 def test_symlink(tmp_path: Path):
@@ -23,24 +34,24 @@ def test_override_symlink(tmp_path: Path):
     assert test_file.is_symlink()
 
 
-def test_create_component_symlinks_fails():
+def test_create_component_symlinks_fails(data: Config):
     component_name = "my-component"
     with pytest.raises(click.ClickException) as excinfo:
-        dependency_mgmt.create_component_symlinks(component_name)
+        dependency_mgmt.create_component_symlinks(data, component_name)
     assert component_name in str(excinfo)
 
 
-def test_create_legacy_component_symlinks(capsys):
+def test_create_legacy_component_symlinks(capsys, data: Config):
     component_name = "my-component"
     target_dir = Path('inventory/classes/components')
     target_dir.mkdir(parents=True, exist_ok=True)
-    dependency_mgmt.create_component_symlinks(component_name)
+    dependency_mgmt.create_component_symlinks(data, component_name)
     capture = capsys.readouterr()
     assert (target_dir / f"{component_name}.yml").is_symlink()
     assert "Old-style component detected." in capture.out
 
 
-def test_create_component_symlinks(capsys):
+def test_create_component_symlinks(capsys, data: Config):
     component_name = "my-component"
     class_dir = Path('dependencies') / component_name / "class"
     class_dir.mkdir(parents=True, exist_ok=True)
@@ -50,7 +61,7 @@ def test_create_component_symlinks(capsys):
     target_dir.mkdir(parents=True, exist_ok=True)
     target_defaults = Path('inventory/classes/defaults')
     target_defaults.mkdir(parents=True, exist_ok=True)
-    dependency_mgmt.create_component_symlinks(component_name)
+    dependency_mgmt.create_component_symlinks(data, component_name)
     capture = capsys.readouterr()
     assert (target_dir / f"{component_name}.yml").is_symlink()
     assert (target_defaults / f"{component_name}.yml").is_symlink()

--- a/tests/test_dependency_mgmt.py
+++ b/tests/test_dependency_mgmt.py
@@ -6,7 +6,8 @@ import click
 import pytest
 
 from commodore import dependency_mgmt
-from commodore.config import Config
+from commodore.config import Config, Component
+from unittest.mock import patch
 
 from pathlib import Path
 
@@ -21,48 +22,116 @@ def data():
 
 
 def test_symlink(tmp_path: Path):
-    test_file = tmp_path / "test1"
-    dependency_mgmt._relsymlink("./", test_file.name, tmp_path)
+    test_file = tmp_path / 'test1'
+    dependency_mgmt._relsymlink('./', test_file.name, tmp_path)
     assert test_file.is_symlink()
 
 
 def test_override_symlink(tmp_path: Path):
-    test_file = tmp_path / "test2"
+    test_file = tmp_path / 'test2'
     test_file.touch()
     assert not test_file.is_symlink()
-    dependency_mgmt._relsymlink("./", test_file.name, tmp_path)
+    dependency_mgmt._relsymlink('./', test_file.name, tmp_path)
     assert test_file.is_symlink()
 
 
 def test_create_component_symlinks_fails(data: Config):
-    component_name = "my-component"
+    component = Component(
+        name='my-component',
+        repo=None,
+        version='master',
+        repo_url=None,
+    )
     with pytest.raises(click.ClickException) as excinfo:
-        dependency_mgmt.create_component_symlinks(data, component_name)
-    assert component_name in str(excinfo)
+        dependency_mgmt.create_component_symlinks(data, component)
+    assert component.name in str(excinfo)
 
 
 def test_create_legacy_component_symlinks(capsys, data: Config):
-    component_name = "my-component"
+    component = Component(
+        name='my-component',
+        repo=None,
+        version='master',
+        repo_url=None,
+    )
     target_dir = Path('inventory/classes/components')
     target_dir.mkdir(parents=True, exist_ok=True)
-    dependency_mgmt.create_component_symlinks(data, component_name)
+    dependency_mgmt.create_component_symlinks(data, component)
     capture = capsys.readouterr()
-    assert (target_dir / f"{component_name}.yml").is_symlink()
-    assert "Old-style component detected." in capture.out
+    assert (target_dir / f"{component.name}.yml").is_symlink()
+    assert 'Old-style component detected.' in capture.out
 
 
 def test_create_component_symlinks(capsys, data: Config):
-    component_name = "my-component"
-    class_dir = Path('dependencies') / component_name / "class"
+    component = Component(
+        name='my-component',
+        repo=None,
+        version='master',
+        repo_url=None,
+    )
+    class_dir = Path('dependencies') / component.name / 'class'
     class_dir.mkdir(parents=True, exist_ok=True)
-    (class_dir / f"{component_name}.yml").touch()
+    (class_dir / f"{component.name}.yml").touch()
     (class_dir / 'defaults.yml').touch()
     target_dir = Path('inventory/classes/components')
     target_dir.mkdir(parents=True, exist_ok=True)
     target_defaults = Path('inventory/classes/defaults')
     target_defaults.mkdir(parents=True, exist_ok=True)
-    dependency_mgmt.create_component_symlinks(data, component_name)
+    dependency_mgmt.create_component_symlinks(data, component)
     capture = capsys.readouterr()
-    assert (target_dir / f"{component_name}.yml").is_symlink()
-    assert (target_defaults / f"{component_name}.yml").is_symlink()
-    assert capture.out == ""
+    assert (target_dir / f"{component.name}.yml").is_symlink()
+    assert (target_defaults / f"{component.name}.yml").is_symlink()
+    assert capture.out == ''
+
+
+def test_read_component_urls_no_config(data: Config):
+    with pytest.raises(click.ClickException) as excinfo:
+        dependency_mgmt._read_component_urls(data, [])
+    assert 'inventory/classes/global/commodore.yml' in str(excinfo)
+
+
+def test_read_component_urls(data: Config):
+    component_names = ['component-overwritten', 'component-default']
+    inventory_global = Path('inventory/classes/global')
+    inventory_global.mkdir(parents=True, exist_ok=True)
+    config_file = inventory_global / 'commodore.yml'
+    override_url = 'ssh://git@git.acme.com/some/component.git'
+    with open(config_file, 'w') as file:
+        file.write(f"""components:
+- name: component-overwritten
+  url: {override_url}
+""")
+
+    components = dependency_mgmt._read_component_urls(data, component_names)
+    override = components[0]
+    default = components[1]
+    assert override.repo_url == override_url
+    assert default.repo_url == \
+        f"{data.default_component_base}/{default.name}.git"
+
+
+@patch('commodore.dependency_mgmt._discover_components')
+@patch('commodore.dependency_mgmt._read_component_urls')
+@patch('commodore.git.clone_repository')
+def test_fetch_components(patch_discover, patch_urls, patch_clone, data: Config):
+    components = ['component-one', 'component-two']
+    # Prepare minimum component directories
+    for component in components:
+        class_dir = Path('dependencies') / component / 'class'
+        class_dir.mkdir(parents=True, exist_ok=True)
+        (class_dir / 'defaults.yml').touch(exist_ok=True)
+    patch_discover.return_value = components
+    patch_urls.return_value = [
+        Component(
+            name=c,
+            repo=None,
+            repo_url='mock-url',
+            version='master',
+        ) for c in components]
+    dependency_mgmt.fetch_components(data)
+    print(data._components)
+    for component in components:
+        assert component in data._components
+        assert (Path('inventory/classes/components') / f"{component}.yml").is_symlink()
+        assert (Path('inventory/classes/defaults') / f"{component}.yml").is_symlink()
+        assert data.get_component_repo(component) is not None

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -2,13 +2,24 @@
 Unit-tests for git
 """
 
+import click
+import pytest
+
 from commodore import git
 from pathlib import Path
 
 
-def test_reconstruct_api_response(tmp_path: Path):
+def test_create_repository(tmp_path: Path):
     repo_path = tmp_path / 'test-repo'
     repo_path.mkdir()
     repo = git.create_repository(repo_path)
     output = git.stage_all(repo)
     assert output != ""
+
+
+def test_clone_error(tmp_path: Path):
+    inexistent_url = 'ssh://git@git.example.com/some/repo.git'
+    with pytest.raises(click.ClickException) as excinfo:
+        git.clone_repository(inexistent_url, tmp_path)
+    print(f"error: {excinfo.value}")
+    assert inexistent_url in str(excinfo.value)

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -21,5 +21,4 @@ def test_clone_error(tmp_path: Path):
     inexistent_url = 'ssh://git@git.example.com/some/repo.git'
     with pytest.raises(click.ClickException) as excinfo:
         git.clone_repository(inexistent_url, tmp_path)
-    print(f"error: {excinfo.value}")
     assert inexistent_url in str(excinfo.value)

--- a/tests/test_new-component.py
+++ b/tests/test_new-component.py
@@ -11,10 +11,10 @@ def test_run_newcomponent_command():
     Run the new-component command
     """
 
-    os.makedirs(P('inventory', 'classes', 'components'))
-    os.makedirs(P('inventory', 'classes', 'defaults'))
-    os.makedirs(P('dependencies', 'lib'))
-    os.makedirs(P('inventory', 'targets'))
+    os.makedirs(P('inventory', 'classes', 'components'), exist_ok=True)
+    os.makedirs(P('inventory', 'classes', 'defaults'), exist_ok=True)
+    os.makedirs(P('dependencies', 'lib'), exist_ok=True)
+    os.makedirs(P('inventory', 'targets'), exist_ok=True)
     targetyml = P('inventory', 'targets', 'cluster.yml')
     with open(targetyml, 'w') as file:
         file.write('''classes:


### PR DESCRIPTION
Allow overwriting of component git repo URLs.
The component git repo URLs can be overwritten in a global Commodore
config file. The config file is searched for in the global inventory
repo. The global git base is used as default for non overwritten
components.

Closes #73 