### PR TITLE
Add a GitHub action to build the Kapitan docker image

### DIFF
--- a/.github/workflows/push-kapitan.yml
+++ b/.github/workflows/push-kapitan.yml
@@ -1,0 +1,28 @@
+name: Build & Push Container Image
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - tools/Dockerfile.kapitan
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      IMAGE: docker.io/projectsyn/kapitan
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set image version
+      run: echo "VERSION=$(grep KAPITAN_VERSION tools/Dockerfile.kapitan | cut -d= -f2)" > ${GITHUB_ENV}
+    - name: Build image
+      run: docker build -t ${IMAGE_NAME} tools/
+      env:
+        IMAGE_NAME: "${IMAGE}:${VERSION}"
+    - name: Push image
+      env:
+        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      run: |
+        docker login docker.io --username "${DOCKER_USERNAME}" --password "${DOCKER_PASSWORD}"
+        docker push "${IMAGE}:${VERSION}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+* Add GitHub action to build Kapitan docker image from `tools/Dockerfile.kapitan` ([#266])
+
 ### Fixed
 * Correctly create a local branch when overriding component version ([#262])
 * Field read when determine revision of the tenant config repository ([#263])
@@ -289,3 +292,4 @@ Initial implementation
 [#262]: https://github.com/projectsyn/commodore/pull/262
 [#263]: https://github.com/projectsyn/commodore/pull/263
 [#265]: https://github.com/projectsyn/commodore/pull/265
+[#266]: https://github.com/projectsyn/commodore/pull/266


### PR DESCRIPTION
This image is used by Syn ArgoCD to reveal secrets in the compiled catalog.

Until now, we've built the image manually and pushed it to docker.io/vshn/kapitan.

This commit also moves the image to docker.io/projectsyn/kapitan

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the ./CHANGELOG.md.