### PR TITLE
 Support for rendering component `jsonnetfile.json` from Jsonnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+* Support for rendering component `jsonnetfile.json` from Jsonnet ([#275])
+
 ### Fixed
 * Correctly handle component instances in Kapitan reference management ([#272])
 
@@ -309,4 +312,5 @@ Initial implementation
 [#266]: https://github.com/projectsyn/commodore/pull/266
 [#269]: https://github.com/projectsyn/commodore/pull/269
 [#272]: https://github.com/projectsyn/commodore/pull/272
+[#275]: https://github.com/projectsyn/commodore/pull/275
 [#276]: https://github.com/projectsyn/commodore/pull/276

--- a/commodore/cluster.py
+++ b/commodore/cluster.py
@@ -10,6 +10,7 @@ from .helpers import (
     yaml_load,
 )
 
+from .component import component_parameters_key
 from .config import Config
 from .inventory import Inventory
 
@@ -153,8 +154,8 @@ def render_target(
         # When component != target we're rendering a target for an aliased
         # component. This needs some extra work.
         if component != target:
-            ckey = component.replace("-", "_")
-            tkey = target.replace("-", "_")
+            ckey = component_parameters_key(component)
+            tkey = component_parameters_key(target)
             parameters[ckey] = f"${{{tkey}}}"
 
     return {

--- a/commodore/compile.py
+++ b/commodore/compile.py
@@ -136,8 +136,8 @@ def compile(config, cluster_id):
     # Verify that all aliased components support instantiation after resolving component version overrides.
     config.verify_component_aliases(cluster_parameters)
 
-    for cn, component in config.get_components().items():
-        ckey = cn.replace("-", "_")
+    for component in config.get_components().values():
+        ckey = component.parameters_key
         component.render_jsonnetfile_json(cluster_parameters[ckey])
 
     jsonnet_libs = cluster_parameters.get("commodore", {}).get("jsonnet_libs", None)

--- a/commodore/compile.py
+++ b/commodore/compile.py
@@ -136,6 +136,10 @@ def compile(config, cluster_id):
     # Verify that all aliased components support instantiation after resolving component version overrides.
     config.verify_component_aliases(cluster_parameters)
 
+    for cn, component in config.get_components().items():
+        ckey = cn.replace("-", "_")
+        component.render_jsonnetfile_json(cluster_parameters[ckey])
+
     jsonnet_libs = cluster_parameters.get("commodore", {}).get("jsonnet_libs", None)
     if jsonnet_libs and not config.local:
         fetch_jsonnet_libs(config, jsonnet_libs)

--- a/commodore/component/__init__.py
+++ b/commodore/component/__init__.py
@@ -1,6 +1,7 @@
 from pathlib import Path as P
 from typing import Iterable
 
+import _jsonnet
 import click
 
 from git import Repo, BadName, GitCommandError
@@ -140,6 +141,20 @@ class Component:
             raise RefError(f"Failed to checkout revision '{self.version}'") from e
         except BadName as e:
             raise RefError(f"Revision '{self.version}' not found in repository") from e
+
+    def render_jsonnetfile_json(self, component_params):
+        """
+        Render jsonnetfile.json from jsonnetfile.jsonnet
+        """
+        jsonnetfile_jsonnet = self._dir / "jsonnetfile.jsonnet"
+        if jsonnetfile_jsonnet.is_file():
+            # pylint: disable=c-extension-no-member
+            output = _jsonnet.evaluate_file(
+                str(jsonnetfile_jsonnet),
+                ext_vars=component_params.get("jsonnetfile_parameters", {}),
+            )
+            with open(self._dir / "jsonnetfile.json", "w") as fp:
+                fp.write(output)
 
 
 def component_dir(work_dir: P, name: str) -> P:

--- a/commodore/component/__init__.py
+++ b/commodore/component/__init__.py
@@ -155,7 +155,7 @@ class Component:
         if jsonnetfile_jsonnet.is_file():
             if jsonnetfile_json.name in self.repo.tree():
                 click.secho(
-                    f" > [WARN] Component {self.name} repo contains both jsonnetfile.json and jsonnetfile.jsonnet,"
+                    f" > [WARN] Component {self.name} repo contains both jsonnetfile.json and jsonnetfile.jsonnet, "
                     + "continuing with jsonnetfile.jsonnet",
                     fg="yellow",
                 )

--- a/commodore/component/__init__.py
+++ b/commodore/component/__init__.py
@@ -151,7 +151,14 @@ class Component:
         Render jsonnetfile.json from jsonnetfile.jsonnet
         """
         jsonnetfile_jsonnet = self._dir / "jsonnetfile.jsonnet"
+        jsonnetfile_json = self._dir / "jsonnetfile.json"
         if jsonnetfile_jsonnet.is_file():
+            if jsonnetfile_json.name in self.repo.tree():
+                click.secho(
+                    f" > [WARN] Component {self.name} repo contains both jsonnetfile.json and jsonnetfile.jsonnet,"
+                    + "continuing with jsonnetfile.jsonnet",
+                    fg="yellow",
+                )
             # pylint: disable=c-extension-no-member
             output = _jsonnet.evaluate_file(
                 str(jsonnetfile_jsonnet),

--- a/commodore/component/__init__.py
+++ b/commodore/component/__init__.py
@@ -100,6 +100,10 @@ class Component:
         # TODO Use self.target_directory when implement https://github.com/projectsyn/commodore/issues/214.
         return P(self.repo.working_tree_dir, "postprocess", "filters.yml")
 
+    @property
+    def parameters_key(self):
+        return component_parameters_key(self.name)
+
     def checkout(self):
         remote_heads = self._repo.remote().fetch()
         remote_prefix = self._repo.remote().name + "/"
@@ -159,3 +163,7 @@ class Component:
 
 def component_dir(work_dir: P, name: str) -> P:
     return work_dir / "dependencies" / name
+
+
+def component_parameters_key(name: str) -> str:
+    return name.replace("-", "_")

--- a/commodore/component/compile.py
+++ b/commodore/component/compile.py
@@ -96,6 +96,12 @@ def compile_component(
                 )
             )
 
+        # Render jsonnetfile.jsonnet if necessary
+        nodes = inventory_reclass(inv.inventory_dir)["nodes"]
+        component_params = nodes[component_name]["parameters"].get(
+            component_name.replace("-", "_"), {}
+        )
+        component.render_jsonnetfile_json(component_params)
         # Fetch Jsonnet libs
         fetch_jsonnet_libraries(component_path)
 
@@ -113,7 +119,6 @@ def compile_component(
         )
 
         # prepare inventory and fake component object for postprocess
-        nodes = inventory_reclass(inv.inventory_dir)["nodes"]
         config.work_dir = output_path
         postprocess_components(config, nodes, config.get_components())
     finally:

--- a/commodore/config.py
+++ b/commodore/config.py
@@ -4,7 +4,7 @@ from typing import Dict
 import click
 from git import Repo
 
-from commodore.component import Component
+from commodore.component import Component, component_parameters_key
 from .inventory import Inventory
 
 
@@ -132,7 +132,7 @@ class Config:
 
     def verify_component_aliases(self, cluster_parameters: Dict):
         for alias, cn in self._component_aliases.items():
-            ckey = cn.replace("-", "_")
+            ckey = component_parameters_key(cn)
             caliasable = cluster_parameters[ckey].get("multi_instance", False)
             if alias != cn and not caliasable:
                 raise click.ClickException(

--- a/commodore/refs.py
+++ b/commodore/refs.py
@@ -6,6 +6,7 @@ from typing import Dict
 
 import click
 
+from .component import component_parameters_key
 from .config import Config
 from .helpers import rm_tree_contents, yaml_dump
 
@@ -176,7 +177,7 @@ def update_refs(config: Config, aliases: Dict[str, str], inventory: Dict):
     rb = RefBuilder(config, inventory)
 
     # Generate list of component keys from component aliases dict
-    component_keys = set(map(lambda x: x.replace("-", "_"), aliases.values()))
+    component_keys = set(map(component_parameters_key, aliases.values()))
     bootstrap_target = config.inventory.bootstrap_target
     # Find all keys in the bootstrap target's parameters which don't directly
     # belong to a component.
@@ -190,7 +191,7 @@ def update_refs(config: Config, aliases: Dict[str, str], inventory: Dict):
     for target, component in aliases.items():
         # For components, any dashes in the component name are replaced by
         # underscores in the parameters key.
-        component_key = component.replace("-", "_")
+        component_key = component_parameters_key(component)
         # Find references for component instance
         rb.find_refs(target, component_key)
 

--- a/docs/modules/ROOT/pages/reference/architecture.adoc
+++ b/docs/modules/ROOT/pages/reference/architecture.adoc
@@ -172,7 +172,7 @@ Jsonnet external variables must be string-valued. Therefore we can't simply pass
 ====
 
 Below a `jsonnetfile.jsonnet` and corresponding `class/defaults.yml` for component `rancher-monitoring` are shown.
-The `rancher-monitoring` component on the `kube-prometheus` Jsonnet library, but requires different versions of the library depending on the target cluster's Kubernetes version.
+The `rancher-monitoring` component depends on the `kube-prometheus` Jsonnet library, but requires different versions of the library depending on the target cluster's Kubernetes version.
 
 .jsonnetfile.jsonnet
 [source,jsonnet]

--- a/docs/modules/ROOT/pages/reference/architecture.adoc
+++ b/docs/modules/ROOT/pages/reference/architecture.adoc
@@ -168,7 +168,8 @@ Commodore injects the key `parameters.<component_name>.jsonnetfile_parameters` a
 
 [NOTE]
 ====
-Jsonnet external variables must be string-valued. Therefore we can't simply pass the full `parameters.component_name` as external variables.
+Jsonnet external variables must be string-valued.
+Therefore it's not possible to simply pass the full `parameters.component_name` as external variables.
 ====
 
 Below a `jsonnetfile.jsonnet` and corresponding `class/defaults.yml` for component `rancher-monitoring` are shown.

--- a/docs/modules/ROOT/pages/reference/architecture.adoc
+++ b/docs/modules/ROOT/pages/reference/architecture.adoc
@@ -156,6 +156,57 @@ Similar to Helm charts, the components themselves must make sure to not cause an
 This is required both for namespaced and non-namespaced resources.
 Components can make use of the meta-parameter `_instance` to ensure objects don't collide, as that parameter is guaranteed to be unique to each instance.
 
+=== Component dependencies
+
+Components can specify their dependencies in a `jsonnetfile.json`.
+Commodore uses https://github.com/jsonnet-bundler/jsonnet-bundler[jsonnet-bundler] to fetch component dependencies.
+
+Components can optionally specify their dependencies in a `jsonnetfile.jsonnet`.
+In this case, Commodore renders the `jsonnetfile.jsonnet` into `jsonnetfile.json` before running jsonnet-bundler.
+
+Commodore injects the key `parameters.<component_name>.jsonnetfile_parameters` as external variables when rendering the `jsonnetfile.jsonnet`.
+
+[NOTE]
+====
+Jsonnet external variables must be string-valued. Therefore we can't simply pass the full `parameters.component_name` as external variables.
+====
+
+Below a `jsonnetfile.jsonnet` and corresponding `class/defaults.yml` for component `rancher-monitoring` are shown.
+The `rancher-monitoring` component on the `kube-prometheus` Jsonnet library, but requires different versions of the library depending on the target cluster's Kubernetes version.
+
+.jsonnetfile.jsonnet
+[source,jsonnet]
+----
+{
+  version: 1,
+  dependencies: [
+    {
+      source: {
+        git: {
+          remote: 'https://github.com/coreos/kube-prometheus',
+          subdir: 'jsonnet/kube-prometheus',
+        },
+      },
+      version: std.extVar('kube_prometheus_version'),
+    },
+  ],
+  legacyImports: true,
+}
+----
+
+.class/defaults.yml
+[source,yaml]
+----
+parameters:
+  rancher_monitoring:
+    kube_prometheus_version:
+      '1.17': 4e7440f742df31cd6da188f52ddc4e4037b81599
+      '1.18': f69ff3d63de17f3f52b955c3b7e0d7aff0372873
+    jsonnetfile_parameters:
+      # Default to K8s 1.18 if not overridden by cluster version
+      kube_prometheus_version: ${rancher_monitoring:kube_prometheus_version:1.18}
+----
+
 == Catalog Compilation
 
 Commodore uses https://kapitan.dev[Kapitan] to compile the cluster catalog.

--- a/docs/modules/ROOT/pages/reference/concepts.adoc
+++ b/docs/modules/ROOT/pages/reference/concepts.adoc
@@ -45,6 +45,12 @@ inventory to install the software.
 Components can optionally provide Jsonnet libraries which can be used by other components.
 To allow Commodore to make component libraries available to other components, they must be placed in directory `lib/`.
 
+Components can specify Jsonnet dependencies in a `jsonnetfile.json` in the component's root directory.
+Commodore uses https://github.com/jsonnet-bundler/jsonnet-bundler[jsonnet-bundler] to fetch all components' dependencies.
+
+Optionally, components can provide a `jsonnetfile.jsonnet` instead which will be rendered to JSON before Commodore fetches component dependencies.
+In this case, external variables which are used in the `jsonnetfile.jsonnet` must be provided in the inventory key `parameters.<component_name>.jsonnetfile_parameters`.
+
 Components can define and use postprocessing filters which are applied on the result of the component's compiled Kapitan catalog.
 Components define postprocessing filters in the <<_inventory,inventory>> in key `parameters.commodore.postprocess.filters`.
 Details of the filter definition format and the postprocessing process can be found in the xref:commodore:ROOT:reference/architecture.adoc#_postprocessing_filters[architecture documentation].

--- a/docs/modules/ROOT/pages/reference/concepts.adoc
+++ b/docs/modules/ROOT/pages/reference/concepts.adoc
@@ -47,9 +47,9 @@ To allow Commodore to make component libraries available to other components, th
 
 Components can specify Jsonnet dependencies in a `jsonnetfile.json` in the component's root directory.
 Commodore uses https://github.com/jsonnet-bundler/jsonnet-bundler[jsonnet-bundler] to fetch all components' dependencies.
-
-Optionally, components can provide a `jsonnetfile.jsonnet` instead which will be rendered to JSON before Commodore fetches component dependencies.
-In this case, external variables which are used in the `jsonnetfile.jsonnet` must be provided in the inventory key `parameters.<component_name>.jsonnetfile_parameters`.
+Optionally, components can provide a `jsonnetfile.jsonnet` instead of `jsonnetfile.json`.
+If a `jsonnetfile.jsonnet` is present it will be rendered to `jsonnetfile.json` before Commodore fetches component dependencies.
+The `jsonnetfile.jsonnet` approach is described in more details in the xref:commodore:ROOT:reference/architecture.adoc#_component_dependencies[architecture documentation].
 
 Components can define and use postprocessing filters which are applied on the result of the component's compiled Kapitan catalog.
 Components define postprocessing filters in the <<_inventory,inventory>> in key `parameters.commodore.postprocess.filters`.

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -223,6 +223,8 @@ def test_render_jsonnetfile_json(tmp_path: P):
             }"""
             )
         )
+    c.repo.index.add("*")
+    c.repo.index.commit("Initial commit")
 
     c.render_jsonnetfile_json(
         {"jsonnetfile_parameters": {"kube_prometheus_version": "1.18"}}

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -6,7 +6,12 @@ from git import Repo
 from textwrap import dedent
 
 
-from commodore.component import Component, component_dir, RefError
+from commodore.component import (
+    Component,
+    component_dir,
+    RefError,
+    component_parameters_key,
+)
 from commodore.inventory import Inventory
 
 
@@ -234,3 +239,15 @@ def test_render_jsonnetfile_json(tmp_path: P):
         assert jsonnetfile_contents["version"] == 1
         assert jsonnetfile_contents["legacyImports"]
         assert jsonnetfile_contents["dependencies"][0]["version"] == "1.18"
+
+
+@pytest.mark.parametrize(
+    "name,key",
+    [
+        ("simple", "simple"),
+        ("simple-name", "simple_name"),
+        ("some-other-name", "some_other_name"),
+    ],
+)
+def test_component_parameters_key(name: str, key: str):
+    assert component_parameters_key(name) == key


### PR DESCRIPTION
Enable hierarchy-based customization for the `jsonnetfile.json` of components.

As an example, this allows users to specify versions of their jsonnet dependencies in the hierarchy (e.g. kube-prometheus version based on cluster K8s version). See https://github.com/projectsyn/component-rancher-monitoring/pull/1 for an example.

Fixes #213 

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update tests.
- [x] Update the ./CHANGELOG.md.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
