### PR TITLE
Build native Helm dependency binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * `component compile` now applies postprocessing filters ([#154])
 * Option to disable postprocessing filters ([#155])
 * `--interactive` option to prompt push confirmation ([#157])
+* Build Helm bindings for native Helm dependencies ([#161])
 
 ## [v0.2.2]
 
@@ -149,3 +150,4 @@ Initial implementation
 [#154]: https://github.com/projectsyn/commodore/pull/154
 [#155]: https://github.com/projectsyn/commodore/pull/155
 [#157]: https://github.com/projectsyn/commodore/pull/157
+[#161]: https://github.com/projectsyn/commodore/pull/161

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,8 @@ WORKDIR /virtualenv
 
 COPY --from=builder /usr/local/lib/python3.8/site-packages/kapitan ./kapitan
 
-RUN ./kapitan/inputs/helm/build.sh
+RUN ./kapitan/inputs/helm/build.sh \
+ && ./kapitan/dependency_manager/helm/build.sh
 
 FROM base AS runtime
 
@@ -60,6 +61,10 @@ COPY --from=helm_binding_builder \
       /virtualenv/kapitan/inputs/helm/libtemplate.so \
       /virtualenv/kapitan/inputs/helm/helm_binding.py \
       /usr/local/lib/python3.8/site-packages/kapitan/inputs/helm/
+
+COPY --from=helm_binding_builder \
+      /virtualenv/kapitan/dependency_manager/helm/helm_fetch.so \
+      /usr/local/lib/python3.8/site-packages/kapitan/dependency_manager/helm/
 
 COPY ./tools/entrypoint.sh /usr/local/bin/
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ using `helm template`.
 
       ```console
       poetry run sh -c '${VIRTUAL_ENV}/lib/python3.*/site-packages/kapitan/inputs/helm/build.sh'
+      poetry run sh -c '${VIRTUAL_ENV}/lib/python3.*/site-packages/kapitan/dependency_manager/helm/build.sh'
       ```
 
 1. Setup a `.env` file to configure Commodore (don't use quotes):

--- a/tools/Dockerfile.build_kapitan_helm_binding
+++ b/tools/Dockerfile.build_kapitan_helm_binding
@@ -5,3 +5,4 @@ ARG PY_VER='python3.6'
 WORKDIR /virtualenv
 COPY ./lib/${PY_VER}/site-packages/kapitan ./kapitan
 RUN ./kapitan/inputs/helm/build.sh
+RUN ./kapitan/dependency_manager/helm/build.sh

--- a/tools/build_kapitan_helm_binding.sh
+++ b/tools/build_kapitan_helm_binding.sh
@@ -5,10 +5,13 @@ set -euo pipefail
 # TODO: nicer pipeline
 readonly pyver="python$(python -V 2>&1 | cut -d' ' -f2 | cut -d. -f1-2)"
 readonly helm_binding_path="${VIRTUAL_ENV}/lib/${pyver}/site-packages/kapitan/inputs/helm"
+readonly helm_dependency_path="${VIRTUAL_ENV}/lib/${pyver}/site-packages/kapitan/dependency_manager/helm"
 readonly dockerfile="$(dirname "$0")/Dockerfile.build_kapitan_helm_binding"
 
 docker build --build-arg PY_VER="$pyver" -t kapitan-helm-build -f "${dockerfile}" "$VIRTUAL_ENV"
 docker create -ti --name khb kapitan-helm-build:latest bash
 docker cp khb:/virtualenv/kapitan/inputs/helm/libtemplate.so "$helm_binding_path"
+docker cp khb:/virtualenv/kapitan/dependency_manager/helm/helm_fetch.so "$helm_dependency_path"
 docker rm -f khb
 "$helm_binding_path"/build.sh
+"$helm_dependency_path"/build.sh


### PR DESCRIPTION
To be able to use the native Helm dependency type [1].

[1] https://kapitan.dev/external_dependencies/#helm-type

Required for https://github.com/projectsyn/component-cert-manager/pull/2

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the ./CHANGELOG.md.
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
