### PR TITLE
 Option to explicitly set a component's display name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * `getValueOrDefault` helper ([#125])
 * `makeMergeable` helper ([#126])
 * `commodore component compile` to compile a single component ([#122])
+* Option to explicitly set a compnents display name ([#133])
 * labels to issue templates ([#134])
 
 ### Changed
@@ -101,4 +102,5 @@ Initial implementation
 [#125]: https://github.com/projectsyn/commodore/pull/125
 [#126]: https://github.com/projectsyn/commodore/pull/126
 [#130]: https://github.com/projectsyn/commodore/pull/130
+[#133]: https://github.com/projectsyn/commodore/pull/133
 [#134]: https://github.com/projectsyn/commodore/pull/134

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * `getValueOrDefault` helper ([#125])
 * `makeMergeable` helper ([#126])
 * `commodore component compile` to compile a single component ([#122])
-* Option to explicitly set a compnents display name ([#133])
+* Option to explicitly set a components display name ([#133])
 * labels to issue templates ([#134])
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * `getValueOrDefault` helper ([#125])
 * `makeMergeable` helper ([#126])
 * `commodore component compile` to compile a single component ([#122])
-* Option to explicitly set a components display name ([#133])
+* Option to explicitly set a component's display name ([#133])
 * labels to issue templates ([#134])
 
 ### Changed

--- a/commodore/cli.py
+++ b/commodore/cli.py
@@ -82,7 +82,9 @@ def component(config: Config, verbose):
 
 
 @component.command(name='new', short_help='Bootstrap a new component.')
-@click.argument('name')
+@click.argument('slug')
+@click.option('--name',
+              help='The compnents name as it will be written in the documentation. Defaults to the slug.')
 @click.option('--lib/--no-lib', default=False, show_default=True,
               help='Add a component library template.')
 @click.option('--pp/--no-pp', default=False, show_default=True,
@@ -95,9 +97,10 @@ def component(config: Config, verbose):
 @verbosity
 @pass_config
 # pylint: disable=too-many-arguments
-def component_new(config: Config, name, lib, pp, owner, copyright_holder, verbose):
+def component_new(config: Config, slug, name, lib, pp, owner, copyright_holder, verbose):
     config.update_verbosity(verbose)
-    f = ComponentFactory(config, name)
+    f = ComponentFactory(config, slug)
+    f.name = name
     f.library = lib
     f.post_process = pp
     f.github_owner = owner

--- a/commodore/cli.py
+++ b/commodore/cli.py
@@ -84,7 +84,7 @@ def component(config: Config, verbose):
 @component.command(name='new', short_help='Bootstrap a new component.')
 @click.argument('slug')
 @click.option('--name',
-              help='The compnents name as it will be written in the documentation. Defaults to the slug.')
+              help="The component's name as it will be written in the documentation. Defaults to the slug.")
 @click.option('--lib/--no-lib', default=False, show_default=True,
               help='Add a component library template.')
 @click.option('--pp/--no-pp', default=False, show_default=True,

--- a/commodore/component-template/cookiecutter.json
+++ b/commodore/component-template/cookiecutter.json
@@ -1,6 +1,6 @@
 {
-  "name": "The Component",
-  "slug": "{{ cookiecutter.name.lower().replace(' ', '-') }}",
+  "name": "{{ cookiecutter.slug }}",
+  "slug": "the-component",
   "parameter_key": "{{ cookiecutter.slug.replace('-', '_') }}",
 
   "add_lib": "n",

--- a/commodore/component/template.py
+++ b/commodore/component/template.py
@@ -30,7 +30,7 @@ class ComponentFactory:
 
     @property
     def name(self):
-        if not isinstance(self._name, str) or len(self._name) == 0:
+        if not self._name:
             return self.slug
         return self._name
 

--- a/commodore/component/template.py
+++ b/commodore/component/template.py
@@ -16,7 +16,6 @@ from commodore.helpers import yaml_load, yaml_dump
 class ComponentFactory:
     # pylint: disable=too-many-instance-attributes
     config: CommodoreConfig
-    name: str
     slug: str
     library: bool
     post_process: bool
@@ -24,11 +23,20 @@ class ComponentFactory:
     copyright_holder: str
     today: datetime
 
-    def __init__(self, config, name):
+    def __init__(self, config, slug):
         self.config = config
-        self.name = name
-        self.slug = name.lower().replace(' ', '-')
+        self.slug = slug
         self.today = datetime.date.today()
+
+    @property
+    def name(self):
+        if not isinstance(self._name, str) or len(self._name) == 0:
+            return self.slug
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        self._name = name
 
     def cookiecutter_args(self):
         return {
@@ -38,6 +46,7 @@ class ComponentFactory:
             'copyright_year': self.today.strftime("%Y"),
             'github_owner': self.github_owner,
             'name': self.name,
+            'slug': self.slug,
             'release_date': self.today.strftime("%Y-%m-%d"),
         }
 

--- a/tests/test_component_new.py
+++ b/tests/test_component_new.py
@@ -6,11 +6,7 @@ import yaml
 from pathlib import Path as P
 
 
-def test_run_component_new_command(tmp_path: P):
-    """
-    Run the component new command
-    """
-
+def setup_directory(tmp_path: P):
     os.chdir(tmp_path)
 
     os.makedirs(P('inventory', 'classes', 'components'), exist_ok=True)
@@ -21,6 +17,17 @@ def test_run_component_new_command(tmp_path: P):
     with open(targetyml, 'w') as file:
         file.write('''classes:
         - test''')
+
+    return targetyml
+
+
+def test_run_component_new_command(tmp_path: P):
+    """
+    Run the component new command
+    """
+
+    targetyml = setup_directory(tmp_path)
+
     component_name = 'test-component'
     exit_status = os.system(f"commodore -vvv component new {component_name} --lib --pp")
     assert exit_status == 0
@@ -41,3 +48,25 @@ def test_run_component_new_command(tmp_path: P):
         target = yaml.safe_load(file)
         assert target['classes'][0] == f"defaults.{component_name}"
         assert target['classes'][-1] == f"components.{component_name}"
+
+
+def test_run_component_new_command_with_name(tmp_path: P):
+    """
+    Run the component new command with the slug option set
+    """
+
+    setup_directory(tmp_path)
+
+    component_name = 'Component with custom name'
+    component_slug = 'named-component'
+    readme_path = P('dependencies', component_slug, 'README.md')
+
+    exit_status = os.system(f"commodore -vvv component new --name '{component_name}' {component_slug}")
+
+    assert exit_status == 0
+    assert os.path.exists(readme_path)
+
+    with open(readme_path, 'r') as file:
+        data = file.read()
+        assert component_name in data
+        assert component_slug not in data


### PR DESCRIPTION
Sometimes the components slug and the wording in the documentation can not be handled with simple transliteration rules. This PR adds an option to set them differently. This is done by changing the `commodore component new` command to take the slug instead of the name as its argument. In order to set the name again, an option is added.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests.
- [x] Update the ./CHANGELOG.md.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
