### PR TITLE
Add "catalog list" command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+* New `commodore cluster list` command ([#135])
 * Vault default values ([#176])
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 * Vault default values ([#176])
 
+### Fixed
+
+* Ignore component versions if not included ([#177])
 
 ## [v0.2.3]
 
@@ -171,3 +174,4 @@ Initial implementation
 [#160]: https://github.com/projectsyn/commodore/pull/160
 [#161]: https://github.com/projectsyn/commodore/pull/161
 [#176]: https://github.com/projectsyn/commodore/pull/176
+[#177]: https://github.com/projectsyn/commodore/pull/177

--- a/commodore/catalog.py
+++ b/commodore/catalog.py
@@ -3,7 +3,10 @@ from pathlib import Path as P
 import click
 
 from . import git
-from .helpers import rm_tree_contents
+from .helpers import (
+    rm_tree_contents,
+    lieutenant_query
+)
 
 
 def fetch_customer_catalog(config, repoinfo):
@@ -101,3 +104,12 @@ def update_catalog(cfg, target_name, repo):
             click.echo(' > Skipping commit+push to catalog in local mode...')
     else:
         click.echo(' > Skipping commit+push to catalog...')
+
+
+def catalog_list(cfg):
+    clusters = lieutenant_query(cfg.api_url, cfg.api_token, 'clusters', '')
+    for cluster in clusters:
+        display_name = cluster['displayName']
+        catalog_id = cluster['id']
+        click.secho(catalog_id, nl=False, bold=True)
+        click.echo(f' - {display_name}')

--- a/commodore/catalog.py
+++ b/commodore/catalog.py
@@ -111,5 +111,8 @@ def catalog_list(cfg):
     for cluster in clusters:
         display_name = cluster['displayName']
         catalog_id = cluster['id']
-        click.secho(catalog_id, nl=False, bold=True)
-        click.echo(f' - {display_name}')
+        if cfg.verbose:
+            click.secho(catalog_id, nl=False, bold=True)
+            click.echo(f' - {display_name}')
+        else:
+            click.echo(catalog_id)

--- a/commodore/cli.py
+++ b/commodore/cli.py
@@ -3,6 +3,7 @@ import click
 from dotenv import load_dotenv
 from importlib_metadata import version
 from commodore import __git_version__
+from .catalog import catalog_list
 from .config import Config
 from .helpers import clean_working_tree
 from .compile import compile as _compile
@@ -82,6 +83,22 @@ def compile_catalog(config: Config, cluster, api_url, api_token,
     config.username = git_author_name
     config.usermail = git_author_email
     _compile(config, cluster)
+
+
+@catalog.command(name='list', short_help='List available catalog cluster IDs')
+@click.option('--api-url',
+              envvar='COMMODORE_API_URL',
+              help='Lieutenant API URL.', metavar='URL')
+@click.option('--api-token',
+              envvar='COMMODORE_API_TOKEN',
+              help='Lieutenant API token.', metavar='TOKEN')
+@verbosity
+@pass_config
+def clusters_list_command(config: Config, api_url, api_token, verbose):
+    config.update_verbosity(verbose)
+    config.api_url = api_url
+    config.api_token = api_token
+    catalog_list(config)
 
 
 @commodore.group(short_help='Interact with components.')

--- a/commodore/dependency_mgmt.py
+++ b/commodore/dependency_mgmt.py
@@ -113,6 +113,8 @@ def set_component_overrides(cfg, versions):
 
     click.secho('Setting component overrides...', bold=True)
     for component_name, overrides in versions.items():
+        if component_name not in cfg.get_components():
+            continue
         component = cfg.get_components()[component_name]
         needs_checkout = False
         if 'url' in overrides:

--- a/docs/modules/ROOT/pages/reference/cli.adoc
+++ b/docs/modules/ROOT/pages/reference/cli.adoc
@@ -92,6 +92,10 @@ See also xref:local-mode.adoc[local mode documentation].
 *--help*::
   Show catalog clean usage and options then exit.
 
+== Catalog List
+
+This command doesn't have any command line options.
+
 == Component Compile
 
 *-f, --values* FILE::


### PR DESCRIPTION
This commit adds the "commodore catalog list" command that will query
lieutenant for a list of available cluster IDs (and descriptions), and
display the information on stdout.

This partially helps with #135 

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [ ] Update tests.
- [x] Update the ./CHANGELOG.md.
- [x] Link this PR to related issues.

## Testing done

Unit tests have not been added since the logic is trivial (basically printing out contents of an already-existing API) and consists mostly of stiching side-effects. Mocking side-effects (the click library and lieutenant function call) would result it unit testing a for loop, which I suspect is not very interesting.
