### PR TITLE
Allow postprocessing filters to be disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 * Validation of component slug ([#153])
 * `component compile` now applies postprocessing filters ([#154])
+* Option to disable postprocessing filters ([#155])
 
 ## [v0.2.2]
 
@@ -145,3 +146,4 @@ Initial implementation
 [#151]: https://github.com/projectsyn/commodore/pull/151
 [#153]: https://github.com/projectsyn/commodore/pull/153
 [#154]: https://github.com/projectsyn/commodore/pull/154
+[#155]: https://github.com/projectsyn/commodore/pull/155

--- a/commodore/postprocess/inventory.py
+++ b/commodore/postprocess/inventory.py
@@ -1,0 +1,45 @@
+import re
+
+
+class InventoryError(Exception):
+    pass
+
+
+INV_REF = re.compile(r'\$\{([^}]+)\}')
+
+
+def _resolve_var(inv, m):
+    var = m.group(1)
+    invpath = var.split(':')
+    val = inv['parameters']
+    for elem in invpath:
+        val = val.get(elem, None)
+        if val is None:
+            raise InventoryError(f"Unable to resolve inventory reference {var}")
+    return val
+
+
+def resolve_inventory_vars(inv, args):
+    """
+    Recursively resolve reclass references in `args`.
+    """
+    resolved = {}
+    for k, v in args.items():
+        if isinstance(v, list):
+            resolved[k] = map(lambda e: resolve_inventory_vars(inv, e), v)
+        elif isinstance(v, dict):
+            resolved[k] = resolve_inventory_vars(inv, v)
+        elif isinstance(v, str):
+            try:
+                resolved[k] = INV_REF.sub(lambda m: _resolve_var(inv, m), v)
+            except TypeError as e:
+                if v.startswith('${') and v.endswith('}'):
+                    m = INV_REF.match(v)
+                    if m is None:
+                        raise InventoryError(f"Error replacing reference: {e}") from e
+                    resolved[k] = _resolve_var(inv, m)
+                else:
+                    raise e
+        else:
+            resolved[k] = v
+    return resolved

--- a/tests/test_postprocess.py
+++ b/tests/test_postprocess.py
@@ -1,0 +1,133 @@
+"""
+Tests for postprocessing
+"""
+import os
+import yaml
+from commodore.config import Config, Component
+from commodore.postprocess import postprocess_components
+from git import Repo
+from test_component_new import test_run_component_new_command
+
+
+def _make_ns_filter(ns, enabled=None):
+    filter = {
+        'filters': [{
+            'path': 'test',
+            'type': 'builtin',
+            'filter': 'helm_namespace',
+            'filterargs': {
+                'namespace': ns,
+            }
+        }]
+    }
+    if enabled is not None:
+        filter['filters'][0]['enabled'] = enabled
+    return filter
+
+
+def _setup(tmp_path, filter):
+    os.chdir(tmp_path)
+
+    test_run_component_new_command(tmp_path=tmp_path)
+
+    target = 'target'
+    targetdir = tmp_path / 'compiled' / target / 'test'
+    os.makedirs(targetdir, exist_ok=True)
+    testf = targetdir / 'object.yaml'
+    with open(testf, 'w') as objf:
+        obj = {
+            'metadata': {
+                'name': 'test',
+                'namespace': 'untouched',
+            },
+            'kind': 'Secret',
+            'apiVersion': 'v1',
+            'stringData': {
+                'content': 'verysecret',
+            },
+        }
+        yaml.dump(obj, objf)
+    with open(tmp_path / 'dependencies' / 'test-component' / 'postprocess' /
+              'filters.yml', 'w') as filterf:
+        yaml.dump(filter, filterf)
+
+    config = Config()
+    component = Component('test-component',
+                          Repo(tmp_path / 'dependencies' / 'test-component'),
+                          'https://fake.repo.url',
+                          'master')
+    inventory = {
+        'classes': {
+            'defaults.test-component',
+            'global.common',
+            'components.test-component',
+        },
+        'parameters': {
+            'test_component': {
+                'namespace': 'syn-test-component',
+            },
+        },
+    }
+    return testf, config, inventory, target, {'test-component': component}
+
+
+def test_postprocess_components(tmp_path, capsys):
+    filter = _make_ns_filter('myns')
+    testf, config, inventory, target, components = _setup(tmp_path, filter)
+    postprocess_components(config, inventory, target, components)
+    assert testf.exists()
+    with open(testf) as objf:
+        obj = yaml.safe_load(objf)
+        assert obj['metadata']['namespace'] == 'myns'
+
+
+def test_postprocess_components_enabled(tmp_path, capsys):
+    filter = _make_ns_filter('myns', enabled=True)
+    testf, config, inventory, target, components = _setup(tmp_path, filter)
+    postprocess_components(config, inventory, target, components)
+    assert testf.exists()
+    with open(testf) as objf:
+        obj = yaml.safe_load(objf)
+        assert obj['metadata']['namespace'] == 'myns'
+
+
+def test_postprocess_components_disabled(tmp_path, capsys):
+    filter = _make_ns_filter('myns', enabled=False)
+    testf, config, inventory, target, components = _setup(tmp_path, filter)
+    postprocess_components(config, inventory, target, components)
+    assert testf.exists()
+    with open(testf) as objf:
+        obj = yaml.safe_load(objf)
+        assert obj['metadata']['namespace'] == 'untouched'
+    captured = capsys.readouterr()
+    assert "Skipping disabled filter" in captured.out
+
+
+def test_postprocess_components_enabledref(tmp_path, capsys):
+    filter = _make_ns_filter('myns',
+                             enabled='${test_component:filter:enabled}')
+    testf, config, inventory, target, components = _setup(tmp_path, filter)
+    inventory['parameters']['test_component']['filter'] = {
+        'enabled': True,
+    }
+    postprocess_components(config, inventory, target, components)
+    assert testf.exists()
+    with open(testf) as objf:
+        obj = yaml.safe_load(objf)
+        assert obj['metadata']['namespace'] == 'myns'
+
+
+def test_postprocess_components_disabledref(tmp_path, capsys):
+    filter = _make_ns_filter('myns',
+                             enabled='${test_component:filter:enabled}')
+    testf, config, inventory, target, components = _setup(tmp_path, filter)
+    inventory['parameters']['test_component']['filter'] = {
+        'enabled': False,
+    }
+    postprocess_components(config, inventory, target, components)
+    assert testf.exists()
+    with open(testf) as objf:
+        obj = yaml.safe_load(objf)
+        assert obj['metadata']['namespace'] == 'untouched'
+    captured = capsys.readouterr()
+    assert "Skipping disabled filter" in captured.out


### PR DESCRIPTION
It can be helpful to make postprocessing components optional based on a reclass reference.

This PR implements this feature by introducing an optional field `enabled` for each filter definition. If the field doesn't exist, filters will count as enabled. This feature is particularly useful if we want to apply a filter to a subchart of a Helm chart which can be enabled or disabled, e.g. Postgres for Keycloak.

The PR also introduces a first set of tests for `postprocess_components`.

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests.
- [x] Update the ./CHANGELOG.md.
