### PR TITLE
Subprocess changes and dedent

### DIFF
--- a/commodore/component/compile.py
+++ b/commodore/component/compile.py
@@ -84,8 +84,8 @@ def compile_component(config: Config, component_path, value_files, search_paths,
                 local ArgoProject(name) = {};
 
                 {
-                App: ArgoApp,
-                Project: ArgoProject,
+                  App: ArgoApp,
+                  Project: ArgoProject,
                 }"""))
 
         # Fetch Jsonnet libs

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,13 +2,14 @@
 Tests for command line interface (CLI)
 """
 import os
+from subprocess import call
 
 
 def test_runas_module():
     """
     Can this package be run as a Python module?
     """
-    exit_status = os.system('python -m commodore')
+    exit_status = call('python -m commodore', shell=True)
     assert exit_status == 0
 
 
@@ -16,7 +17,7 @@ def test_entrypoint():
     """
     Is entrypoint script installed?
     """
-    exit_status = os.system('commodore --help')
+    exit_status = call('commodore --help', shell=True)
     assert exit_status == 0
 
 
@@ -24,7 +25,7 @@ def test_clean_command():
     """
     Is subcommand available?
     """
-    exit_status = os.system('commodore catalog clean --help')
+    exit_status = call('commodore catalog clean --help', shell=True)
     assert exit_status == 0
 
 
@@ -32,7 +33,7 @@ def test_compile_command():
     """
     Is subcommand available?
     """
-    exit_status = os.system('commodore catalog compile --help')
+    exit_status = call('commodore catalog compile --help', shell=True)
     assert exit_status == 0
 
 
@@ -40,7 +41,7 @@ def test_component_new_command():
     """
     Is subcommand available?
     """
-    exit_status = os.system('commodore component new --help')
+    exit_status = call('commodore component new --help', shell=True)
     assert exit_status == 0
 
 
@@ -48,5 +49,5 @@ def test_component_compile_command():
     """
     Is subcommand available?
     """
-    exit_status = os.system('commodore component compile --help')
+    exit_status = call('commodore component compile --help', shell=True)
     assert exit_status == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,6 @@
 """
 Tests for command line interface (CLI)
 """
-import os
 from subprocess import call
 
 

--- a/tests/test_component_compile.py
+++ b/tests/test_component_compile.py
@@ -4,6 +4,9 @@ Tests for component compile command
 import os
 import yaml
 import pytest
+
+from subprocess import call
+
 from click import ClickException
 from commodore.config import Config
 from commodore.component.compile import compile_component
@@ -51,7 +54,8 @@ def test_run_component_compile_command(tmp_path):
     component_name = 'test-component'
     _prepare_component(tmp_path, component_name)
 
-    exit_status = os.system(f"commodore component compile -o ./testdir dependencies/{component_name}")
+    # exit_status = os.system(f"commodore component compile -o ./testdir dependencies/{component_name}")
+    exit_status = call(f"commodore component compile -o ./testdir dependencies/{component_name}", shell=True)
     assert exit_status == 0
     assert os.path.exists(tmp_path / f"testdir/compiled/test/apps/{component_name}.yaml")
     rendered_yaml = tmp_path / 'testdir/compiled/test' / component_name / 'test_service_account.yaml'
@@ -74,7 +78,7 @@ def test_run_component_compile_command_postprocess(tmp_path):
     _prepare_component(tmp_path, component_name)
     _add_postprocessing_filter(tmp_path, component_name)
 
-    exit_status = os.system(f"commodore component compile -o ./testdir dependencies/{component_name}")
+    exit_status = call(f"commodore component compile -o ./testdir dependencies/{component_name}", shell=True)
     assert exit_status == 0
     assert os.path.exists(tmp_path / f"testdir/compiled/test/apps/{component_name}.yaml")
     rendered_yaml = tmp_path / 'testdir/compiled/test' / component_name / 'test_service_account.yaml'

--- a/tests/test_component_compile.py
+++ b/tests/test_component_compile.py
@@ -20,11 +20,11 @@ def _prepare_component(tmp_path, component_name='test-component'):
     with open(tmp_path / 'dependencies' / component_name / 'component/main.jsonnet', 'a') as file:
         file.write(dedent('''
             {
-            "test_service_account": kube.ServiceAccount('test') {
+              "test_service_account": kube.ServiceAccount('test') {
                 metadata+: {
-                namespace: params.namespace,
+                  namespace: params.namespace,
                 },
-            },
+              },
             }'''))
 
 

--- a/tests/test_component_compile.py
+++ b/tests/test_component_compile.py
@@ -6,6 +6,7 @@ import yaml
 import pytest
 
 from subprocess import call
+from textwrap import dedent
 
 from click import ClickException
 from commodore.config import Config
@@ -17,15 +18,14 @@ def _prepare_component(tmp_path, component_name='test-component'):
     test_run_component_new_command(tmp_path=tmp_path)
 
     with open(tmp_path / 'dependencies' / component_name / 'component/main.jsonnet', 'a') as file:
-        file.write('''
-{
-  "test_service_account": kube.ServiceAccount('test') {
-    metadata+: {
-      namespace: params.namespace,
-    },
-  },
-}
-''')
+        file.write(dedent('''
+            {
+            "test_service_account": kube.ServiceAccount('test') {
+                metadata+: {
+                namespace: params.namespace,
+                },
+            },
+            }'''))
 
 
 def _add_postprocessing_filter(tmp_path, component_name='test-component'):

--- a/tests/test_dependency_mgmt.py
+++ b/tests/test_dependency_mgmt.py
@@ -7,6 +7,7 @@ import click
 import pytest
 from unittest.mock import patch
 from pathlib import Path
+from textwrap import dedent
 
 from commodore import dependency_mgmt
 from commodore.config import Config, Component
@@ -103,10 +104,10 @@ def test_read_component_urls(data: Config, tmp_path):
     config_file = inventory_global / 'commodore.yml'
     override_url = 'ssh://git@git.acme.com/some/component.git'
     with open(config_file, 'w') as file:
-        file.write(f"""components:
-- name: component-overwritten
-  url: {override_url}
-""")
+        file.write(dedent(f"""
+            components:
+            - name: component-overwritten
+              url: {override_url}"""))
 
     components = dependency_mgmt._read_component_urls(data, component_names)
     override = components[0]

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -5,6 +5,9 @@ Unit-tests for target generation
 import os
 import click
 import pytest
+
+from textwrap import dedent
+
 from commodore import cluster
 
 
@@ -82,23 +85,24 @@ def test_reconstruct_api_response(tmp_path):
     os.chdir(tmp_path)
     targetyml = tmp_path / 'cluster.yml'
     with open(targetyml, 'w') as file:
-        file.write('''classes:
-- defaults.argocd
-- global.common
-- global.distribution.k3d
-- global.cloud.localdev
-- t-delicate-pine-3938.c-twilight-water-9032
-parameters:
-  cloud:
-    provider: localdev
-    region: north
-  cluster:
-    catalog_url: ssh://git@git.vshn.net/syn-dev/cluster-catalogs/srueg-k3d-int.git
-    dist: k3d
-    name: c-twilight-water-9032
-  customer:
-    name: t-delicate-pine-3938
-  target_name: cluster ''')
+        file.write(dedent('''
+            classes:
+            - defaults.argocd
+            - global.common
+            - global.distribution.k3d
+            - global.cloud.localdev
+            - t-delicate-pine-3938.c-twilight-water-9032
+            parameters:
+              cloud:
+                provider: localdev
+                region: north
+              cluster:
+                catalog_url: ssh://git@git.vshn.net/syn-dev/cluster-catalogs/srueg-k3d-int.git
+                dist: k3d
+                name: c-twilight-water-9032
+              customer:
+                name: t-delicate-pine-3938
+              target_name: cluster'''))
 
     api_response = cluster.reconstruct_api_response(targetyml)
     assert api_response['id'] == 'c-twilight-water-9032'
@@ -111,17 +115,18 @@ def test_reconstruct_api_response_no_region(tmp_path):
     os.chdir(tmp_path)
     targetyml = tmp_path / 'cluster.yml'
     with open(targetyml, 'w') as file:
-        file.write('''classes: []
-parameters:
-  cloud:
-    provider: localdev
-  cluster:
-    catalog_url: ssh://git@git.vshn.net/syn-dev/cluster-catalogs/srueg-k3d-int.git
-    dist: k3d
-    name: c-twilight-water-9032
-  customer:
-    name: t-delicate-pine-3938
-  target_name: cluster ''')
+        file.write(dedent('''
+            classes: []
+            parameters:
+              cloud:
+                provider: localdev
+              cluster:
+                catalog_url: ssh://git@git.vshn.net/syn-dev/cluster-catalogs/srueg-k3d-int.git
+                dist: k3d
+                name: c-twilight-water-9032
+              customer:
+                name: t-delicate-pine-3938
+              target_name: cluster'''))
 
     api_response = cluster.reconstruct_api_response(targetyml)
     assert 'region' not in api_response['facts']
@@ -131,18 +136,19 @@ def test_reconstruct_api_response_with_lieutenant_fact(tmp_path):
     os.chdir(tmp_path)
     targetyml = tmp_path / 'cluster.yml'
     with open(targetyml, 'w') as file:
-        file.write('''classes:
-- global.lieutenant-instance.lieutenant-dev
-parameters:
-  cloud:
-    provider: localdev
-  cluster:
-    catalog_url: ssh://git@git.vshn.net/syn-dev/cluster-catalogs/srueg-k3d-int.git
-    dist: k3d
-    name: c-twilight-water-9032
-  customer:
-    name: t-delicate-pine-3938
-  target_name: cluster ''')
+        file.write(dedent('''
+            classes:
+            - global.lieutenant-instance.lieutenant-dev
+            parameters:
+              cloud:
+                provider: localdev
+              cluster:
+                catalog_url: ssh://git@git.vshn.net/syn-dev/cluster-catalogs/srueg-k3d-int.git
+                dist: k3d
+                name: c-twilight-water-9032
+              customer:
+                name: t-delicate-pine-3938
+              target_name: cluster'''))
 
     api_response = cluster.reconstruct_api_response(targetyml)
     assert api_response['facts']['lieutenant-instance'] == "lieutenant-dev"
@@ -152,17 +158,18 @@ def test_reconstruct_api_response_missing_fact(tmp_path):
     os.chdir(tmp_path)
     targetyml = tmp_path / 'cluster.yml'
     with open(targetyml, 'w') as file:
-        file.write('''classes: []
-parameters:
-  cloud:
-    region: north
-  cluster:
-    catalog_url: ssh://git@git.vshn.net/syn-dev/cluster-catalogs/srueg-k3d-int.git
-    dist: k3d
-    name: c-twilight-water-9032
-  customer:
-    name: t-delicate-pine-3938
-  target_name: cluster ''')
+        file.write(dedent('''
+            classes: []
+            parameters:
+              cloud:
+                region: north
+              cluster:
+                catalog_url: ssh://git@git.vshn.net/syn-dev/cluster-catalogs/srueg-k3d-int.git
+                dist: k3d
+                name: c-twilight-water-9032
+              customer:
+                name: t-delicate-pine-3938
+              target_name: cluster'''))
 
     with pytest.raises(KeyError):
         cluster.reconstruct_api_response(targetyml)


### PR DESCRIPTION
This branch provides two nitpicky non-functional changes:

1. Switch from using os.system() to the higher-level subprocess.call() (the recommended interface for shelling out in python). In particular this allows to retrieve non-zero exit codes instead of getting the syscall + exit code integer from os.system.
2. Use textwrap.dedent() to have the yaml snippets aligh with the rest of the code instead of "leaking" to the left-hand side of the text file.

These changes are entirely "cosmetic" and should not affect the functionality at all.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
