### PR TITLE
Run postprocessing filters when compiling a single component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 * Validation of component slug ([#153])
+* `component compile` now applies postprocessing filters ([#154])
 
 ## [v0.2.2]
 
@@ -143,3 +144,4 @@ Initial implementation
 [#148]: https://github.com/projectsyn/commodore/pull/148
 [#151]: https://github.com/projectsyn/commodore/pull/151
 [#153]: https://github.com/projectsyn/commodore/pull/153
+[#154]: https://github.com/projectsyn/commodore/pull/154


### PR DESCRIPTION
When compiling a single component using `commodore component compile`, any postprocessing filters which are defined for the component should be applied to the output of `kapitan compile`.

This commit adds code which calls the usual `postprocess.postprocess_components()` method for just the component that is getting compiled.

## Checklist
- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests.
- [x] Update the ./CHANGELOG.md.
