### PR TITLE
Rename ComponentFactory to ComponentTemplater

### DIFF
--- a/commodore/cli.py
+++ b/commodore/cli.py
@@ -7,7 +7,7 @@ from .catalog import catalog_list
 from .config import Config
 from .helpers import clean_working_tree
 from .compile import compile as _compile
-from .component.template import ComponentFactory
+from .component.template import ComponentTemplater
 from .component.compile import compile_component
 
 pass_config = click.make_pass_decorator(Config)
@@ -126,7 +126,7 @@ def component(config: Config, verbose):
 # pylint: disable=too-many-arguments
 def component_new(config: Config, slug, name, lib, pp, owner, copyright_holder, verbose):
     config.update_verbosity(verbose)
-    f = ComponentFactory(config, slug)
+    f = ComponentTemplater(config, slug)
     f.name = name
     f.library = lib
     f.post_process = pp

--- a/commodore/component/template.py
+++ b/commodore/component/template.py
@@ -13,7 +13,7 @@ from commodore.dependency_mgmt import create_component_symlinks
 from commodore.helpers import yaml_load, yaml_dump
 
 
-class ComponentFactory:
+class ComponentTemplater:
     # pylint: disable=too-many-instance-attributes
     config: CommodoreConfig
     slug: str


### PR DESCRIPTION
This is a simple nitpick branch - Having a class called *Factory makes me assume (and I suspect other programmers as well) that the object is an implementation of the Factory design pattern.

Changing the name of the class avoids this confusion without changing program behavior at all.

Note: this is a nitpick in its purest form - don't feel bad closing this PR without further comment :)