### PR TITLE
More explicit error when failing to add component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 * Slightly improved error message in case `commodore component new` is called in
-  a folder that is not a populated (compiled) catalog.
+  a folder that is not a populated (compiled) catalog ([#183])
 * New `commodore cluster list` command ([#135])
 * Vault default values ([#176])
 * Improved `component new` documentation ([#182])
@@ -180,3 +180,4 @@ Initial implementation
 [#176]: https://github.com/projectsyn/commodore/pull/176
 [#177]: https://github.com/projectsyn/commodore/pull/177
 [#182]: https://github.com/projectsyn/commodore/pull/182
+[#183]: https://github.com/projectsyn/commodore/pull/183

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+* Slightly improved error message in case `commodore component new` is called in
+  a folder that is not a populated (compiled) catalog.
 * New `commodore cluster list` command ([#135])
 * Vault default values ([#176])
 * Improved `component new` documentation ([#182])

--- a/commodore/component/template.py
+++ b/commodore/component/template.py
@@ -87,12 +87,16 @@ class ComponentTemplater:
         git.commit(repo, 'Initial commit', self.config)
 
         click.echo(' > Installing component')
-        create_component_symlinks(self.config, component)
+        try:
+            create_component_symlinks(self.config, component)
 
-        targetfile = P('inventory', 'targets', 'cluster.yml')
-        target = yaml_load(targetfile)
-        target['classes'].append(f"components.{self.slug}")
-        target['classes'].insert(0, f"defaults.{self.slug}")
-        yaml_dump(target, targetfile)
-
-        click.secho(f"Component {self.name} successfully added 🎉", bold=True)
+            targetfile = P('inventory', 'targets', 'cluster.yml')
+            target = yaml_load(targetfile)
+            target['classes'].append(f"components.{self.slug}")
+            target['classes'].insert(0, f"defaults.{self.slug}")
+            yaml_dump(target, targetfile)
+        except FileNotFoundError:
+            # TODO: This should maybe cleanup the "dependencies" subdirectory (since we just created it).
+            click.echo("Cannot find catalog files. Did you forget to run 'catalog compile' in the current directory?")
+        else:
+            click.secho(f"Component {self.name} successfully added 🎉", bold=True)

--- a/commodore/helpers.py
+++ b/commodore/helpers.py
@@ -170,9 +170,6 @@ def relsymlink(srcdir, srcname, destdir, destname=None):
     # https://docs.python.org/3/library/pathlib.html#pathlib.PurePath.relative_to
     link_src = os.path.relpath(P(srcdir) / srcname, start=destdir)
     link_dst = P(destdir) / destname
-    try:
-        if link_dst.exists():
-            os.remove(link_dst)
-        os.symlink(link_src, link_dst)
-    except Exception as e:
-        raise click.ClickException(f"While setting up symlinks: {e}") from e
+    if link_dst.exists():
+        os.remove(link_dst)
+    os.symlink(link_src, link_dst)

--- a/tests/test_dependency_mgmt.py
+++ b/tests/test_dependency_mgmt.py
@@ -46,9 +46,8 @@ def test_create_component_symlinks_fails(data: Config, tmp_path: Path):
         version='master',
         repo_url=None,
     )
-    with pytest.raises(click.ClickException) as excinfo:
+    with pytest.raises(FileNotFoundError):
         dependency_mgmt.create_component_symlinks(data, component)
-    assert component.name in str(excinfo)
 
 
 def test_create_legacy_component_symlinks(capsys, data: Config, tmp_path):


### PR DESCRIPTION
Should "component create" be called outside of a catalog, display some
information in this regard to the user.

The lower layer exception (FileNotFound) is not wrapped in the top-layer
click.Exception() wrapper anymore in order to differentiate exception
types.

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests.

