### PR TITLE
Always create targets from component aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 * Add GitHub action to build Kapitan docker image from `tools/Dockerfile.kapitan` ([#266])
 
+### Changed
+* Always create targets from component aliases ([#269])
+
 ### Fixed
 * Correctly create a local branch when overriding component version ([#262])
 * Field read when determine revision of the tenant config repository ([#263])
@@ -293,3 +296,4 @@ Initial implementation
 [#263]: https://github.com/projectsyn/commodore/pull/263
 [#265]: https://github.com/projectsyn/commodore/pull/265
 [#266]: https://github.com/projectsyn/commodore/pull/266
+[#269]: https://github.com/projectsyn/commodore/pull/269

--- a/commodore/compile.py
+++ b/commodore/compile.py
@@ -69,8 +69,6 @@ def _regular_setup(config: Config, cluster_id):
     fetch_components(config)
 
     update_target(config, config.inventory.bootstrap_target)
-    for component in config.get_components().keys():
-        update_target(config, component)
 
     for alias, component in config.get_component_aliases().items():
         update_target(config, alias, component=component)
@@ -153,7 +151,7 @@ def compile(config, cluster_id):
 
     components = config.get_components()
     aliases = config.get_component_aliases()
-    targets = list(components.keys()) + list(aliases.keys())
+    targets = list(aliases.keys())
     kapitan_compile(config, targets, search_paths=[config.vendor_dir])
 
     postprocess_components(config, kapitan_inventory, components)

--- a/commodore/config.py
+++ b/commodore/config.py
@@ -133,7 +133,8 @@ class Config:
     def verify_component_aliases(self, cluster_parameters: Dict):
         for alias, cn in self._component_aliases.items():
             ckey = cn.replace("-", "_")
-            if not cluster_parameters[ckey].get("multi_instance", False):
+            caliasable = cluster_parameters[ckey].get("multi_instance", False)
+            if alias != cn and not caliasable:
                 raise click.ClickException(
                     f"Component {cn} with alias {alias} does not support instantiation."
                 )

--- a/commodore/dependency_mgmt.py
+++ b/commodore/dependency_mgmt.py
@@ -66,21 +66,20 @@ def _discover_components(cfg, inventory_path):
             cn, alias = component.split(" as ")
         except ValueError:
             cn = component
-            alias = None
+            alias = component
         if cfg.debug:
             msg = f"   > Found component {cn}"
-            if alias:
+            if alias != component:
                 msg += f" aliased to {alias}"
             click.echo(msg)
         components.add(cn)
 
-        if alias:
-            if alias in component_aliases:
-                pc = component_aliases[alias]
-                raise KeyError(
-                    f"Duplicate component alias {alias}: component {pc} is already aliased to {alias}"
-                )
-            component_aliases[alias] = cn
+        if alias in component_aliases:
+            pc = component_aliases[alias]
+            raise KeyError(
+                f"Duplicate component alias {alias}: component {pc} is already aliased to {alias}"
+            )
+        component_aliases[alias] = cn
 
     return sorted(components), component_aliases
 

--- a/docs/modules/ROOT/pages/reference/architecture.adoc
+++ b/docs/modules/ROOT/pages/reference/architecture.adoc
@@ -105,6 +105,15 @@ Component instances are declared in the `applications` array using `as` as the i
 The current implementation of instances can be seen as a mechanism for introducing aliases for a component.
 Commodore supports hierarchies which include the same component non-aliased and aliased.
 
+[NOTE]
+====
+Non-aliased components are internally transformed into the aliased identity form `component as component`.
+This enables support for hierarchies which want to include a component only using aliases.
+
+A component can be aliased to its own name, regardless of whether the component supports instantiation.
+Having a component explicitly included both as `component` and `component as component` will result in an error during compilation.
+====
+
 The merged content of `parameters.<component_name>` in the configuration hierarchy is used as the base configuration for each instance.
 If an instance-aware component is included non-aliased, that "instance" sees the merged content of `parameters.<component_name>` in the hierarchy.
 For all other instances of a component, the content of `parameters.<instance_name>` is merged into `parameters.<component_name>`.
@@ -141,7 +150,7 @@ Components can make use of the meta-parameter `_instance` to ensure objects don'
 == Catalog Compilation
 
 Commodore uses https://kapitan.dev[Kapitan] to compile the cluster catalog.
-Commodore defines a https://kapitan.dev/inventory/#inventory-targets[Kapitan target] per component.
+Commodore defines a https://kapitan.dev/inventory/#inventory-targets[Kapitan target] for each <<_component_instantiation,component instance>>.
 Kapitan is called with a few options enabled.
 Most importantly, Kapitan is configured to support fetching dependencies of components, such as Helm charts.
 Further, Kapitan is configured with an extended search path to support component libraries and the builtin `commodore.libjsonnet`.


### PR DESCRIPTION
This commit addresses the issue reported in #268, where we found that if a component is only included in aliased forms, the plain component is rendered to the catalog in addition to the aliased versions.

This commit changes component discovery to handle unaliased components as if they were aliased to the component name itself.

This change in discovery allows us to only generate targets for aliases which correctly doesn't create a target for the unaliased version of a component if it's only included in aliased form.

Fixes #268.

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update the ./CHANGELOG.md.
- [x] Link this PR to related issues.
