### PR TITLE
Deprecate parameter `commodore.jsonnet_libs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 * Render multi-line strings as block-scalars in Commodore's YAML dump helpers ([#294])
+* Deprecation notice for parameter `commodore.jsonnet_libs` ([#300])
 
 ### Fixed
 
@@ -354,3 +355,4 @@ Initial implementation
 [#290]: https://github.com/projectsyn/commodore/pull/290
 [#294]: https://github.com/projectsyn/commodore/pull/294
 [#295]: https://github.com/projectsyn/commodore/pull/295
+[#300]: https://github.com/projectsyn/commodore/pull/300

--- a/commodore/compile.py
+++ b/commodore/compile.py
@@ -141,6 +141,10 @@ def compile(config, cluster_id):
 
     jsonnet_libs = cluster_parameters.get("commodore", {}).get("jsonnet_libs", None)
     if jsonnet_libs and not config.local:
+        config.register_deprecation_notice(
+            "Parameter `commodore.jsonnet_libs` is deprecated. "
+            + "If your component needs Jsonnet dependencies, specify them in the component's `jsonnetfile.json`"
+        )
         fetch_jsonnet_libs(config, jsonnet_libs)
 
     if not config.local:

--- a/docs/modules/ROOT/pages/reference/deprecation-notices.adoc
+++ b/docs/modules/ROOT/pages/reference/deprecation-notices.adoc
@@ -3,6 +3,14 @@
 This page lists deprecations of Commodore features organized by version.
 We include a link to relevant documentation, if applicable.
 
+== Unreleased
+
+=== `parameters.commodore.jsonnet_libs` is deprecated
+
+Users should specify Jsonnet dependencies of components in the component's `jsonnetfile.json`.
+
+For now, Commodore itself ensures `kube-libsonnet` is available as `lib/kube.libsonnet`.
+
 == https://github.com/projectsyn/commodore/blob/master/CHANGELOG.md#v050-20210312[v0.5.0]
 
 === `parameters.component_versions` is deprecated


### PR DESCRIPTION
The only use of this parameter is to fetch kube-libsonnet. This library is fetched by jsonnet-bundler since PR #246 has been merged.

Relates #255

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update the ./CHANGELOG.md.
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
