### PR TITLE
Merge component_versions into components in `params.cluster`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Default component version to "origin/HEAD" instead of "master" ([#286])
 * Deprecated use of `parameters.component_versions` ([#287])
 
+### Fixed
+
+* Values in `parameters.components` always have precedence over values in `parameters.component_versions` ([#289])
+
 ## [v0.4.2] - 2021-01-14
 
 ### Added
@@ -334,3 +338,4 @@ Initial implementation
 [#284]: https://github.com/projectsyn/commodore/pull/284
 [#286]: https://github.com/projectsyn/commodore/pull/286
 [#287]: https://github.com/projectsyn/commodore/pull/287
+[#289]: https://github.com/projectsyn/commodore/pull/289

--- a/commodore/cluster.py
+++ b/commodore/cluster.py
@@ -131,8 +131,6 @@ def render_target(
     classes = [f"params.{inv.bootstrap_target}"]
     parameters: Dict[str, Union[Dict, str]] = {
         "_instance": target,
-        "component_versions": {},
-        "components": "${component_versions}",
     }
 
     for c in components:
@@ -206,6 +204,14 @@ def render_params(inv: Inventory, cluster: Cluster):
             "customer": {
                 "name": cluster.tenant,
             },
+            # Merge component_versions into components in params.cluster for
+            # backwards-compatibility.
+            # We do this here instead of the target to ensure values in
+            # `components` have precedence over values in
+            # `component_versions`.
+            # TODO Remove once the deprecated `component_versions` field is removed
+            "component_versions": {},
+            "components": "${component_versions}",
         },
     }
 


### PR DESCRIPTION
Previously, for #284, we've merged component_versions into components in each Kapitan target.

This led to counter-intuitive behavior when trying to override versions in `components`, if the same component also has a version override in `component_versions`, as the override in `component_versions` would always have precedence over overrides in `components` regardless of their relative order in the hierarchy.

This component moves the merging of `component_versions` into `components` to the class `params.cluster` which has the lowest precedence of all classes.

This ensures that configuration in `components` has precedence over configurations in `component_versions` in all cases, while still allowing configurations which use `component_versions` to function.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the ./CHANGELOG.md.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
