### PR TITLE
Simplify docker-compose configuration

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,8 +10,7 @@ services:
     env_file: .env
     user: "${USER_ID:-0}"
     volumes:
-    - ./catalog/:/app/catalog/
-    - ./dependencies/:/app/dependencies/
-    - ./inventory/:/app/inventory/
-    - ~/.ssh/:/app/.ssh/:ro
-    - ~/.gitconfig:/app/.gitconfig:ro
+      - ~/.ssh/:/app/.ssh/:ro
+      - ~/.gitconfig:/app/.gitconfig:ro
+      - ./:/app/data
+    working_dir: /app/data


### PR DESCRIPTION
The use of distinct volume mounts for each and every directory does not
scale. Whenever something new is added, the docker-compose config would
need to change. Instead, we can use only one volume by also changing the
workdir within the container.

This change got triggered by #196.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
