### PR TITLE
Added network requirements in the docker-compose.yaml file

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,8 @@
 version: "3.0"
+networks:
+  default:
+    external:
+      name: host
 services:
   commodore:
     build: .


### PR DESCRIPTION
Adds host network support to the docker-compose.yaml file, so that Docker-based Commodore can connect to local instances of the Lieutenant API.

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [ ] Update the documentation.
- [ ] Update tests.
- [ ] Update the ./CHANGELOG.md.
- [ ] Link this PR to related issues.
