### PR TITLE
Silence pylint error for class inheriting from NamedTuple

### DIFF
--- a/commodore/config.py
+++ b/commodore/config.py
@@ -4,6 +4,10 @@ from pathlib import Path as P
 from git import Repo
 
 
+# Python 3.9 changed typing.NamedTuple to be a function that can be inherited
+# from. This trips up pylint, cf. https://github.com/PyCQA/pylint/issues/3876.
+# pylint: disable=inherit-non-class
+# pylint: disable=too-few-public-methods
 class Component(NamedTuple):
     name: str
     repo: Repo


### PR DESCRIPTION
Python 3.9 changed typing.NamedTuple to be a function that can be inherited from. This trips up pylint, cf. https://github.com/PyCQA/pylint/issues/3876.

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.