### PR TITLE
Add folders generated during catalog compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 _antora
 
 ## Ignore commodore output
+catalog
 compiled
 dependencies
 inventory

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ _antora
 
 ## Ignore commodore output
 compiled
+dependencies
+inventory
 ## From here: GitHub's gitignore template for Python
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,7 @@
 _antora
 
 ## Ignore commodore output
-catalog
 compiled
-dependencies
-inventory
 ## From here: GitHub's gitignore template for Python
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ using `helm template`.
 
 ## Run Commodore in Docker
 
+NOTE: After checking out this project, run `mkdir -p catalog inventory dependencies` in it before running any Docker commands. This will ensure the folders are writable by the current user in the context of the Docker container.
+
 A docker-compose setup enables running Commodore in a container.
 The environment variables are picked up from the local `.env` file.
 By default your `~/.ssh/` directory is mounted into the container and an `ssh-agent` is started.

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ using `helm template`.
 
 ## Run Commodore in Docker
 
-NOTE: After checking out this project, run `mkdir -p catalog inventory dependencies` in it before running any Docker commands. This will ensure the folders are writable by the current user in the context of the Docker container.
+*IMPORTANT:* After checking out this project, run `mkdir -p catalog inventory dependencies` in it before running any Docker commands. This will ensure the folders are writable by the current user in the context of the Docker container.
 
 A docker-compose setup enables running Commodore in a container.
 The environment variables are picked up from the local `.env` file.

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ using `helm template`.
 
 ## Run Commodore in Docker
 
-*IMPORTANT:* After checking out this project, run `mkdir -p catalog inventory dependencies` in it before running any Docker commands. This will ensure the folders are writable by the current user in the context of the Docker container.
+**IMPORTANT:** After checking out this project, run `mkdir -p catalog inventory dependencies` in it before running any Docker commands. This will ensure the folders are writable by the current user in the context of the Docker container.
 
 A docker-compose setup enables running Commodore in a container.
 The environment variables are picked up from the local `.env` file.


### PR DESCRIPTION
This PR includes folders that were previously ignored. 

## Reason

The reason is the `docker run projectsyn/commodore catalog compile` command which generates those folders as belonging to the root user, which prevents from writing to them. Situation found on a Ubuntu 18.04 system. The solution was to `mkdir` the folders before running the command.

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [ ] Update the documentation.
- [ ] Update tests.
- [ ] Update the ./CHANGELOG.md.
- [ ] Link this PR to related issues.
