### PR TITLE
Improve and clarify component new command documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 * New `commodore cluster list` command ([#135])
 * Vault default values ([#176])
+* Improved `component new` documentation ([#182])
 
 ### Fixed
 
@@ -176,3 +177,4 @@ Initial implementation
 [#161]: https://github.com/projectsyn/commodore/pull/161
 [#176]: https://github.com/projectsyn/commodore/pull/176
 [#177]: https://github.com/projectsyn/commodore/pull/177
+[#182]: https://github.com/projectsyn/commodore/pull/182

--- a/docs/modules/ROOT/pages/reference/commands.adoc
+++ b/docs/modules/ROOT/pages/reference/commands.adoc
@@ -39,19 +39,14 @@ check with the user whether they really want to remove the items listed above.
 
   commodore component new COMPONENT_NAME
 
-This command creates a new component from a Cookiecutter template in
-`dependencies/`.
+This command creates a new component repository under `dependencies/` in Commodore's working directory.
+The component repository is created using a Cookiecutter template which provides a skeleton for writing a new component.
+Optionally, the template can be used to add a component library and postprocessing filter configuration.
 
-The command also provides skeleton files for the component class
-and templates.
+The command expects to run in a directory which already holds a Commodore directory structure.
+The command makes sure to create symlinks for the new component's classes and includes the component defaults and component class in the cluster target class.
 
-Optionally, the command will add a component library and postprocessing filter
-configuration.
-
-Additionally the command provides templates for many meta-files in the
-component repository, such as the readme and changelog, standardized license,
-contributing and code of conduct files, a documentation template, and GitHub
-issue and actions configurations.
+The template also provides many meta-files in the component repository, such as the readme and changelog, standardized license, contributing and code of conduct files, a documentation template, and GitHub issue templates and actions configuration.
 
 == Component Compile
 


### PR DESCRIPTION
The documentation for the `component new` command was rather dense, and required some prior knowledge.

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update the ./CHANGELOG.md.
