### PR TITLE
Upgraded antora-preview to latest version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ docker_cmd  ?= docker
 docker_opts ?= --rm --tty --user "$$(id -u)"
 
 vale_cmd           ?= $(docker_cmd) run $(docker_opts) --volume "$${PWD}"/docs/modules/ROOT/pages:/pages vshn/vale:2.1.1 --minAlertLevel=error /pages
-antora_preview_cmd ?= $(docker_cmd) run --rm --publish 2020:2020 --volume "${PWD}":/antora vshn/antora-preview:2.3.3 --style=syn --antora=docs
+antora_preview_cmd ?= $(docker_cmd) run --rm --publish 35729:35729 --publish 2020:2020 --volume "${PWD}":/preview/antora vshn/antora-preview:2.3.4 --style=syn --antora=docs
 
 UNAME := $(shell uname)
 ifeq ($(UNAME), Linux)

--- a/commodore/component-template/{{ cookiecutter.slug }}/Makefile
+++ b/commodore/component-template/{{ cookiecutter.slug }}/Makefile
@@ -22,7 +22,7 @@ YAMLLINT_DOCKER ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(YAMLLINT_IMAGE)
 VALE_CMD  ?= $(DOCKER_CMD) $(DOCKER_ARGS) --volume "$${PWD}"/docs/modules:/pages vshn/vale:2.1.1
 VALE_ARGS ?= --minAlertLevel=error --config=/pages/ROOT/pages/.vale.ini /pages
 
-ANTORA_PREVIEW_CMD ?= $(DOCKER_CMD) run --rm --publish 2020:2020 --volume "${PWD}":/antora vshn/antora-preview:2.3.3 --style=syn --antora=docs
+ANTORA_PREVIEW_CMD ?= $(DOCKER_CMD) run --rm --publish 35729:35729 --publish 2020:2020 --volume "${PWD}":/preview/antora vshn/antora-preview:2.3.4 --style=syn --antora=docs
 
 .PHONY: all
 all: lint open


### PR DESCRIPTION
This PR provides upgrades antora-preview to the last version (2.3.4) which includes a new live reloading capability:

1. Run `make docs-serve`.
2. Open http://localhost:2020 on a browser with the [LiveReload plugin](https://github.com/vshn/antora-preview#livereload).
3. Edit your documentation in your preferred editor.
4. Watch your changes appear automatically on the browser.

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [ ] Update the documentation.
- [ ] Update tests.
- [ ] Update the ./CHANGELOG.md.
- [ ] Link this PR to related issues.
