### PR TITLE
Adjust component new/delete to update jsonnetfile.json

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,13 @@ jobs:
     - name: Install Poetry
       run: |
         pip install poetry tox
+    - name: Install jsonnet-bundler
+      run: |
+        mkdir -p /opt/bin && curl -sLo /opt/bin/jb \
+          https://github.com/jsonnet-bundler/jsonnet-bundler/releases/download/v0.4.0/jb-linux-amd64 \
+          && chmod +x /opt/bin/jb
+    - name: Update PATH
+      run: echo "/opt/bin" >> $GITHUB_PATH
     - name: Run tests on Python ${{ matrix.python-version }}
       run: make test_py${{ matrix.python-version }}
   docs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 * Replace remaining references to `common.yml` with `commodore.yml` ([#204])
+* Adjust component new/delete to update `jsonnetfile.json` ([#211])
 * Provide `inventory_path` in Kapitan's argument cache ([#212])
 
 ## [v0.3.0] - 2020-10-01
@@ -228,4 +229,5 @@ Initial implementation
 [#195]: https://github.com/projectsyn/commodore/pull/195
 [#201]: https://github.com/projectsyn/commodore/pull/201
 [#204]: https://github.com/projectsyn/commodore/pull/204
+[#211]: https://github.com/projectsyn/commodore/pull/211
 [#212]: https://github.com/projectsyn/commodore/pull/212

--- a/docs/modules/ROOT/pages/reference/commands.adoc
+++ b/docs/modules/ROOT/pages/reference/commands.adoc
@@ -46,6 +46,7 @@ Optionally, the template can be used to add a component library and postprocessi
 
 The command expects to run in a directory which already holds a Commodore directory structure.
 The command makes sure to create symlinks for the new component's classes and includes the component defaults and component class in the cluster target class.
+The command also adds the new component as a dependency in `jsonnetfile.json` and runs jsonnet-bundler to symlink the new component into `vendor/`.
 
 The template also provides many meta-files in the component repository, such as the readme and changelog, standardized license, contributing and code of conduct files, a documentation template, and GitHub issue templates and actions configuration.
 
@@ -58,6 +59,7 @@ The command will require confirmation before performing destructive operations, 
 
 The command expects to run in a directory which already holds a Commodore directory structure.
 The command makes sure to remove symlinks for the new component's classes and removes the component defaults and component class in the cluster target class.
+The command also removes the deleted component as a dependency in `jsonnetfile.json` and runs jsonnet-bundler to remove the symlink to the deleted component in `vendor/`.
 
 == Component Compile
 

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -1,6 +1,7 @@
 """
 Tests for component new command
 """
+import json
 import os
 import pytest
 import yaml
@@ -22,6 +23,9 @@ def setup_directory(tmp_path: P):
             """classes:
         - test"""
         )
+    jsonnetfile = P("jsonnetfile.json")
+    with open(jsonnetfile, "w") as jf:
+        json.dump({"version": 1, "dependencies": [], "legacyImports": True}, jf)
 
     return targetyml
 
@@ -53,6 +57,7 @@ def test_run_component_new_command(tmp_path: P):
         P("inventory", "classes", "components", f"{component_name}.yml"),
         P("inventory", "classes", "defaults", f"{component_name}.yml"),
         P("dependencies", "lib", f"{component_name}.libsonnet"),
+        P("vendor", component_name),
     ]:
         assert file.is_symlink()
     with open(targetyml) as file:
@@ -135,6 +140,7 @@ def test_run_component_new_then_delete(tmp_path: P):
         P("inventory", "classes", "components", f"{component_name}.yml"),
         P("inventory", "classes", "defaults", f"{component_name}.yml"),
         P("dependencies", "lib", f"{component_name}.libsonnet"),
+        P("vendor", component_name),
     ]:
         assert not f.exists()
 


### PR DESCRIPTION
When creating/removing components with `commodore component new` and `commodore component delete`, we need to also update the jsonnetfile.json and rerun jsonnet-bundler to ensure that the symlinks in `vendor/` exist.
    
Otherwise, `commodore catalog compile --local` fails after adding a component with `commodore component new`.

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update tests.
- [x] Update the ./CHANGELOG.md.
