### PR TITLE
Generate a best-effort SSH-based push URL for component repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+* Generate a best-effort SSH-based push URL for component repos ([#281])
+
 ## [v0.4.2] - 2021-01-14
 
 ### Added
@@ -317,3 +321,4 @@ Initial implementation
 [#272]: https://github.com/projectsyn/commodore/pull/272
 [#275]: https://github.com/projectsyn/commodore/pull/275
 [#276]: https://github.com/projectsyn/commodore/pull/276
+[#281]: https://github.com/projectsyn/commodore/pull/281

--- a/commodore/component/__init__.py
+++ b/commodore/component/__init__.py
@@ -11,7 +11,7 @@ from git import Repo, BadName, GitCommandError
 from commodore.git import RefError
 
 
-HTTP_SSH_REPLACER = re.compile("^https?://")
+HTTP_SSH_REPLACER = re.compile(r"^https?://(\w+(:\w+)?@)?")
 
 
 class Component:

--- a/commodore/component/__init__.py
+++ b/commodore/component/__init__.py
@@ -1,3 +1,5 @@
+import re
+
 from pathlib import Path as P
 from typing import Iterable
 
@@ -7,6 +9,9 @@ import click
 from git import Repo, BadName, GitCommandError
 
 from commodore.git import RefError
+
+
+HTTP_SSH_REPLACER = re.compile("^https?://")
 
 
 class Component:
@@ -65,6 +70,11 @@ class Component:
             self._repo.remote().set_url(url)
         except ValueError:
             self._repo.create_remote("origin", url)
+        # Try to generate a best effort push-over-SSH URL. If the URL starts
+        # with http/https, replace the protocol prefix with ssh://git@,
+        # otherwise return the url string unchanged.
+        pushurl = HTTP_SSH_REPLACER.sub("ssh://git@", url)
+        self._repo.remote().set_url(pushurl, push=True)
 
     @property
     def version(self) -> str:

--- a/docs/modules/ROOT/pages/reference/architecture.adoc
+++ b/docs/modules/ROOT/pages/reference/architecture.adoc
@@ -56,6 +56,7 @@ components:
 ====
 Commodore will attempt to transform http(s) Git URLs to their SSH-based counterparts when configuring the push URL on the local repository.
 This transformation allows authorized users to push feature branches to component repos without having to first manually adjust the repository's push URL.
+If the http(s) Git URL contains a `user@` or `user:pass@` part, that part will be removed when transforming the URL to a SSH-based push URL.
 
 The transformation assumes that SSH URLs follow the pattern `git@host:path/to/repo.git` (or `ssh://git@host/path/to/repo.git`).
 This assumption holds for many popular Git hosting services, such as GitHub and GitLab.

--- a/docs/modules/ROOT/pages/reference/architecture.adoc
+++ b/docs/modules/ROOT/pages/reference/architecture.adoc
@@ -52,6 +52,15 @@ components:
   url: https://github.com/projectsyn/component-metrics-server.git
 --
 
+[NOTE]
+====
+Commodore will attempt to transform http(s) Git URLs to their SSH-based counterparts when configuring the push URL on the local repository.
+This transformation allows authorized users to push feature branches to component repos without having to first manually adjust the repository's push URL.
+
+The transformation assumes that SSH URLs follow the pattern `git@host:path/to/repo.git` (or `ssh://git@host/path/to/repo.git`).
+This assumption holds for many popular Git hosting services, such as GitHub and GitLab.
+====
+
 Additionally, component repositories can be overridden in the hierarchy in
 parameter `parameters.component_versions.<component-name>` by setting the key
 `url`.

--- a/docs/modules/ROOT/pages/reference/architecture.adoc
+++ b/docs/modules/ROOT/pages/reference/architecture.adoc
@@ -54,9 +54,9 @@ components:
 
 [NOTE]
 ====
-Commodore will attempt to transform http(s) Git URLs to their SSH-based counterparts when configuring the push URL on the local repository.
+Commodore will attempt to transform HTTP(S) Git URLs to their SSH-based counterparts when configuring the push URL on the local repository.
 This transformation allows authorized users to push feature branches to component repos without having to first manually adjust the repository's push URL.
-If the http(s) Git URL contains a `user@` or `user:pass@` part, that part will be removed when transforming the URL to a SSH-based push URL.
+User information (`user@` or `user:pass@`) and non-standard ports in HTTP(S) URLs will be removed when transforming the URL to a SSH-based push URL.
 
 The transformation assumes that SSH URLs follow the pattern `git@host:path/to/repo.git` (or `ssh://git@host/path/to/repo.git`).
 This assumption holds for many popular Git hosting services, such as GitHub and GitLab.

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -69,6 +69,7 @@ def test_component_setup_remote_no_sub(tmp_path, repo_url):
         ("http://host/path/to/repo.git", "ssh://git@host/path/to/repo.git"),
         ("https://host/path/to/repo.git", "ssh://git@host/path/to/repo.git"),
         ("https://user@host/path/to/repo.git", "ssh://git@host/path/to/repo.git"),
+        ("https://user:pass@host/path/to/repo.git", "ssh://git@host/path/to/repo.git"),
     ],
 )
 def test_component_setup_remote_sub(tmp_path, repo_url, push_url):

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -30,10 +30,13 @@ def _init_repo(tmp_path: P, cn: str, url: str):
     cr.create_remote("origin", url)
 
 
+REPO_URL = "https://github.com/projectsyn/component-argocd.git"
+
+
 def _setup_component(
     tmp_path: P,
     version="master",
-    repo_url="https://github.com/projectsyn/component-argocd.git",
+    repo_url=REPO_URL,
 ):
     return Component(
         "argocd",
@@ -43,12 +46,51 @@ def _setup_component(
     )
 
 
+@pytest.mark.parametrize(
+    "repo_url",
+    [
+        "ssh://user@host/path/to/repo.git",
+        "user@host:path/to/repo.git",
+        "file:///path/to/repo.git",
+    ],
+)
+def test_component_setup_remote_no_sub(tmp_path, repo_url):
+    c = _setup_component(tmp_path, repo_url=repo_url)
+
+    pull_remote = c.repo.git.remote("get-url", "origin")
+    push_remote = c.repo.git.remote("get-url", "--push", "origin")
+    assert pull_remote == repo_url
+    assert push_remote == repo_url
+
+
+@pytest.mark.parametrize(
+    "repo_url,push_url",
+    [
+        ("http://host/path/to/repo.git", "ssh://git@host/path/to/repo.git"),
+        ("https://host/path/to/repo.git", "ssh://git@host/path/to/repo.git"),
+        ("https://user@host/path/to/repo.git", "ssh://git@host/path/to/repo.git"),
+    ],
+)
+def test_component_setup_remote_sub(tmp_path, repo_url, push_url):
+    c = _setup_component(tmp_path, repo_url=repo_url)
+
+    pull_remote = c.repo.git.remote("get-url", "origin")
+    push_remote = c.repo.git.remote("get-url", "--push", "origin")
+    assert pull_remote == repo_url
+    assert push_remote == push_url
+
+
 def test_component_checkout(tmp_path):
     c = _setup_component(tmp_path)
 
     c.checkout()
 
     assert c.repo.head.ref.name == "master"
+    pull_remote = c.repo.git.remote("get-url", "origin")
+    push_remote = c.repo.git.remote("get-url", "--push", "origin")
+    assert pull_remote == REPO_URL
+    assert push_remote.startswith("ssh://git@")
+    assert push_remote == REPO_URL.replace("https://", "ssh://git@")
 
 
 def test_component_checkout_branch(tmp_path):

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -68,8 +68,13 @@ def test_component_setup_remote_no_sub(tmp_path, repo_url):
     [
         ("http://host/path/to/repo.git", "ssh://git@host/path/to/repo.git"),
         ("https://host/path/to/repo.git", "ssh://git@host/path/to/repo.git"),
+        ("https://host:1234/path/to/repo.git", "ssh://git@host/path/to/repo.git"),
         ("https://user@host/path/to/repo.git", "ssh://git@host/path/to/repo.git"),
         ("https://user:pass@host/path/to/repo.git", "ssh://git@host/path/to/repo.git"),
+        (
+            "https://user:pass@host:1234/path/to/repo.git",
+            "ssh://git@host/path/to/repo.git",
+        ),
     ],
 )
 def test_component_setup_remote_sub(tmp_path, repo_url, push_url):


### PR DESCRIPTION
This change assumes that most Git hosting services will use the pattern `ssh://git@example.com/path/to/repo.git` for SSH-based push URLs.

We configure each component repo's push-URL using the assumed substitution. This may not always generate a working push-URL, but for popular services like GitHub and GitLab, this removes the need of manually fixing the origin remote when trying to push a feature branch.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update tests.
- [x] Update the ./CHANGELOG.md.


<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
