### PR TITLE
Fix component checkout when local repo already contains the requested branch

### DIFF
--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -97,6 +97,27 @@ def test_component_checkout_existing_repo_update_version(tmp_path: P):
     assert c.repo.head.commit.hexsha == commit
 
 
+def test_component_checkout_existing_repo_update_latest_upstream(tmp_path: P):
+    c = _setup_component(tmp_path, version="master")
+    c.checkout()
+
+    assert not c.repo.head.is_detached
+    assert c.repo.head.ref.name == "master"
+    master_commit = c.repo.head.commit.hexsha
+
+    c.repo.git.reset("HEAD^", hard=True)
+
+    assert not c.repo.head.is_detached
+    assert c.repo.head.ref.name == "master"
+    assert c.repo.head.commit.hexsha != master_commit
+
+    c.checkout()
+
+    assert not c.repo.head.is_detached
+    assert c.repo.head.ref.name == "master"
+    assert not c.repo.is_dirty()
+
+
 @pytest.mark.parametrize(
     "mode",
     ["reinit", "update"],


### PR DESCRIPTION
Previously, Component.checkout would fail to update a component to a new version, if the local branch already exists but there's a newer upstream version.

This commit adjusts Component.checkout to always update the local branch to the latest upstream commit, discarding uncommitted local changes if any exist.

Closes #257.

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests.
- [x] Link this PR to related issues.
