### PR TITLE
Remove usage of deprecated ::set-env in GitHub actions

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,10 +17,10 @@ jobs:
         fetch-depth: "0"
     - name: Set image version latest
       if: github.ref == 'refs/heads/master'
-      run: echo ::set-env name=VERSION::latest
+      run: echo "VERSION=latest" >> ${GITHUB_ENV}
     - name: Set image version from tag
       if: startsWith(github.ref, 'refs/tags/v')
-      run: echo ::set-env name=VERSION::$(echo ${GITHUB_REF#refs/tags/})
+      run: echo "VERSION=$(echo ${GITHUB_REF#refs/tags/})" >> ${GITHUB_ENV}
     - name: Build Image
       run: make docker
       env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 * Correctly create a local branch when overriding component version ([#262])
 * Field read when determine revision of the tenant config repository ([#263])
+* Remove usage of deprecated `::set-env` in GitHub actions ([#265])
 
 ## [v0.4.0] 2020—11—05
 
@@ -287,3 +288,4 @@ Initial implementation
 [#256]: https://github.com/projectsyn/commodore/pull/256
 [#262]: https://github.com/projectsyn/commodore/pull/262
 [#263]: https://github.com/projectsyn/commodore/pull/263
+[#265]: https://github.com/projectsyn/commodore/pull/265


### PR DESCRIPTION
## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update CHANGELOG.md.