### PR TITLE
Default component version to "origin/HEAD" instead of "master"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 * Update pytest options to remove warnings ([#283])
 * Move component URLs to `parameters.components` ([#284])
+* Default component version to "origin/HEAD" instead of "master" ([#286])
 
 ## [v0.4.2] - 2021-01-14
 
@@ -329,3 +330,4 @@ Initial implementation
 [#281]: https://github.com/projectsyn/commodore/pull/281
 [#283]: https://github.com/projectsyn/commodore/pull/283
 [#284]: https://github.com/projectsyn/commodore/pull/284
+[#286]: https://github.com/projectsyn/commodore/pull/286

--- a/commodore/component/__init__.py
+++ b/commodore/component/__init__.py
@@ -114,7 +114,7 @@ class Component:
         return component_parameters_key(self.name)
 
     def checkout(self):
-        remote_heads = self._repo.remote().fetch()
+        remote_heads = self._repo.remote().fetch(prune=True)
         remote_prefix = self._repo.remote().name + "/"
         version = self._version
         if self._version is None:

--- a/commodore/dependency_mgmt.py
+++ b/commodore/dependency_mgmt.py
@@ -37,7 +37,7 @@ def delete_component_symlinks(cfg, component: Component):
     """
     Remove the component symlinks in the inventory subdirectory.
 
-    This is the reverse from the createa_component_symlinks method and is used
+    This is the reverse from the create_component_symlinks method and is used
     when deleting a component.
     """
     delsymlink(cfg.inventory.component_file(component), cfg.debug)
@@ -110,7 +110,8 @@ def _read_components(
         if "version" in info:
             component_versions[component_name] = info["version"]
         else:
-            component_versions[component_name] = "master"
+            # Note: We use version=None as a marker for checking out the remote repo's default branch
+            component_versions[component_name] = None
         if cfg.debug:
             click.echo(
                 f" > Version for {component_name}: {component_versions[component_name]}"

--- a/docs/modules/ROOT/pages/reference/architecture.adoc
+++ b/docs/modules/ROOT/pages/reference/architecture.adoc
@@ -44,7 +44,7 @@ The key `parameters.components` holds a dictionary of dictionaries mapping compo
 The remote repository location is specified in key `url`.
 The version is specified in key `version`.
 The version can be any Git https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddeftree-ishatree-ishalsotreeish[tree-ish].
-If no version is given for a component, Commodore defaults to `master` for the version.
+If no version is given for a component, Commodore defaults to the remote repository's default branch for the version.
 Commodore fetches the remote repository and directly checks out the specified version.
 
 [source,yaml]

--- a/tests/bench_component.py
+++ b/tests/bench_component.py
@@ -15,7 +15,7 @@ def setup_components_upstream(tmp_path: Path, components: Iterable[str]):
     for component in components:
         repo_path = upstream / component
         component_urls[component] = f"file://#{repo_path.resolve()}"
-        component_versions[component] = "master"
+        component_versions[component] = None
         repo = git.Repo.init(repo_path)
 
         class_dir = repo_path / "class"

--- a/tests/test_dependency_mgmt.py
+++ b/tests/test_dependency_mgmt.py
@@ -155,7 +155,7 @@ def test_read_components_multiple(patch_inventory, data: Config):
     assert set(components.keys()) == set(component_versions.keys())
     assert all(components[cn]["url"] == component_urls[cn] for cn in components.keys())
     assert all(
-        components[cn].get("version", "master") == component_versions[cn]
+        components[cn].get("version", None) == component_versions[cn]
         for cn in components.keys()
     )
 


### PR DESCRIPTION
This commit removes the hard default version of "master" for components when there's no version specified in the hierarchy, and instead uses the default branch of the remote repository, which is indicated by `origin/HEAD`.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update tests.
- [x] Update the ./CHANGELOG.md.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
