### PR TITLE
Add mypy validation step to tox

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ jobs:
           - lint_flake8
           - lint_pylint
           - lint_bandit
+          - lint_mypy
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+* Mypy static type analysis to the tox/CI environments. ([#180])
+
 ### Changed
 
 * Slightly improved error message in case `commodore component new` is called in
@@ -179,5 +183,6 @@ Initial implementation
 [#161]: https://github.com/projectsyn/commodore/pull/161
 [#176]: https://github.com/projectsyn/commodore/pull/176
 [#177]: https://github.com/projectsyn/commodore/pull/177
+[#180]: https://github.com/projectsyn/commodore/pull/180
 [#182]: https://github.com/projectsyn/commodore/pull/182
 [#183]: https://github.com/projectsyn/commodore/pull/183

--- a/commodore/config.py
+++ b/commodore/config.py
@@ -28,6 +28,9 @@ class Config:
         self._verbose = verbose
         self.username = username
         self.usermail = usermail
+        self.local = None
+        self.push = None
+        self.interactive = None
 
     @property
     def verbose(self):

--- a/commodore/helpers.py
+++ b/commodore/helpers.py
@@ -2,6 +2,7 @@ import json
 import shutil
 import os
 from pathlib import Path as P
+from typing import Callable
 
 import click
 import requests
@@ -9,7 +10,6 @@ import yaml
 
 # pylint: disable=redefined-builtin
 from requests.exceptions import ConnectionError, HTTPError
-from typing import Callable
 from url_normalize import url_normalize
 from kapitan import targets
 from kapitan import defaults

--- a/commodore/helpers.py
+++ b/commodore/helpers.py
@@ -9,6 +9,7 @@ import yaml
 
 # pylint: disable=redefined-builtin
 from requests.exceptions import ConnectionError, HTTPError
+from typing import Callable
 from url_normalize import url_normalize
 from kapitan import targets
 from kapitan import defaults
@@ -92,6 +93,9 @@ def _verbose_rmtree(tree, *args, **kwargs):
 
 
 def clean_working_tree(config: Config):
+    # Defining rmtree as a naked Callable means that mypy won't complain about
+    # _verbose_rmtree and shutil.rmtree having slightly different signatures.
+    rmtree: Callable
     if config.debug:
         rmtree = _verbose_rmtree
     else:

--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,15 @@ deps =
 commands =
     pylint --rcfile=tox.ini commodore
 
+[testenv:mypy]
+description = Run static analysis for typing
+deps =
+     mypy
+commands =
+     # We ignore missing imports since some of our dependencies do not have type information.
+     # Someday, it might be useful to try and import headers for them. ~chrisglass
+     mypy --ignore-missing-imports commodore
+
 [bandit]
 exclude = .cache,.git,.tox,build,dist,docs,tests
 targets = .

--- a/tox.mk
+++ b/tox.mk
@@ -14,7 +14,10 @@ lint_pylint:
 lint_bandit:
 	$(TOX_COMMAND) -e bandit
 
-lint: lint_flake8 lint_pylint lint_bandit
+lint_mypy:
+	$(TOX_COMMAND) -e mypy
+
+lint: lint_flake8 lint_pylint lint_bandit lint_mypy
 
 .PHONY: test_py36 test_py37 test_py38
 


### PR DESCRIPTION
This commit adds a tox mypy validation test environment, and makes a few
simple adjustments to ensure the current code passes said validation.

## Testing done

This PR adds some testing to the project (static analysis for optional types).
