### PR TITLE
Refactor test GitHub workflow to ensure right Python version is installed

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
     - master
 
 jobs:
-  tests:
+  lints:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -13,9 +13,6 @@ jobs:
           - lint_flake8
           - lint_pylint
           - lint_bandit
-          - test_py36
-          - test_py37
-          - test_py38
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
@@ -24,6 +21,24 @@ jobs:
         pip install poetry tox
     - name: Run ${{ matrix.command }}
       run: make ${{ matrix.command }}
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version:
+          - '3.6'
+          - '3.7'
+          - '3.8'
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install Poetry
+      run: |
+        pip install poetry tox
+    - name: Run tests on Python ${{ matrix.python-version }}
+      run: make test_py${{ matrix.python-version }}
   docs:
     runs-on: ubuntu-latest
     steps:
@@ -34,6 +49,7 @@ jobs:
       run: make docs
   build:
     needs:
+    - lints
     - tests
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Option to explicitly set a component's display name ([#133])
 * labels to issue templates ([#134])
 * Vale Makefile target in component template ([#137])
+* Refactor tests to work with new setup-python ([#143])
 
 ### Changed
 
@@ -112,3 +113,4 @@ Initial implementation
 [#134]: https://github.com/projectsyn/commodore/pull/134
 [#136]: https://github.com/projectsyn/commodore/issues/136
 [#137]: https://github.com/projectsyn/commodore/pull/137
+[#137]: https://github.com/projectsyn/commodore/pull/143

--- a/tox.mk
+++ b/tox.mk
@@ -18,11 +18,11 @@ lint: lint_flake8 lint_pylint lint_bandit
 
 .PHONY: test_py36 test_py37 test_py38
 
-test_py36:
+test_py3.6:
 	$(TOX_COMMAND) -e py36
 
-test_py37:
+test_py3.7:
 	$(TOX_COMMAND) -e py37
 
-test_py38:
+test_py3.8:
 	$(TOX_COMMAND) -e py38


### PR DESCRIPTION
The setup-python action does not install multiple Python versions
anymore, but defaults to the latest stable Python 3 version. The version
can be selected by specifying `python-version` to the action.

This commit refactors the testing workflow to setup the right versions
to run the tests under Python 3.6, 3.7, and 3.8.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the ./CHANGELOG.md.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
