### PR TITLE
Do not use `pip` to install Poetry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,18 @@
 FROM docker.io/python:3.8.6-slim-buster AS base
 
 ENV HOME=/app
-ENV PATH=${PATH}:${HOME}/.poetry/bin
 
 WORKDIR ${HOME}
 
 FROM base AS builder
 
+ENV PATH=${PATH}:${HOME}/.poetry/bin
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
       build-essential \
       curl \
  && rm -rf /var/lib/apt/lists/* \
- && curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python - \
+ && curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python - --version 1.1.0 \
  && mkdir -p /app/.config
 
 COPY pyproject.toml poetry.lock ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM docker.io/python:3.8.6-slim-buster AS base
 
 ENV HOME=/app
+ENV PATH=${PATH}:${HOME}/.poetry/bin
 
 WORKDIR ${HOME}
 
@@ -8,8 +9,9 @@ FROM base AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
       build-essential \
+      curl \
  && rm -rf /var/lib/apt/lists/* \
- && pip install poetry \
+ && curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python - \
  && mkdir -p /app/.config
 
 COPY pyproject.toml poetry.lock ./


### PR DESCRIPTION
Having Poetry installed within the same scope as the application, can
result in unexpected behaviour. Using their install script, puts poetry
in isolation and no interference should occur.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
