### PR TITLE
Fix component compile to not break existing remote in component repo

### DIFF
--- a/commodore/component/compile.py
+++ b/commodore/component/compile.py
@@ -46,6 +46,7 @@ def compile_component(
             click.echo(f"   > Created temp workspace: {temp_dir}")
 
         component = Component(component_name, directory=component_path)
+        config.register_component(component)
         _prepare_fake_inventory(temp_dir, component, value_files)
 
         # Create class for fake parameters
@@ -125,8 +126,6 @@ def compile_component(
 
         # prepare inventory and fake component object for postprocess
         inventory = inventory_reclass(temp_dir / "inventory")["nodes"]
-        component = Component(component_name, repo_url="https://fake.repo.url/")
-        config.register_component(component)
         # We change the working directory to the output_path directory here,
         # as postprocess expects to find `compiled/<target>` in the working
         # directory.

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -9,6 +9,8 @@ from pathlib import Path as P
 from subprocess import call
 from git import Repo
 
+from commodore.component import Component, component_dir
+
 
 def setup_directory(tmp_path: P):
     os.chdir(tmp_path)
@@ -155,3 +157,20 @@ def test_deleting_inexistant_component(tmp_path: P):
         f"commodore -vvv component delete --force {component_name}", shell=True
     )
     assert exit_status == 2
+
+
+def _init_repo(tmp_path: P, cn: str, url: str):
+    setup_directory(tmp_path)
+    cr = Repo.init(component_dir(cn))
+    cr.create_remote("origin", url)
+
+
+def test_init_existing_component(tmp_path: P):
+    cn = "test-component"
+    orig_url = "git@github.com:projectsyn/commodore.git"
+    _init_repo(tmp_path, cn, orig_url)
+
+    c = Component(cn)
+
+    for url in c.repo.remote().urls:
+        assert url == orig_url

--- a/tests/test_component_compile.py
+++ b/tests/test_component_compile.py
@@ -8,7 +8,10 @@ import pytest
 from subprocess import call
 from textwrap import dedent
 
+
 from click import ClickException
+from git import Repo
+
 from commodore.config import Config
 from commodore.component.compile import compile_component
 from test_component import test_run_component_new_command
@@ -63,6 +66,9 @@ def test_run_component_compile_command(tmp_path):
     component_name = "test-component"
     _prepare_component(tmp_path, component_name)
 
+    component_repo = Repo(tmp_path / "dependencies" / component_name)
+    orig_remote_urls = list(component_repo.remote().urls)
+
     exit_status = call(
         f"commodore component compile -o ./testdir dependencies/{component_name}",
         shell=True,
@@ -83,6 +89,8 @@ def test_run_component_compile_command(tmp_path):
         target = yaml.safe_load(file)
         assert target["kind"] == "ServiceAccount"
         assert target["metadata"]["namespace"] == f"syn-{component_name}"
+
+    assert list(component_repo.remote().urls) == orig_remote_urls
 
 
 def test_run_component_compile_command_postprocess(tmp_path):


### PR DESCRIPTION
Remove unnecessary and wrong reinitialization of the `Component()` object in `commodore component compile`.

Also update the `run component compile` test to verify that the repo remotes are not changed.

Originally noticed in https://github.com/projectsyn/component-espejo/pull/8

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests.
- [x] Link this PR to related issues.
