### PR TITLE
Handle empty facts

### DIFF
--- a/commodore/cluster.py
+++ b/commodore/cluster.py
@@ -46,7 +46,7 @@ def reconstruct_api_response(target_yml):
 def _full_target(cluster, components, catalog):
     cluster_facts = cluster['facts']
     for required_fact in ['distribution', 'cloud']:
-        if required_fact not in cluster_facts:
+        if required_fact not in cluster_facts or not cluster_facts[required_fact]:
             raise click.ClickException(f"Required fact '{required_fact}' not set")
 
     cluster_distro = cluster_facts['distribution']
@@ -58,9 +58,9 @@ def _full_target(cluster, components, catalog):
     global_defaults = ['global.common',
                        f"global.distribution.{cluster_distro}",
                        f"global.cloud.{cloud_provider}"]
-    if 'region' in cluster_facts:
+    if 'region' in cluster_facts and cluster_facts['region']:
         global_defaults.append(f"global.cloud.{cloud_provider}.{cluster_facts['region']}")
-    if 'lieutenant-instance' in cluster_facts:
+    if 'lieutenant-instance' in cluster_facts and cluster_facts['lieutenant-instance']:
         global_defaults.append(
             f"global.lieutenant-instance.{cluster_facts['lieutenant-instance']}")
     global_defaults.append(f"{customer}.{cluster_id}")

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -51,6 +51,13 @@ def test_optional_fact_region(data):
     assert f"global.cloud.{facts['cloud']}.{facts['region']}" in target['classes']
 
 
+def test_optional_fact_region_empty(data):
+    data['cluster']['facts']['region'] = ''
+    target = cluster._full_target(data['cluster'], data['components'], data['catalog'])
+    facts = data['cluster']['facts']
+    assert f"global.cloud.{facts['cloud']}.{facts['region']}" not in target['classes']
+
+
 def test_optional_fact_lieutenant_instance(data):
     data['cluster']['facts']['lieutenant-instance'] = 'lieutenant-dev'
     target = cluster._full_target(data['cluster'], data['components'], data['catalog'])
@@ -60,6 +67,12 @@ def test_optional_fact_lieutenant_instance(data):
 
 def test_missing_facts(data):
     data['cluster']['facts'].pop('cloud')
+    with pytest.raises(click.ClickException):
+        cluster._full_target(data['cluster'], data['components'], data['catalog'])
+
+
+def test_empty_facts(data):
+    data['cluster']['facts']['cloud'] = ''
     with pytest.raises(click.ClickException):
         cluster._full_target(data['cluster'], data['components'], data['catalog'])
 


### PR DESCRIPTION
If a fact is set to an empty string, handle it accordingly. Depending if
the fact is required or not, fail or ignore it respectively.

