### PR TITLE
Replace remaining references to common.yml with commodore.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Please document all notable changes to this project in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+* Replace remaining references to `common.yml` with `commodore.yml` ([#204])
+
 ## [v0.3.0] - 2020-10-01
 
 ### Added
@@ -220,3 +226,4 @@ Initial implementation
 [#192]: https://github.com/projectsyn/commodore/pull/192
 [#195]: https://github.com/projectsyn/commodore/pull/195
 [#201]: https://github.com/projectsyn/commodore/pull/201
+[#204]: https://github.com/projectsyn/commodore/pull/204

--- a/docs/modules/ROOT/pages/reference/hierarchy.adoc
+++ b/docs/modules/ROOT/pages/reference/hierarchy.adoc
@@ -39,7 +39,7 @@ inventory/
 
 == Available parameters
 
-To build up your configuration hierarchy, include classes in `common.yml` within your global configuration inventory.
+To build up your configuration hierarchy, include classes in `commodore.yml` within your global configuration inventory.
 The following parameters can be used to make your hierarchy dynamic based on cluster facts.
 
 [source,yaml]
@@ -74,9 +74,9 @@ From commodore we get the following base hierarchy:
 
 * Component default parameter values
 * Cluster parameter values
-* `common.yml within the global configuration repository
+* `commodore.yml` within the global configuration repository
 
-Within `common.yml`, we then can include further classes and build up the hierarchy.
+Within `commodore.yml`, we then can include further classes and build up the hierarchy.
 The hierarchy could then be extended by configurations related to a:
 
 * Kubernetes distribution
@@ -115,7 +115,7 @@ classes:
 Reclass requires parameters to be defined when used in references.
 When building a hierarchy that has optional parts, one must be creative.
 You might work with clouds that don't know the concept of a region.
-So instead of including the region in `common.yml`, include it only for those clouds that have regions.
+So instead of including the region in `commodore.yml`, include it only for those clouds that have regions.
 
 .commodore.yml
 [source,yaml]


### PR DESCRIPTION
There were a few places in the hierarchy documentation which referred to `common.yml` in the global config repository.

Since Commodore now uses `global.commodore` as the hierarchy starting point, the documentation should refer to `commodore.yml`.

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update the ./CHANGELOG.md.