### PR TITLE
Create a Kapitan target for each component

### DIFF
--- a/commodore/catalog.py
+++ b/commodore/catalog.py
@@ -1,4 +1,5 @@
 from pathlib import Path as P
+from typing import Iterable
 
 import click
 
@@ -65,15 +66,15 @@ def clean_catalog(repo):
         rm_tree_contents(repo.working_tree_dir)
 
 
-def update_catalog(cfg, target_name, repo):
+def update_catalog(cfg, targets: Iterable[str], repo):
     click.secho("Updating catalog repository...", bold=True)
     # pylint: disable=import-outside-toplevel
     from distutils import dir_util
     import textwrap
 
     catalogdir = P(repo.working_tree_dir, "manifests")
-    # copy compiled catalog into catalog directory
-    dir_util.copy_tree(P("compiled") / target_name, str(catalogdir))
+    for target_name in targets:
+        dir_util.copy_tree(str(P("compiled") / target_name), str(catalogdir))
 
     difftext, changed = git.stage_all(repo)
     if changed:

--- a/commodore/cluster.py
+++ b/commodore/cluster.py
@@ -23,13 +23,13 @@ def fetch_cluster(cfg, clusterid):
     return cluster
 
 
-def read_cluster_and_tenant(target: str) -> Tuple[str, str]:
+def read_cluster_and_tenant() -> Tuple[str, str]:
     """
     Reads the cluster and tenant ID from the current target.
     """
-    file = params_file(target)
+    file = params_file()
     if not file.is_file():
-        raise click.ClickException(f"params file for target {target} does not exist")
+        raise click.ClickException(f"params file for {file.stem} does not exist")
 
     data = yaml_load(file)
 
@@ -39,8 +39,12 @@ def read_cluster_and_tenant(target: str) -> Tuple[str, str]:
     )
 
 
-def render_target(target: str, components: Iterable[str]):
-    classes = [f"params.{target}"]
+def render_target(target: str, components: Iterable[str], bootstrap=False):
+    if not bootstrap and target not in components:
+        raise click.ClickException(f"Target {target} is not a component")
+
+    classes = ["params.cluster"]
+    parameters = {}
 
     for component in components:
         defaults_file = P("inventory", "classes", "defaults") / f"{component}.yml"
@@ -49,11 +53,24 @@ def render_target(target: str, components: Iterable[str]):
 
     classes.append("global.commodore")
 
-    for component in components:
-        classes.append(f"components.{component}")
+    if not bootstrap:
+        component_file = P("inventory", "classes", "components") / f"{target}.yml"
+        if not component_file.is_file():
+            raise click.ClickException(
+                f"Target rendering failed for {target}: component class is missing"
+            )
+        classes.append(f"components.{target}")
+        parameters = {
+            "kapitan": {
+                "vars": {
+                    "target": target,
+                }
+            }
+        }
 
     return {
         "classes": classes,
+        "parameters": parameters,
     }
 
 
@@ -61,14 +78,15 @@ def target_file(target: str):
     return P("inventory", "targets") / f"{target}.yml"
 
 
-def update_target(cfg: Config, target):
-    click.secho("Updating Kapitan target...", bold=True)
+def update_target(cfg: Config, target: str, bootstrap=False):
+    click.secho(f"Updating Kapitan target for {target}...", bold=True)
     file = target_file(target)
     os.makedirs(file.parent, exist_ok=True)
-    yaml_dump(render_target(target, cfg.get_components().keys()), file)
+    targetdata = render_target(target, cfg.get_components().keys(), bootstrap=bootstrap)
+    yaml_dump(targetdata, file)
 
 
-def render_params(cluster, target: str):
+def render_params(cluster):
     facts = cluster["facts"]
     for fact in ["distribution", "cloud"]:
         if fact not in facts or not facts[fact]:
@@ -76,7 +94,6 @@ def render_params(cluster, target: str):
 
     data = {
         "parameters": {
-            "target_name": target,
             "cluster": {
                 "name": cluster["id"],
                 "catalog_url": cluster["gitRepo"]["url"],
@@ -102,12 +119,12 @@ def render_params(cluster, target: str):
     return data
 
 
-def params_file(target: str):
-    return P("inventory", "classes", "params") / f"{target}.yml"
+def params_file():
+    return P("inventory", "classes", "params", "cluster.yml")
 
 
-def update_params(cluster, target):
+def update_params(cluster):
     click.secho("Updating cluster parameters...", bold=True)
-    file = params_file(target)
+    file = params_file()
     os.makedirs(file.parent, exist_ok=True)
-    yaml_dump(render_params(cluster, target), file)
+    yaml_dump(render_params(cluster), file)

--- a/commodore/cluster.py
+++ b/commodore/cluster.py
@@ -49,6 +49,9 @@ def render_target(target: str, components: Iterable[str]):
 
     classes.append("global.commodore")
 
+    for component in components:
+        classes.append(f"components.{component}")
+
     return {
         "classes": classes,
     }

--- a/commodore/compile.py
+++ b/commodore/compile.py
@@ -31,9 +31,6 @@ from .postprocess import postprocess_components
 from .refs import update_refs
 
 
-TARGET = "cluster"
-
-
 def _fetch_global_config(cfg, cluster):
     config = cluster["base_config"]
     click.secho("Updating global config...", bold=True)
@@ -59,36 +56,39 @@ def _fetch_customer_config(cfg, customer_id):
     cfg.register_config("customer", repo)
 
 
-def _regular_setup(config, cluster_id, target):
+def _regular_setup(config, cluster_id):
     try:
         cluster = fetch_cluster(config, cluster_id)
     except ApiError as e:
         raise click.ClickException(f"While fetching cluster specification: {e}") from e
 
-    update_target(config, target)
-    update_params(cluster, target)
+    update_target(config, "cluster", bootstrap=True)
+    update_params(cluster)
 
     # Fetch components and config
     _fetch_global_config(config, cluster)
     _fetch_customer_config(config, cluster["tenant"])
     fetch_components(config)
-    update_target(config, target)
+
+    update_target(config, "cluster", bootstrap=True)
+    for component in config.get_components().keys():
+        update_target(config, component)
 
     # Fetch catalog
     return fetch_customer_catalog(config, cluster["gitRepo"])
 
 
-def _local_setup(config, cluster_id, target):
+def _local_setup(config, cluster_id):
     click.secho("Running in local mode", bold=True)
     click.echo(" > Will use existing inventory, dependencies, and catalog")
 
-    # Currently, a target name other than "cluster" is not supported
-    if not target_file(target).is_file():
-        raise click.ClickException(f"Invalid target: {target}")
-    click.echo(f" > Using target: {target}")
+    if not target_file("cluster").is_file():
+        raise click.ClickException(
+            "Invalid working dir state: 'inventory/targets/cluster.yml' is missing"
+        )
 
-    click.echo(" > Assert current target matches")
-    current_cluster_id, tenant = read_cluster_and_tenant(target)
+    click.echo(" > Assert current working dir state matches requested compilation")
+    current_cluster_id, tenant = read_cluster_and_tenant()
     if current_cluster_id != cluster_id:
         error = (
             "[Local mode] Cluster ID mismatch: local state targets "
@@ -125,25 +125,26 @@ def _local_setup(config, cluster_id, target):
 # pylint: disable=redefined-builtin
 def compile(config, cluster_id):
     if config.local:
-        catalog_repo = _local_setup(config, cluster_id, TARGET)
+        catalog_repo = _local_setup(config, cluster_id)
     else:
         clean_working_tree(config)
-        catalog_repo = _regular_setup(config, cluster_id, TARGET)
+        catalog_repo = _regular_setup(config, cluster_id)
 
     # Compile kapitan inventory to extract component versions. Component
     # versions are assumed to be defined in the inventory key
     # 'parameters.component_versions'
     reset_reclass_cache()
-    kapitan_inventory = inventory_reclass("inventory")["nodes"][TARGET]
-    versions = kapitan_inventory["parameters"].get("component_versions", None)
+    cluster_inventory = inventory_reclass("inventory")["nodes"]["cluster"]
+    versions = cluster_inventory["parameters"].get("component_versions", None)
     if versions and not config.local:
         set_component_overrides(config, versions)
-        update_target(config, TARGET)
     # Rebuild reclass inventory to use new version of components
     reset_reclass_cache()
-    kapitan_inventory = inventory_reclass("inventory")["nodes"][TARGET]
+    kapitan_inventory = inventory_reclass("inventory")["nodes"]
     jsonnet_libs = (
-        kapitan_inventory["parameters"].get("commodore", {}).get("jsonnet_libs", None)
+        kapitan_inventory["cluster"]["parameters"]
+        .get("commodore", {})
+        .get("jsonnet_libs", None)
     )
     if jsonnet_libs and not config.local:
         fetch_jsonnet_libs(config, jsonnet_libs)
@@ -156,12 +157,14 @@ def compile(config, cluster_id):
 
     # Generate Kapitan secret references from refs found in inventory
     # parameters
-    update_refs(config, kapitan_inventory["parameters"])
+    update_refs(config, kapitan_inventory["cluster"]["parameters"])
 
-    kapitan_compile(config, search_paths=["./vendor/"])
+    components = config.get_components()
+    component_names = components.keys()
+    kapitan_compile(config, component_names, search_paths=["./vendor/"])
 
-    postprocess_components(config, kapitan_inventory, TARGET, config.get_components())
+    postprocess_components(config, kapitan_inventory, components)
 
-    update_catalog(config, TARGET, catalog_repo)
+    update_catalog(config, component_names, catalog_repo)
 
     click.secho("Catalog compiled! 🎉", bold=True)

--- a/commodore/dependency_mgmt.py
+++ b/commodore/dependency_mgmt.py
@@ -71,20 +71,18 @@ def delete_component_symlinks(cfg, component: Component):
 
 def _discover_components(cfg, inventory_path):
     """
-    Discover components in `inventory_path/`. Parse all classes found in
-    inventory_path and look for class includes starting with `components.`.
+    Discover components in `inventory_path/` by extracting all entries from
+    the reclass applications dictionary.
     """
     reset_reclass_cache()
-    kapitan_inventory = inventory_reclass(inventory_path, ignore_class_notfound=True)[
-        "nodes"
-    ]["cluster"]
+    kapitan_applications = inventory_reclass(
+        inventory_path, ignore_class_notfound=True
+    )["applications"]
     components = set()
-    for kls in kapitan_inventory["classes"]:
-        if kls.startswith("components."):
-            component = kls.split(".")[1]
-            if cfg.debug:
-                click.echo(f"   > Found component {component}")
-            components.add(component)
+    for component in kapitan_applications.keys():
+        if cfg.debug:
+            click.echo(f"   > Found component {component}")
+        components.add(component)
     return sorted(components)
 
 

--- a/commodore/helpers.py
+++ b/commodore/helpers.py
@@ -3,7 +3,7 @@ import json
 import shutil
 import os
 from pathlib import Path as P
-from typing import Callable
+from typing import Callable, Iterable
 
 import click
 import requests
@@ -13,7 +13,7 @@ import yaml
 from requests.exceptions import ConnectionError, HTTPError
 from url_normalize import url_normalize
 from kapitan import cached
-from kapitan import targets
+from kapitan import targets as kapitan_targets
 from kapitan import defaults
 from kapitan.cached import reset_cache as reset_reclass_cache
 from kapitan.refs.base import RefController, PlainRef
@@ -117,7 +117,7 @@ def clean_working_tree(config: Config):
 # pylint: disable=too-many-arguments
 def kapitan_compile(
     config: Config,
-    target="cluster",
+    targets: Iterable[str],
     output_dir="./",
     search_paths=None,
     fake_refs=False,
@@ -136,11 +136,11 @@ def kapitan_compile(
         refController.register_backend(FakeVaultBackend())
     click.secho("Compiling catalog...", bold=True)
     cached.args["compile"] = ArgumentCache(inventory_path="./inventory")
-    targets.compile_targets(
+    kapitan_targets.compile_targets(
         inventory_path="./inventory",
         search_paths=search_paths,
         output_path=output_dir,
-        targets=[target],
+        targets=targets,
         parallel=4,
         labels=None,
         ref_controller=refController,

--- a/commodore/postprocess/builtin_filters.py
+++ b/commodore/postprocess/builtin_filters.py
@@ -10,7 +10,7 @@ from commodore import __install_dir__
 from .jsonnet import jsonnet_runner
 
 
-def _builtin_filter_helm_namespace(inv, component, target, path, **kwargs):
+def _builtin_filter_helm_namespace(inv, component, path, **kwargs):
     if "namespace" not in kwargs:
         raise click.ClickException(
             "Builtin filter 'helm_namespace': filter argument 'namespace' is required"
@@ -18,13 +18,12 @@ def _builtin_filter_helm_namespace(inv, component, target, path, **kwargs):
     create_namespace = kwargs.get("create_namespace", "false")
     exclude_objects = kwargs.get("exclude_objects", [])
     exclude_objects = "|".join([json.dumps(e) for e in exclude_objects])
-    output_dir = P("compiled", target, path)
+    output_dir = P("compiled", component, path)
 
     # pylint: disable=c-extension-no-member
     jsonnet_runner(
         inv,
         component,
-        target,
         path,
         _jsonnet.evaluate_file,
         __install_dir__ / "filters" / "helm_namespace.jsonnet",
@@ -40,9 +39,9 @@ _builtin_filters = {
 }
 
 
-def run_builtin_filter(inv, component, target, f):
+def run_builtin_filter(inv, component, f):
     fname = f["filter"]
     if fname not in _builtin_filters:
         click.secho(f"   > [ERR ] Unknown builtin filter {fname}", fg="red")
         return
-    _builtin_filters[fname](inv, component, target, f["path"], **f["filterargs"])
+    _builtin_filters[fname](inv, component, f["path"], **f["filterargs"])

--- a/commodore/postprocess/jsonnet.py
+++ b/commodore/postprocess/jsonnet.py
@@ -76,17 +76,15 @@ _native_callbacks = {
 
 
 # pylint: disable=too-many-arguments
-def jsonnet_runner(
-    inv, component, target, output_path, jsonnet_func, jsonnet_input, **kwargs
-):
+def jsonnet_runner(inv, component, output_path, jsonnet_func, jsonnet_input, **kwargs):
     def _inventory():
         return inv
 
     _native_cb = _native_callbacks
     _native_cb["inventory"] = ((), _inventory)
-    kwargs["target"] = target
+    kwargs["target"] = component
     kwargs["component"] = component
-    output_dir = P("compiled", target, output_path)
+    output_dir = P("compiled", component, output_path)
     kwargs["output_path"] = str(output_dir)
     output = jsonnet_func(
         str(jsonnet_input),
@@ -106,7 +104,7 @@ def jsonnet_runner(
             yaml_dump(outcontents, outpath)
 
 
-def run_jsonnet_filter(inv, component, target, filterdir, f):
+def run_jsonnet_filter(inv, component, filterdir, f):
     """
     Run user-supplied jsonnet as postprocessing filter. This is the original
     way of doing postprocessing filters.
@@ -116,6 +114,4 @@ def run_jsonnet_filter(inv, component, target, filterdir, f):
     filterpath = filterdir / f["filter"]
     output_path = f["output_path"]
     # pylint: disable=c-extension-no-member
-    jsonnet_runner(
-        inv, component, target, output_path, _jsonnet.evaluate_file, filterpath
-    )
+    jsonnet_runner(inv, component, output_path, _jsonnet.evaluate_file, filterpath)

--- a/tests/test_component_compile.py
+++ b/tests/test_component_compile.py
@@ -63,18 +63,21 @@ def test_run_component_compile_command(tmp_path):
     component_name = "test-component"
     _prepare_component(tmp_path, component_name)
 
-    # exit_status = os.system(f"commodore component compile -o ./testdir dependencies/{component_name}")
     exit_status = call(
         f"commodore component compile -o ./testdir dependencies/{component_name}",
         shell=True,
     )
     assert exit_status == 0
     assert os.path.exists(
-        tmp_path / f"testdir/compiled/test/apps/{component_name}.yaml"
+        tmp_path
+        / "testdir/standalone/compiled"
+        / component_name
+        / f"apps/{component_name}.yaml"
     )
     rendered_yaml = (
         tmp_path
-        / "testdir/compiled/test"
+        / "testdir/standalone/compiled"
+        / component_name
         / component_name
         / "test_service_account.yaml"
     )
@@ -103,11 +106,15 @@ def test_run_component_compile_command_postprocess(tmp_path):
     )
     assert exit_status == 0
     assert os.path.exists(
-        tmp_path / f"testdir/compiled/test/apps/{component_name}.yaml"
+        tmp_path
+        / "testdir/standalone/compiled"
+        / component_name
+        / f"apps/{component_name}.yaml"
     )
     rendered_yaml = (
         tmp_path
-        / "testdir/compiled/test"
+        / "testdir/standalone/compiled"
+        / component_name
         / component_name
         / "test_service_account.yaml"
     )


### PR DESCRIPTION
WIP PR for a PoC for #223 

Notable changes:
* Components are included in the hierarchy via `applications` instead of `classes` (64b82ee8fe6d03f9176bbbfd14670ef1291ef94f). Component includes in the commodore-defaults and tenant repos need to be moved to `applications`, as described in the commit message.
* The refactored code implicitly disallows a component with name "cluster" to exist, as we're using the target name "cluster" for the bootstrapping target, so we can actually discover components, find component versions, generate Kapitan refs, etc. from a well-known target.
* The refactored code does not support compiling a component in a Kapitan target whose name is not the component name.
* Due to the previous point, the single-component compilation had to be adjusted to create a target named the same as the component. Therefore, component compilation would overwrite the intermediate result of catalog compilation for the component, if it exists. To avoid this, single-component compilation appends "standalone" to the requested output dir (TBD if we can do this in a nicer way).

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [ ] Keep pull requests small so they can be easily reviewed.
- [ ] Update the documentation.
- [x] Update tests.
- [ ] Update the ./CHANGELOG.md.
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
