### PR TITLE
Fix bandit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+* Fix failing bandit CI check ([#185])
 * Ignore component versions if not included ([#177])
 
 ## [v0.2.3]
@@ -186,3 +187,4 @@ Initial implementation
 [#180]: https://github.com/projectsyn/commodore/pull/180
 [#182]: https://github.com/projectsyn/commodore/pull/182
 [#183]: https://github.com/projectsyn/commodore/pull/183
+[#185]: https://github.com/projectsyn/commodore/pull/185

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ commands =
 
 [testenv:bandit]
 description = PyCQA security linter
-deps = bandit<1.6.0
+deps = bandit
 commands = bandit -r --ini tox.ini commodore/
 
 [testenv:flake8]


### PR DESCRIPTION
The bandit version used by this project was pinned to pre-1.6.0 which
seems to fail silently (!) locally and on CI.

## Testing done

Running `tox -e bandit` before this commit:

https://pastebin.ubuntu.com/p/V72Q49XvTt/

After this commit:

https://pastebin.ubuntu.com/p/82S9XTCqW9/