### PR TITLE
Correctly handle component versions which are tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 * Values in `parameters.components` always have precedence over values in `parameters.component_versions` ([#289])
+* Correctly handle tags as component versions ([#290])
 
 ## [v0.4.2] - 2021-01-14
 
@@ -339,3 +340,4 @@ Initial implementation
 [#286]: https://github.com/projectsyn/commodore/pull/286
 [#287]: https://github.com/projectsyn/commodore/pull/287
 [#289]: https://github.com/projectsyn/commodore/pull/289
+[#290]: https://github.com/projectsyn/commodore/pull/290

--- a/commodore/component/__init__.py
+++ b/commodore/component/__init__.py
@@ -1,3 +1,4 @@
+from collections import namedtuple
 from pathlib import Path as P
 from typing import Iterable, Optional
 
@@ -8,6 +9,9 @@ from git import Repo, BadName, GitCommandError
 from url_normalize.tools import deconstruct_url
 
 from commodore.git import RefError
+
+
+CommitInfo = namedtuple("CommitInfo", ["commit", "branch", "tag"])
 
 
 class Component:
@@ -113,19 +117,25 @@ class Component:
     def parameters_key(self):
         return component_parameters_key(self.name)
 
-    def checkout(self):
-        remote_heads = self._repo.remote().fetch(prune=True, tags=True)
-        remote_prefix = self._repo.remote().name + "/"
-        version = self._version
-        if self._version is None:
-            # Handle case where we want the default branch of the remote
-            try:
-                version = self._repo.remote().refs["HEAD"].reference.name
-            except IndexError:
-                self._repo.git.remote("set-head", "origin", "--auto")
-                version = self._repo.remote().refs["HEAD"].reference.name
+    def _remote_prefix(self):
+        """
+        Find prefix of Git remote, will usually be 'origin/'.
+        """
+        return self._repo.remote().name + "/"
 
-            version = version.replace(remote_prefix, "", 1)
+    def _default_version(self):
+        """
+        Find default branch of the remote
+        """
+        try:
+            version = self._repo.remote().refs["HEAD"].reference.name
+        except IndexError:
+            self._repo.git.remote("set-head", "origin", "--auto")
+            version = self._repo.remote().refs["HEAD"].reference.name
+        return version.replace(self._remote_prefix(), "", 1)
+
+    def _find_commit_for_version(self, version, remote_heads):
+        remote_prefix = self._remote_prefix()
         for head in remote_heads:
             tag = None
             branch = None
@@ -145,6 +155,17 @@ class Component:
             commit = version
             branch = None
             tag = None
+
+        return CommitInfo(commit=commit, branch=branch, tag=tag)
+
+    def checkout(self):
+        remote_heads = self._repo.remote().fetch(prune=True, tags=True)
+        version = self._version
+        if self._version is None:
+            # Handle case where we want the default branch of the remote
+            version = self._default_version()
+
+        commit, branch, tag = self._find_commit_for_version(version, remote_heads)
 
         try:
             if branch:

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -37,11 +37,12 @@ def _setup_component(
     tmp_path: P,
     version="master",
     repo_url=REPO_URL,
+    name="argocd",
 ):
     return Component(
-        "argocd",
+        name,
         repo_url=repo_url,
-        directory=tmp_path / "argocd",
+        directory=tmp_path / name,
         version=version,
     )
 
@@ -126,6 +127,20 @@ def test_component_checkout_sha1version(tmp_path: P):
 
     assert c.repo.head.is_detached
     assert c.repo.head.commit.hexsha == commit
+
+
+def test_component_checkout_tag(tmp_path: P):
+    c = _setup_component(
+        tmp_path,
+        version="v1.0.0",
+        repo_url="https://github.com/projectsyn/component-backup-k8up.git",
+        name="backup-k8up",
+    )
+
+    c.checkout()
+
+    assert c.repo.head.is_detached
+    assert c.repo.head.commit.hexsha == c.repo.tags["v1.0.0"].commit.hexsha
 
 
 def test_component_checkout_nonexisting_version(tmp_path: P):


### PR DESCRIPTION
Tags show up as heads in the remote, but without the remote name as prefix. Previously the code would then try to checkout a branch with the name of the tag.

This commit makes the assumption that any heads in a remote which don't have the remote name as a prefix are tags, and handles checkout accordingly.

To keep the things simple, tags are checked out in detached HEAD state.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests.
- [x] Update the ./CHANGELOG.md.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
