### PR TITLE
 Move component URLs to parameters.components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-* Update pytest options to remove warnings([#283])
+* Update pytest options to remove warnings ([#283])
+* Move component URLs to `parameters.components` ([#284])
 
 ## [v0.4.2] - 2021-01-14
 
@@ -327,3 +328,4 @@ Initial implementation
 [#276]: https://github.com/projectsyn/commodore/pull/276
 [#281]: https://github.com/projectsyn/commodore/pull/281
 [#283]: https://github.com/projectsyn/commodore/pull/283
+[#284]: https://github.com/projectsyn/commodore/pull/284

--- a/commodore/cluster.py
+++ b/commodore/cluster.py
@@ -131,6 +131,8 @@ def render_target(
     classes = [f"params.{inv.bootstrap_target}"]
     parameters: Dict[str, Union[Dict, str]] = {
         "_instance": target,
+        "component_versions": {},
+        "components": "${component_versions}",
     }
 
     for c in components:

--- a/commodore/compile.py
+++ b/commodore/compile.py
@@ -17,7 +17,6 @@ from .dependency_mgmt import (
     fetch_jsonnet_libs,
     fetch_jsonnet_libraries,
     register_components,
-    set_component_overrides,
     jsonnet_dependencies,
 )
 from .helpers import (
@@ -116,24 +115,13 @@ def compile(config, cluster_id):
         clean_working_tree(config)
         catalog_repo = _regular_setup(config, cluster_id)
 
-    # Compile kapitan inventory to extract component versions. Component
-    # versions are assumed to be defined in the inventory key
-    # 'parameters.component_versions'
-    reset_reclass_cache()
-    cluster_inventory = inventory_reclass(config.inventory.inventory_dir)["nodes"][
-        config.inventory.bootstrap_target
-    ]
-    versions = cluster_inventory["parameters"].get("component_versions", None)
-    if versions and not config.local:
-        set_component_overrides(config, versions)
-    # Rebuild reclass inventory to use new version of components
     reset_reclass_cache()
     kapitan_inventory = inventory_reclass(config.inventory.inventory_dir)["nodes"]
     cluster_parameters = kapitan_inventory[config.inventory.bootstrap_target][
         "parameters"
     ]
 
-    # Verify that all aliased components support instantiation after resolving component version overrides.
+    # Verify that all aliased components support instantiation
     config.verify_component_aliases(cluster_parameters)
 
     for component in config.get_components().values():

--- a/commodore/dependency_mgmt.py
+++ b/commodore/dependency_mgmt.py
@@ -95,11 +95,13 @@ def _read_components(
     cluster_inventory = inv["nodes"][cfg.inventory.bootstrap_target]
     components = cluster_inventory["parameters"].get("components", None)
     if not components:
-        raise click.ClickException("Component list (parameters.components) missing")
+        raise click.ClickException("Component list ('parameters.components') missing")
 
     for component_name in component_names:
         if component_name not in components:
-            raise click.ClickException(f"Unknown component '{component_name}'")
+            raise click.ClickException(
+                f"Unknown component '{component_name}'. Please add it to 'parameters.components'"
+            )
 
         info = components[component_name]
 

--- a/commodore/helpers.py
+++ b/commodore/helpers.py
@@ -3,7 +3,7 @@ import json
 import shutil
 import os
 from pathlib import Path as P
-from typing import Callable, Iterable, Optional
+from typing import Callable, Dict, Iterable, Optional
 
 import click
 import requests
@@ -18,6 +18,7 @@ from kapitan import defaults
 from kapitan.cached import reset_cache as reset_reclass_cache
 from kapitan.refs.base import RefController, PlainRef
 from kapitan.refs.secrets.vaultkv import VaultBackend
+from kapitan.resources import inventory_reclass
 
 from commodore import __install_dir__
 from commodore.config import Config
@@ -161,6 +162,16 @@ def kapitan_compile(
         schemas_path=config.work_dir / "schemas",
         jinja2_filters=defaults.DEFAULT_JINJA2_FILTERS_PATH,
     )
+
+
+def kapitan_inventory(config: Config, key="nodes") -> Dict:
+    """
+    Reset reclass cache and render inventory.
+    Returns the top-level key according to the kwarg.
+    """
+    reset_reclass_cache()
+    inv = inventory_reclass(config.inventory.inventory_dir)
+    return inv[key]
 
 
 def rm_tree_contents(basedir):

--- a/docs/modules/ROOT/pages/reference/architecture.adoc
+++ b/docs/modules/ROOT/pages/reference/architecture.adoc
@@ -20,9 +20,9 @@ Commodore fetches the following dependencies:
 * Tenant configuration
 * Components as discovered in global and tenant configuration
 * Jsonnet libraries as described in the
-  <<_configuration_hierarchy,configuration hierarchy>>
+  xref:commodore:ROOT:reference/concepts.adoc#_configuration_hierarchy[configuration hierarchy]
 
-=== Component discovery
+=== Component discovery and versions
 
 To discover all required components, Commodore reads the https://reclass.pantsfullofunix.net/operations.html#yaml-fs-storage[`applications` array] which is made available by reclass.
 If a component should be disabled in a subset of the hierarchy, it can be removed from the `applications` array by adding the component name prefixed with a `~`.
@@ -36,20 +36,26 @@ applications:
 Note that this only works to remove components which have been included previously, and won't remove components that are included further down in the hierarchy.
 
 Commodore currently has no mechanism to automatically discover components based on their names.
-Instead all components which are referenced in the hierarchy must be listed in key `components` in the file `commodore.yml` in the root of the global configuration repository.
-The key `components` holds an array of dictionaries with keys `name` and `url`.
-Each array entry specifies the repository URL of a single component.
-A sample `commodore.yml` can be found below.
-The file `commodore.yml` is also used to define the xref:commodore:ROOT:reference:hierarchy.adoc[Commodore class hierarchy].
+Instead all components which are referenced in the `applications` array must be listed in key `parameters.components` in the hierarchy.
+Using the xref:commodore:ROOT:reference/concepts.adoc#_configuration_hierarchy[configuration hierarchy] for specifying component locations and versions allows tight integration of component management with the rest of the configuration.
 
-.commodore.yml
+Commodore will read `parameters.components` from the hierarchy _before component defaults are included_.
+The key `parameters.components` holds a dictionary of dictionaries mapping component names to their remote repository location and version.
+The remote repository location is specified in key `url`.
+The version is specified in key `version`.
+The version can be any Git https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddeftree-ishatree-ishalsotreeish[tree-ish].
+If no version is given for a component, Commodore defaults to `master` for the version.
+Commodore fetches the remote repository and directly checks out the specified version.
+
 [source,yaml]
 --
-components:
-- name: argocd
-  url: https://github.com/projectsyn/component-argocd.git
-- name: metrics-server
-  url: https://github.com/projectsyn/component-metrics-server.git
+parameters:
+  components:
+    argocd:
+      url: https://github.com/projectsyn/component-argocd.git
+    metrics-server:
+      url: https://github.com/projectsyn/component-metrics-server.git
+      version: v1.0.2
 --
 
 [NOTE]
@@ -62,53 +68,23 @@ The transformation assumes that SSH URLs follow the pattern `git@host:path/to/re
 This assumption holds for many popular Git hosting services, such as GitHub and GitLab.
 ====
 
-Additionally, component repositories can be overridden in the hierarchy in
-parameter `parameters.component_versions.<component-name>` by setting the key
-`url`.
-This can't be used as a replacement for globally overriding the default
-location in `commodore.yml`, as the component must be discoverable without
-having to parse the Kapitan inventory.
-However, this mechanism can be used to configure a subset of managed clusters
-to use a fork of a component.
+Component repositories and versions can be overridden by setting the keys `url` and `versions` respectively in `parameters.components.<component-name>` in the xref:commodore:ROOT:reference/concepts.adoc#_inventory[inventory repositories].
+This allows configuring a subset of managed clusters to use a fork or different version of a component.
 
 [source,yaml]
 --
 parameters:
-  component_versions:
+  components:
     argocd:
-      url: https://github.com/projectsyn/component-argocd/
---
-
-=== Component versioning
-
-As described in the xref:reference/concepts.adoc[Commodore concepts],
-component versions and remote repository locations can be specified in the
-configuration hierarchy.
-Component versions are tracked in the inventory in key `version` under
-parameter `component_versions.<component-name>` and default to the component
-repository's default branch.
-
-An example:
-
-[source,yaml]
---
-parameters:
-  component_versions:
-    argocd:
+      url: https://github.com/projectsyn/component-argocd-fork.git
       version: v1.0.0
 --
 
-Reusing the <<_configuration_hierarchy,configuration hierarchy>> for
-specifying the component versions allows tight integration of component
-version management with the rest of the configuration.
+[NOTE]
+====
+Since Commodore won't re-read `parameters.components` after including the discovered components' default classes, entries in `parameters.components` in a component's `defaults.yml` will be ignored.
+====
 
-After cloning component repositories, all components will be checked out on
-the repository's default branch.
-Commodore will then explicitly check out the version specified in the
-inventory for any components that specify a version.
-The version specification is parsed from the inventory using Kapitan's
-inventory parsing, allowing the version to be overridden at any point in the
-configuration hierarchy.
 
 === Component instantiation
 

--- a/docs/modules/ROOT/pages/reference/concepts.adoc
+++ b/docs/modules/ROOT/pages/reference/concepts.adoc
@@ -26,8 +26,7 @@ desired state.
 
 Inventory repositories are cloned directly into the Kapitan `inventory` directory to make their contents available as inventory classes in Kapitan.
 
-Commodore also makes use of the inventory to allow tracking
-<<_component_versions,component versions>>.
+Commodore also makes use of the inventory to manage xref:commodore:ROOT:reference/architecture.adoc#_component_discovery_and_versions[component repository locations and versions].
 
 == Components
 

--- a/tests/bench_component.py
+++ b/tests/bench_component.py
@@ -11,9 +11,11 @@ def setup_components_upstream(tmp_path: Path, components: Iterable[str]):
     # Prepare minimum component directories
     upstream = tmp_path / "upstream"
     component_urls = {}
+    component_versions = {}
     for component in components:
         repo_path = upstream / component
         component_urls[component] = f"file://#{repo_path.resolve()}"
+        component_versions[component] = "master"
         repo = git.Repo.init(repo_path)
 
         class_dir = repo_path / "class"
@@ -23,11 +25,11 @@ def setup_components_upstream(tmp_path: Path, components: Iterable[str]):
         repo.index.add(["class/defaults.yml"])
         repo.index.commit("component defaults")
 
-    return component_urls
+    return component_urls, component_versions
 
 
 def _setup_component(tmp_path: Path, cn: str):
-    urls = setup_components_upstream(tmp_path, [cn])
+    urls, _ = setup_components_upstream(tmp_path, [cn])
     return Component(cn, repo_url=urls[cn], directory=tmp_path / "test-component")
 
 

--- a/tests/test_dependency_mgmt.py
+++ b/tests/test_dependency_mgmt.py
@@ -153,7 +153,10 @@ def test_read_components_missing_component(patch_inventory, data: Config):
     with pytest.raises(click.ClickException) as e:
         dependency_mgmt._read_components(data, ["component-missing"])
 
-    assert "Unknown component 'component-missing'" in str(e)
+    assert (
+        "Unknown component 'component-missing'. Please add it to 'parameters.components'"
+        in str(e)
+    )
 
 
 @patch.object(dependency_mgmt, "inventory_reclass")

--- a/tests/test_dependency_mgmt.py
+++ b/tests/test_dependency_mgmt.py
@@ -108,15 +108,15 @@ def _setup_read_components(patch_inventory):
     }
     mock_inventory = {"nodes": {"cluster": {"parameters": {"components": components}}}}
 
-    def inv(inventory_dir):
-        return mock_inventory
+    def inv(inventory_dir, key="nodes"):
+        return mock_inventory[key]
 
     patch_inventory.side_effect = inv
 
     return mock_inventory["nodes"]["cluster"]["parameters"]["components"]
 
 
-@patch.object(dependency_mgmt, "inventory_reclass")
+@patch.object(dependency_mgmt, "kapitan_inventory")
 def test_read_components(patch_inventory, data: Config):
     components = _setup_read_components(patch_inventory)
     component_urls, component_versions = dependency_mgmt._read_components(
@@ -131,7 +131,7 @@ def test_read_components(patch_inventory, data: Config):
     )
 
 
-@patch.object(dependency_mgmt, "inventory_reclass")
+@patch.object(dependency_mgmt, "kapitan_inventory")
 def test_read_components_multiple(patch_inventory, data: Config):
     components = _setup_read_components(patch_inventory)
     component_urls, component_versions = dependency_mgmt._read_components(
@@ -147,7 +147,7 @@ def test_read_components_multiple(patch_inventory, data: Config):
     )
 
 
-@patch.object(dependency_mgmt, "inventory_reclass")
+@patch.object(dependency_mgmt, "kapitan_inventory")
 def test_read_components_missing_component(patch_inventory, data: Config):
     _setup_read_components(patch_inventory)
     with pytest.raises(click.ClickException) as e:
@@ -159,12 +159,10 @@ def test_read_components_missing_component(patch_inventory, data: Config):
     )
 
 
-@patch.object(dependency_mgmt, "inventory_reclass")
+@patch.object(dependency_mgmt, "kapitan_inventory")
 def test_read_components_missing_component_url(patch_inventory, data: Config):
-    def inv(inventory_dir):
-        return {
-            "nodes": {"cluster": {"parameters": {"components": {"test-component": {}}}}}
-        }
+    def inv(inventory_dir, key="nodes"):
+        return {"cluster": {"parameters": {"components": {"test-component": {}}}}}
 
     patch_inventory.side_effect = inv
     with pytest.raises(click.ClickException) as e:


### PR DESCRIPTION
This commit removes the `components` list in `commodore.yml` in the global config repository and instead looks for component URLs in `parameters.components`.

We deprecate `parameters.component_versions`, but to allow gradual migration to `parameters.components`, we merge
`parameters.component_versions` into `parameters.components` in the Kapitan targets.

Resolves #254 

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update tests.
- [x] Update the ./CHANGELOG.md.
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
