### PR TITLE
Fix Component.lib_files to produce proper paths

### DIFF
--- a/commodore/component/__init__.py
+++ b/commodore/component/__init__.py
@@ -1,5 +1,3 @@
-import os
-
 from pathlib import Path as P
 from typing import Iterable
 
@@ -80,12 +78,11 @@ class Component:
 
     @property
     def lib_files(self) -> Iterable[P]:
-        files = []
         lib_dir = self.target_directory / "lib"
         if lib_dir.exists():
-            for file in os.listdir(lib_dir):
-                files.append(P(file))
-        return files
+            return lib_dir.iterdir()
+
+        return []
 
     @property
     def filters_file(self) -> P:


### PR DESCRIPTION
`os.listdir` doesn't preserve path information, so the appended `P(file)` entries which were returned by lib_files were just directly relative to the working directory, leaving dangling symlinks in `dependencies/lib` after symlinking the component files.

## Checklist
- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests.