### PR TITLE
Correctly create a local branch when overriding component version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Please document all notable changes to this project in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+* Correctly create a local branch when overriding component version ([#262])
+
 ## [v0.4.0] 2020—11—05
 
 ### Added
@@ -279,3 +284,4 @@ Initial implementation
 [#249]: https://github.com/projectsyn/commodore/pull/249
 [#253]: https://github.com/projectsyn/commodore/pull/253
 [#256]: https://github.com/projectsyn/commodore/pull/256
+[#262]: https://github.com/projectsyn/commodore/pull/262

--- a/commodore/component/__init__.py
+++ b/commodore/component/__init__.py
@@ -125,6 +125,8 @@ class Component:
                     head.commit = commit
                 else:
                     head = self._repo.create_head(branch, commit=commit)
+
+                head.set_tracking_branch(self.repo.remote().refs[branch])
                 self._repo.head.reference = head
             else:
                 # Create detached head by setting repo.head.reference as

--- a/commodore/dependency_mgmt.py
+++ b/commodore/dependency_mgmt.py
@@ -148,27 +148,20 @@ def set_component_overrides(cfg, versions):
         if component_name not in cfg.get_components():
             continue
         component = cfg.get_components()[component_name]
-        needs_checkout = False
         if "url" in overrides:
             url = overrides["url"]
             if cfg.debug:
                 click.echo(f" > Set URL for {component.name}: {url}")
-            needs_checkout = git.update_remote(component.repo, url)
             component.repo_url = url
         if "version" in overrides:
             component.version = overrides["version"]
             if cfg.debug:
                 click.echo(f" > Set version for {component.name}: {component.version}")
-            needs_checkout = True
-        if needs_checkout:
-            try:
-                git.checkout_version(component.repo, component.version)
-            except git.RefError as e:
-                raise click.ClickException(
-                    f"While setting component override: {e}"
-                ) from e
-            # Create symlinks again with correctly checked out components
-            create_component_symlinks(cfg, component)
+
+        # Call checkout to ensure component is checked out from the correct remote&version
+        component.checkout()
+        # Create symlinks again with correctly checked out components
+        create_component_symlinks(cfg, component)
 
 
 def fetch_jsonnet_libs(config: Config, libs):

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -59,6 +59,7 @@ def test_component_checkout_branch(tmp_path):
     else:
         raise ValueError(f"No remote branch for {branch}")
 
+    assert not c.repo.head.is_detached
     assert c.repo.head.ref.name == branch
     assert c.repo.head.commit == remote_branch_commit
 
@@ -80,7 +81,24 @@ def test_component_checkout_nonexisting_version(tmp_path: P):
         c.checkout()
 
 
-def test_component_checkout_existing_repo_update_version(tmp_path: P):
+def test_component_checkout_existing_repo_update_version_branch(tmp_path: P):
+    c = _setup_component(tmp_path, version="master")
+    c.checkout()
+
+    assert not c.repo.head.is_detached
+    assert c.repo.head.ref.name == "master"
+
+    # update version
+    branch = "component-defs-in-applications"
+    c.version = branch
+
+    c.checkout()
+
+    assert not c.repo.head.is_detached
+    assert c.repo.head.ref.name == branch
+
+
+def test_component_checkout_existing_repo_update_version_sha1version(tmp_path: P):
     c = _setup_component(tmp_path, version="master")
     c.checkout()
 


### PR DESCRIPTION
This PR updates `dependency_mgmt.set_component_versions` to use `Component.checkout` instead of `git.checkout_version` to check out component repo to the selected version.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests.
- [x] Update the ./CHANGELOG.md.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
