### PR TITLE
Allow overriding of component URL in inventory

### DIFF
--- a/commodore/catalog.py
+++ b/commodore/catalog.py
@@ -17,7 +17,7 @@ def _pretty_print_component_commit(name, component):
     repo = component.repo
     sha = repo.head.commit.hexsha
     short_sha = repo.git.rev_parse(sha, short=6)
-    return f" * {name}:{component.version} ({short_sha})"
+    return f" * {name}: {component.version} ({short_sha})"
 
 
 def _pretty_print_config_commit(name, repo):

--- a/commodore/compile.py
+++ b/commodore/compile.py
@@ -18,7 +18,7 @@ from .config import Component
 from .dependency_mgmt import (
     fetch_components,
     fetch_jsonnet_libs,
-    set_component_versions
+    set_component_overrides
 )
 from .helpers import (
     ApiError,
@@ -137,7 +137,7 @@ def compile(config, cluster_id):
     kapitan_inventory = inventory_reclass('inventory')['nodes'][target_name]
     versions = kapitan_inventory['parameters'].get('component_versions', None)
     if versions and not config.local:
-        set_component_versions(config, versions)
+        set_component_overrides(config, versions)
         update_target(config, cluster)
 
     jsonnet_libs = kapitan_inventory['parameters'].get(

--- a/commodore/config.py
+++ b/commodore/config.py
@@ -1,8 +1,15 @@
-from collections import namedtuple
+from typing import NamedTuple
 from pathlib import Path as P
 
+from git import Repo
 
-class Component(namedtuple('Component', ['name', 'repo', 'version', 'repo_url'])):
+
+class Component(NamedTuple):
+    name: str
+    repo: Repo
+    repo_url: str
+    version: str = 'master'
+
     @property
     def target_directory(self):
         return P('dependencies') / self.name
@@ -61,6 +68,13 @@ class Config:
         c = self._components[component_name]
         c = c._replace(version=version)
         self._components[component_name] = c
+        return c
+
+    def set_repo_url(self, component_name, repo_url):
+        c = self._components[component_name]
+        c = c._replace(repo_url=repo_url)
+        self._components[component_name] = c
+        return c
 
     def get_component_repo(self, component_name):
         return self._components[component_name].repo

--- a/commodore/git.py
+++ b/commodore/git.py
@@ -72,6 +72,20 @@ def clone_repository(repository_url, directory):
     return repo
 
 
+def update_remote(repo: Repo, remote_url):
+    origin = repo.remotes.origin
+    if origin.url != remote_url:
+        with origin.config_writer as cw:
+            cw.set("url", remote_url)
+        try:
+            origin.pull(prune=True)
+            return True
+        except Exception as e:
+            raise click.ClickException(
+                f"While fetching git repository: {e}") from e
+    return False
+
+
 def init_repository(path):
     return Repo(path)
 

--- a/commodore/git.py
+++ b/commodore/git.py
@@ -8,9 +8,7 @@ from git.exc import GitCommandError, BadName
 
 
 class RefError(ValueError):
-    def __init__(self, message):
-        super().__init__()
-        self.message = message
+    pass
 
 
 def _normalize_git_ssh(url):

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -6,19 +6,27 @@ import click
 import pytest
 
 from commodore import git
+from git import Repo
 from pathlib import Path
 
 
-def test_create_repository(tmp_path: Path):
-    repo_path = tmp_path / 'test-repo'
-    repo_path.mkdir()
-    repo = git.create_repository(repo_path)
+def test_create_repository(tmpdir: Path):
+    repo = git.create_repository(tmpdir)
     output = git.stage_all(repo)
     assert output != ""
 
 
-def test_clone_error(tmp_path: Path):
+def test_clone_error(tmpdir: Path):
     inexistent_url = 'ssh://git@git.example.com/some/repo.git'
     with pytest.raises(click.ClickException) as excinfo:
-        git.clone_repository(inexistent_url, tmp_path)
+        git.clone_repository(inexistent_url, tmpdir)
     assert inexistent_url in str(excinfo.value)
+
+
+def test_update_remote(tmpdir: Path):
+    new_url = 'ssh://git@git.example.com/some/repo.git'
+    repo = Repo.init(tmpdir)
+    repo.create_remote('origin', url='ssh://')
+    with pytest.raises(click.ClickException):
+        git.update_remote(repo, new_url)
+    assert repo.remotes.origin.url == new_url


### PR DESCRIPTION
In addition to the version this allows to override the Git URL for a component, using the `component_versions` dict. This allows for example the usecase of a forked component repository to be used for a certain part of the hierarchy.

Closes https://github.com/projectsyn/commodore/issues/73