### PR TITLE
Provide inventory_path in Kapitan's argument cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 * Replace remaining references to `common.yml` with `commodore.yml` ([#204])
+* Provide `inventory_path` in Kapitan's argument cache ([#212])
 
 ## [v0.3.0] - 2020-10-01
 
@@ -227,3 +228,4 @@ Initial implementation
 [#195]: https://github.com/projectsyn/commodore/pull/195
 [#201]: https://github.com/projectsyn/commodore/pull/201
 [#204]: https://github.com/projectsyn/commodore/pull/204
+[#212]: https://github.com/projectsyn/commodore/pull/212

--- a/commodore/helpers.py
+++ b/commodore/helpers.py
@@ -1,3 +1,4 @@
+import collections
 import json
 import shutil
 import os
@@ -11,6 +12,7 @@ import yaml
 # pylint: disable=redefined-builtin
 from requests.exceptions import ConnectionError, HTTPError
 from url_normalize import url_normalize
+from kapitan import cached
 from kapitan import targets
 from kapitan import defaults
 from kapitan.cached import reset_cache as reset_reclass_cache
@@ -19,6 +21,9 @@ from kapitan.refs.secrets.vaultkv import VaultBackend
 
 from commodore import __install_dir__
 from commodore.config import Config
+
+
+ArgumentCache = collections.namedtuple("ArgumentCache", ["inventory_path"])
 
 
 class FakeVaultBackend(VaultBackend):
@@ -130,6 +135,7 @@ def kapitan_compile(
     if fake_refs:
         refController.register_backend(FakeVaultBackend())
     click.secho("Compiling catalog...", bold=True)
+    cached.args["compile"] = ArgumentCache(inventory_path="./inventory")
     targets.compile_targets(
         inventory_path="./inventory",
         search_paths=search_paths,


### PR DESCRIPTION
Kapitan 0.29.3 contains  [PR#625] where the default inventory path `./inventory` is removed and the default path is extracted from the command line argument if necessary.

Since we do not call Kapitan via the CLI we need to manually populate the argument cache.

This commit introduces a namedtuple `ArgumentCache` which can be provided as a minimal argument cache to Kapitan's cached module. This change ensures that our calls to Kapitan's compile_targets method continue working with Kapitan 0.29.3

[PR#625]: https://github.com/deepmind/kapitan/pull/625

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the ./CHANGELOG.md.
- [x] Link this PR to related issues.
