### PR TITLE
Use block-scalars in Commodore's YAML dump helpers for multi-line strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+* Render multi-line strings as block-scalars in Commodore's YAML dump helpers ([#294])
+
 ## [v0.5.0] - 2021-03-12
 
 ### Added
@@ -344,3 +348,4 @@ Initial implementation
 [#287]: https://github.com/projectsyn/commodore/pull/287
 [#289]: https://github.com/projectsyn/commodore/pull/289
 [#290]: https://github.com/projectsyn/commodore/pull/290
+[#294]: https://github.com/projectsyn/commodore/pull/294

--- a/commodore/helpers.py
+++ b/commodore/helpers.py
@@ -56,10 +56,28 @@ def yaml_load_all(file):
         return list(yaml.safe_load_all(f))
 
 
+def _represent_str(dumper, data):
+    """
+    Custom string rendering when dumping data as YAML.
+
+    Hooking this method into PyYAML with
+
+        yaml.add_representer(str, _represent_str)
+
+    will configure the YAML dumper to render strings which contain newline
+    characters as block scalars with the last newline stripped.
+    """
+    style = None
+    if "\n" in data:
+        style = "|"
+    return dumper.represent_scalar("tag:yaml.org,2002:str", data, style=style)
+
+
 def yaml_dump(obj, file):
     """
     Dump obj as single-document YAML
     """
+    yaml.add_representer(str, _represent_str)
     with open(file, "w") as outf:
         yaml.dump(obj, outf)
 
@@ -68,6 +86,7 @@ def yaml_dump_all(obj, file):
     """
     Dump obj as multi-document YAML
     """
+    yaml.add_representer(str, _represent_str)
     with open(file, "w") as outf:
         yaml.dump_all(obj, outf)
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -2,6 +2,9 @@
 Unit-tests for helpers
 """
 from pathlib import Path
+from typing import Callable
+import textwrap
+import pytest
 
 import commodore.helpers as helpers
 from commodore.config import Config
@@ -27,3 +30,107 @@ def test_clean_working_tree(tmp_path: Path):
     assert d.is_dir()
     helpers.clean_working_tree(cfg)
     assert d.is_dir()
+
+
+def _test_yaml_dump_fun(
+    dumpfunc: Callable[[str, Path], None], tmp_path: Path, input, expected
+):
+    output = tmp_path / "test.yaml"
+    dumpfunc(input, output)
+    with open(output) as f:
+        data = "".join(f.readlines())
+    assert expected == data
+
+
+@pytest.mark.parametrize(
+    "input,expected",
+    [
+        (
+            {"a": 1, "b": "test"},
+            textwrap.dedent(
+                """
+                a: 1
+                b: test
+                """
+            )[1:],
+        ),
+        (
+            {"a": [1, 2], "b": "test"},
+            textwrap.dedent(
+                """
+                a:
+                - 1
+                - 2
+                b: test
+                """
+            )[1:],
+        ),
+        (
+            {"a": {"test": 1}, "b": "test"},
+            textwrap.dedent(
+                """
+                a:
+                  test: 1
+                b: test
+                """
+            )[1:],
+        ),
+        (
+            {"a": "first line\nsecond line", "b": "test"},
+            textwrap.dedent(
+                """
+                a: |-
+                  first line
+                  second line
+                b: test
+                """
+            )[1:],
+        ),
+    ],
+)
+def test_yaml_dump(tmp_path: Path, input, expected):
+    _test_yaml_dump_fun(helpers.yaml_dump, tmp_path, input, expected)
+
+
+@pytest.mark.parametrize(
+    "input,expected",
+    [
+        (
+            [{"a": 1}, {"b": "test"}],
+            textwrap.dedent(
+                """
+                    a: 1
+                    ---
+                    b: test
+                    """
+            )[1:],
+        ),
+        (
+            [{"a": {"test": "first line\nsecond line"}}, {"b": "test"}],
+            textwrap.dedent(
+                """
+                a:
+                  test: |-
+                    first line
+                    second line
+                ---
+                b: test
+                """
+            )[1:],
+        ),
+        (
+            [{"a": [1, 2]}, {"b": "test"}],
+            textwrap.dedent(
+                """
+                a:
+                - 1
+                - 2
+                ---
+                b: test
+                """
+            )[1:],
+        ),
+    ],
+)
+def test_yaml_dump_all(tmp_path: Path, input, expected):
+    _test_yaml_dump_fun(helpers.yaml_dump_all, tmp_path, input, expected)


### PR DESCRIPTION
By providing a custom implementation of `represent_str` and injecting it into PyYAML's dumper with `yaml.add_representer()`, we can control how multi-line strings are rendered.

This commit enables block-scalar style without trailing newline for any input strings which contain `\n`.

This will improve readability of catalog diffs for manifests which contain multi-line strings and have been processed by Commodore's postprocessing step.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests.
- [x] Update the ./CHANGELOG.md.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
