### PR TITLE
Correctly handle component instances in Kapitan reference management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+* Correctly handle component instances in Kapitan reference management ([#272])
+
 ## [v0.4.1] 2020-12-28
 
 ### Added
@@ -301,3 +304,4 @@ Initial implementation
 [#265]: https://github.com/projectsyn/commodore/pull/265
 [#266]: https://github.com/projectsyn/commodore/pull/266
 [#269]: https://github.com/projectsyn/commodore/pull/269
+[#272]: https://github.com/projectsyn/commodore/pull/272

--- a/commodore/compile.py
+++ b/commodore/compile.py
@@ -145,13 +145,14 @@ def compile(config, cluster_id):
 
     clean_catalog(catalog_repo)
 
-    # Generate Kapitan secret references from refs found in inventory
-    # parameters
-    update_refs(config, cluster_parameters)
-
     components = config.get_components()
     aliases = config.get_component_aliases()
     targets = list(aliases.keys())
+
+    # Generate Kapitan secret references from refs found in inventory
+    # parameters
+    update_refs(config, aliases, kapitan_inventory)
+
     kapitan_compile(config, targets, search_paths=[config.vendor_dir])
 
     postprocess_components(config, kapitan_inventory, components)

--- a/commodore/config.py
+++ b/commodore/config.py
@@ -21,7 +21,7 @@ class Config:
         work_dir: P,
         api_url=None,
         api_token=None,
-        verbose=False,
+        verbose=0,
         username=None,
         usermail=None,
     ):

--- a/tests/test_refs.py
+++ b/tests/test_refs.py
@@ -1,0 +1,175 @@
+import pytest
+
+from pathlib import Path
+
+from commodore import refs
+from commodore.config import Config
+
+
+@pytest.fixture
+def inventory():
+    """
+    Setup test inventory
+    """
+
+    kapitan = {
+        "secrets": {
+            "vaultkv": {
+                "VAULT_ADDR": "https://vault.example.com",
+                "VAULT_CAPATH": "/etc/ssl/certs/",
+                "VAULT_SKIP_VERIFY": "false",
+                "auth": "token",
+                "engine": "kv-v2",
+                "mount": "clusters/kv",
+            }
+        },
+    }
+
+    return {
+        "cluster": {
+            "parameters": {
+                "_instance": "cluster",
+                "test": {
+                    "accesskey": "?{vaultkv:t-tenant/c-cluster/test/cluster-accesskey}",
+                    "secretkey": "?{vaultkv:t-tenant/c-cluster/test/cluster-secretkey}",
+                    "config": "something else",
+                    "params": {
+                        "env": [
+                            {"key": "envA", "value": "valA"},
+                            {"key": "envB", "value": "valB"},
+                        ],
+                        "complex": True,
+                    },
+                },
+                "non_component": {
+                    "password": "?{vaultkv:t-tenant/c-cluster/global/password}",
+                },
+                "other_component": {
+                    "enabled": True,
+                    "thesecret": "?{vaultkv:t-tenant/c-cluster/other-component/thesecret}",
+                    "users": ["user1", "user2"],
+                },
+                "kapitan": kapitan,
+            },
+        },
+        "test-a": {
+            "parameters": {
+                "_instance": "test-a",
+                "test": {
+                    "accesskey": "?{vaultkv:t-tenant/c-cluster/test/test-a-accesskey}",
+                    "secretkey": "?{vaultkv:t-tenant/c-cluster/test/test-a-secretkey}",
+                    "config": "something else",
+                    "params": {
+                        "env": [
+                            {"key": "envA", "value": "valA"},
+                            {"key": "envB", "value": "valB"},
+                        ],
+                        "complex": True,
+                    },
+                },
+                "non_component": {
+                    "password": "?{vaultkv:t-tenant/c-cluster/global/password}",
+                },
+                "other_component": {
+                    "enabled": True,
+                    "thesecret": "?{vaultkv:t-tenant/c-cluster/other-component/thesecret}",
+                    "users": ["user1", "user2"],
+                },
+                "kapitan": kapitan,
+            },
+        },
+        "test-b": {
+            "parameters": {
+                "_instance": "test-b",
+                "test": {
+                    "accesskey": "?{vaultkv:t-tenant/c-cluster/test/test-b-accesskey}",
+                    "secretkey": "?{vaultkv:t-tenant/c-cluster/test/test-b-secretkey}",
+                    "config": "something else",
+                    "params": {
+                        "env": [
+                            {"key": "envA", "value": "valA"},
+                            {"key": "envB", "value": "valB"},
+                        ],
+                        "complex": True,
+                    },
+                },
+                "non_component": {
+                    "password": "?{vaultkv:t-tenant/c-cluster/global/password}",
+                },
+                "other_component": {
+                    "enabled": True,
+                    "thesecret": "?{vaultkv:t-tenant/c-cluster/other-component/thesecret}",
+                    "users": ["user1", "user2"],
+                },
+                "kapitan": kapitan,
+            },
+        },
+        "other-component": {
+            "parameters": {
+                "_instance": "other-component",
+                "test": {
+                    "accesskey": "?{vaultkv:t-tenant/c-cluster/test/other-component-accesskey}",
+                    "secretkey": "?{vaultkv:t-tenant/c-cluster/test/other-component-secretkey}",
+                    "config": "something else",
+                    "params": {
+                        "env": [
+                            {"key": "envA", "value": "valA"},
+                            {"key": "envB", "value": "valB"},
+                        ],
+                        "complex": True,
+                    },
+                },
+                "non_component": {
+                    "password": "?{vaultkv:t-tenant/c-cluster/global/password}",
+                },
+                "other_component": {
+                    "enabled": True,
+                    "thesecret": "?{vaultkv:t-tenant/c-cluster/other-component/thesecret}",
+                    "users": ["user1", "user2"],
+                },
+                "kapitan": kapitan,
+            },
+        },
+    }
+
+
+@pytest.fixture
+def config(tmp_path: Path):
+    """
+    Setup test config
+    """
+    c = Config(work_dir=tmp_path)
+    aliases = {
+        "other-component": "other-component",
+        "test-a": "test",
+        "test-b": "test",
+    }
+    c.register_component_aliases(aliases)
+    return c
+
+
+def test_update_refs(tmp_path: Path, config, inventory):
+    aliases = config.get_component_aliases()
+    refs.update_refs(config, aliases, inventory)
+    ref_prefix = config.refs_dir / "t-tenant" / "c-cluster"
+    expected_refs = [
+        Path("other-component/thesecret"),
+        Path("test/test-a-accesskey"),
+        Path("test/test-a-secretkey"),
+        Path("test/test-b-accesskey"),
+        Path("test/test-b-secretkey"),
+        Path("global/password"),
+    ]
+    for ref in expected_refs:
+        refpath = ref_prefix / ref
+        assert refpath.is_file()
+
+    not_expected_refs = [
+        Path("test/cluster-accesskey"),
+        Path("test/cluster-secretkey"),
+        Path("test/other-component-accesskey"),
+        Path("test/other-component-secretkey"),
+    ]
+    for ref in not_expected_refs:
+        refpath = ref_prefix / ref
+        assert not refpath.exists()

--- a/tests/test_refs.py
+++ b/tests/test_refs.py
@@ -33,6 +33,10 @@ def inventory():
             "non_component": {
                 "password": "?{vaultkv:t-tenant/c-cluster/global/password}",
             },
+            "non-component-2": {
+                "key1": "value",
+                "key2": 42,
+            },
             "other_component": {
                 "enabled": True,
                 "thesecret": "?{vaultkv:t-tenant/c-cluster/other-component/thesecret}",

--- a/tests/test_refs.py
+++ b/tests/test_refs.py
@@ -12,123 +12,58 @@ def inventory():
     Setup test inventory
     """
 
-    kapitan = {
-        "secrets": {
-            "vaultkv": {
-                "VAULT_ADDR": "https://vault.example.com",
-                "VAULT_CAPATH": "/etc/ssl/certs/",
-                "VAULT_SKIP_VERIFY": "false",
-                "auth": "token",
-                "engine": "kv-v2",
-                "mount": "clusters/kv",
-            }
-        },
-    }
+    def _test(target):
+        return {
+            "accesskey": f"?{{vaultkv:t-tenant/c-cluster/test/{target}-accesskey}}",
+            "secretkey": f"?{{vaultkv:t-tenant/c-cluster/test/{target}-secretkey}}",
+            "config": "something else",
+            "params": {
+                "env": [
+                    {"key": "envA", "value": "valA"},
+                    {"key": "envB", "value": "valB"},
+                ],
+                "complex": True,
+            },
+        }
+
+    def _params(target):
+        return {
+            "_instance": target,
+            "test": _test(target),
+            "non_component": {
+                "password": "?{vaultkv:t-tenant/c-cluster/global/password}",
+            },
+            "other_component": {
+                "enabled": True,
+                "thesecret": "?{vaultkv:t-tenant/c-cluster/other-component/thesecret}",
+                "users": ["user1", "user2"],
+            },
+            "kapitan": {
+                "secrets": {
+                    "vaultkv": {
+                        "VAULT_ADDR": "https://vault.example.com",
+                        "VAULT_CAPATH": "/etc/ssl/certs/",
+                        "VAULT_SKIP_VERIFY": "false",
+                        "auth": "token",
+                        "engine": "kv-v2",
+                        "mount": "clusters/kv",
+                    }
+                },
+            },
+        }
 
     return {
         "cluster": {
-            "parameters": {
-                "_instance": "cluster",
-                "test": {
-                    "accesskey": "?{vaultkv:t-tenant/c-cluster/test/cluster-accesskey}",
-                    "secretkey": "?{vaultkv:t-tenant/c-cluster/test/cluster-secretkey}",
-                    "config": "something else",
-                    "params": {
-                        "env": [
-                            {"key": "envA", "value": "valA"},
-                            {"key": "envB", "value": "valB"},
-                        ],
-                        "complex": True,
-                    },
-                },
-                "non_component": {
-                    "password": "?{vaultkv:t-tenant/c-cluster/global/password}",
-                },
-                "other_component": {
-                    "enabled": True,
-                    "thesecret": "?{vaultkv:t-tenant/c-cluster/other-component/thesecret}",
-                    "users": ["user1", "user2"],
-                },
-                "kapitan": kapitan,
-            },
+            "parameters": _params("cluster"),
         },
         "test-a": {
-            "parameters": {
-                "_instance": "test-a",
-                "test": {
-                    "accesskey": "?{vaultkv:t-tenant/c-cluster/test/test-a-accesskey}",
-                    "secretkey": "?{vaultkv:t-tenant/c-cluster/test/test-a-secretkey}",
-                    "config": "something else",
-                    "params": {
-                        "env": [
-                            {"key": "envA", "value": "valA"},
-                            {"key": "envB", "value": "valB"},
-                        ],
-                        "complex": True,
-                    },
-                },
-                "non_component": {
-                    "password": "?{vaultkv:t-tenant/c-cluster/global/password}",
-                },
-                "other_component": {
-                    "enabled": True,
-                    "thesecret": "?{vaultkv:t-tenant/c-cluster/other-component/thesecret}",
-                    "users": ["user1", "user2"],
-                },
-                "kapitan": kapitan,
-            },
+            "parameters": _params("test-a"),
         },
         "test-b": {
-            "parameters": {
-                "_instance": "test-b",
-                "test": {
-                    "accesskey": "?{vaultkv:t-tenant/c-cluster/test/test-b-accesskey}",
-                    "secretkey": "?{vaultkv:t-tenant/c-cluster/test/test-b-secretkey}",
-                    "config": "something else",
-                    "params": {
-                        "env": [
-                            {"key": "envA", "value": "valA"},
-                            {"key": "envB", "value": "valB"},
-                        ],
-                        "complex": True,
-                    },
-                },
-                "non_component": {
-                    "password": "?{vaultkv:t-tenant/c-cluster/global/password}",
-                },
-                "other_component": {
-                    "enabled": True,
-                    "thesecret": "?{vaultkv:t-tenant/c-cluster/other-component/thesecret}",
-                    "users": ["user1", "user2"],
-                },
-                "kapitan": kapitan,
-            },
+            "parameters": _params("test-b"),
         },
         "other-component": {
-            "parameters": {
-                "_instance": "other-component",
-                "test": {
-                    "accesskey": "?{vaultkv:t-tenant/c-cluster/test/other-component-accesskey}",
-                    "secretkey": "?{vaultkv:t-tenant/c-cluster/test/other-component-secretkey}",
-                    "config": "something else",
-                    "params": {
-                        "env": [
-                            {"key": "envA", "value": "valA"},
-                            {"key": "envB", "value": "valB"},
-                        ],
-                        "complex": True,
-                    },
-                },
-                "non_component": {
-                    "password": "?{vaultkv:t-tenant/c-cluster/global/password}",
-                },
-                "other_component": {
-                    "enabled": True,
-                    "thesecret": "?{vaultkv:t-tenant/c-cluster/other-component/thesecret}",
-                    "users": ["user1", "user2"],
-                },
-                "kapitan": kapitan,
-            },
+            "parameters": _params("other-component"),
         },
     }
 


### PR DESCRIPTION
Previously, we simply used the bootstrap target's `parameters` to generate Kapitan secret reference files. This approach doesn't support using `${_instance}` in secret references.

However, supporting that pattern is desirable, as it allows configuring sensible per-instance secret references in components which support instantiation.

This commit refactors Commodore's reference discovery and Kapitan reference file creation to correctly create reference files for "instantiated" secret references.

The refactored reference discovery iterates over all component instances and generates secret references for the component's key in `parameters` of the instance targets.

Just processing the component's key in `parameters` of the instance targets would not necessarily discover all secret references, as we don't prohibit having keys in parameters which are not directly associated with a component. Therefore, we additionally search for secret references in the bootstrap target's `parameters` dict for all keys that don't match a component name.

Fixes #271 

## Checklist
- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests.
- [x] Update the ./CHANGELOG.md.
- [x] Link this PR to related issues.