### PR TITLE
Implement slug validation for `component new`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * New `commodore cluster list` command ([#135])
 * Vault default values ([#176])
 * Improved `component new` documentation ([#182])
+* `component new` restricts allowed component slugs ([#189])
 
 ### Fixed
 
@@ -191,3 +192,4 @@ Initial implementation
 [#183]: https://github.com/projectsyn/commodore/pull/183
 [#185]: https://github.com/projectsyn/commodore/pull/185
 [#186]: https://github.com/projectsyn/commodore/pull/186
+[#189]: https://github.com/projectsyn/commodore/pull/189

--- a/commodore/component/template.py
+++ b/commodore/component/template.py
@@ -3,6 +3,7 @@ import datetime
 from pathlib import Path as P
 
 import click
+import re
 
 from cookiecutter.main import cookiecutter
 
@@ -11,6 +12,9 @@ from commodore import config as CommodoreConfig
 from commodore.config import Component
 from commodore.dependency_mgmt import create_component_symlinks
 from commodore.helpers import yaml_load, yaml_dump
+
+
+slug_regex = re.compile("^[a-z][a-z0-9-]+[a-z0-9]$")
 
 
 class ComponentTemplater:
@@ -34,8 +38,14 @@ class ComponentTemplater:
 
     @slug.setter
     def slug(self, slug):
-        if slug.startswith('component-'):
-            raise click.ClickException('The component slug may not start with "component-"')
+        if slug.startswith("component-"):
+            raise click.ClickException(
+                'The component slug may not start with "component-"'
+            )
+        if not slug_regex.match(slug):
+            raise click.ClickException(
+                f"The component slug must match '{slug_regex.pattern}'"
+            )
         self._slug = slug
 
     @property

--- a/docs/modules/ROOT/pages/reference/commands.adoc
+++ b/docs/modules/ROOT/pages/reference/commands.adoc
@@ -37,10 +37,11 @@ check with the user whether they really want to remove the items listed above.
 
 == Component New
 
-  commodore component new COMPONENT_NAME
+  commodore component new SLUG
 
 This command creates a new component repository under `dependencies/` in Commodore's working directory.
 The component repository is created using a Cookiecutter template which provides a skeleton for writing a new component.
+The command requires the argument `SLUG` to match the regular expression `^[a-z][a-z0-9-]+[a-z0-9]$`.
 Optionally, the template can be used to add a component library and postprocessing filter configuration.
 
 The command expects to run in a directory which already holds a Commodore directory structure.

--- a/tests/test_component_new.py
+++ b/tests/test_component_new.py
@@ -2,6 +2,7 @@
 Tests for component new command
 """
 import os
+import pytest
 import yaml
 from pathlib import Path as P
 
@@ -75,12 +76,22 @@ def test_run_component_new_command_with_name(tmp_path: P):
         assert component_slug not in data
 
 
-def test_run_component_new_command_with_illegal_slug(tmp_path: P):
+@pytest.mark.parametrize(
+    "test_input",
+    [
+        'component-test-illegal',
+        'test-illegal-',
+        '-test-illegal',
+        '00-test-illegal',
+        'TestIllegal',
+        'test_illegal',
+    ]
+)
+def test_run_component_new_command_with_illegal_slug(tmp_path: P, test_input):
     """
     Run the component new command with an illegal slug
     """
 
     setup_directory(tmp_path)
-    component_slug = 'component-test-illegal'
-    exit_status = os.system(f"commodore -vvv component new {component_slug}")
+    exit_status = os.system(f"commodore -vvv component new {test_input}")
     assert exit_status != 0


### PR DESCRIPTION
In https://github.com/projectsyn/commodore/pull/186 we decided to disallow component slugs with a leading digit. While implementing this policy, I've suggested to restrict slugs further.

After some further discussion, we decided to restrict component slugs to the regex `^[a-z][a-z0-9-]+[a-z0-9]$`, when creating components with `component new`.

This PR implements slug validation in the component templater using the regex mentioned above, and introduces a number of test cases which validate the new behavior.

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update tests.
- [x] Update the ./CHANGELOG.md.
