### PR TITLE
Fix component template GitHub workflow to correctly lint docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 * Render multi-line strings as block-scalars in Commodore's YAML dump helpers ([#294])
 
+### Fixed
+
+* Fix component template GitHub workflow to correctly lint docs ([#295])
+
 ## [v0.5.0] - 2021-03-12
 
 ### Added
@@ -349,3 +353,4 @@ Initial implementation
 [#289]: https://github.com/projectsyn/commodore/pull/289
 [#290]: https://github.com/projectsyn/commodore/pull/290
 [#294]: https://github.com/projectsyn/commodore/pull/294
+[#295]: https://github.com/projectsyn/commodore/pull/295

--- a/commodore/component-template/{{ cookiecutter.slug }}/.github/workflows/test.yaml
+++ b/commodore/component-template/{{ cookiecutter.slug }}/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
         command:
           - lint_jsonnet
           - lint_yaml
-          - docs
+          - docs-vale
     steps:
       - uses: actions/checkout@v2
       - name: Run {% raw %}${{ matrix.command }}{% endraw %}


### PR DESCRIPTION
The make target for running Vale has changed to `docs-vale` but the GitHub workflow configuration has not been updated to reflect this change.

This commit changes the workflow configuration to call `make docs-vale`.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [X] Update the ./CHANGELOG.md.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
