### PR TITLE
Add command line options to override global and tenant repo revisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 * Render multi-line strings as block-scalars in Commodore's YAML dump helpers ([#294])
 * Deprecation notice for parameter `commodore.jsonnet_libs` ([#300])
+* Command line options to override global and tenant repo revisions ([#301])
 
 ### Fixed
 
@@ -356,3 +357,4 @@ Initial implementation
 [#294]: https://github.com/projectsyn/commodore/pull/294
 [#295]: https://github.com/projectsyn/commodore/pull/295
 [#300]: https://github.com/projectsyn/commodore/pull/300
+[#301]: https://github.com/projectsyn/commodore/pull/301

--- a/commodore/cli.py
+++ b/commodore/cli.py
@@ -106,6 +106,26 @@ def clean(config: Config, verbose):
     metavar="EMAIL",
     help="E-mail address of catalog commit author",
 )
+@click.option(
+    "-g",
+    "--global-repo-revision-override",
+    envvar="GLOBAL_REPO_REVISION_OVERRIDE",
+    metavar="REV",
+    help=(
+        "Git revision (tree-ish) to checkout for the global config repo "
+        + "(overrides configuration in Lieutenant tenant & cluster)"
+    ),
+)
+@click.option(
+    "-t",
+    "--tenant-repo-revision-override",
+    envvar="TENANT_REPO_REVISION_OVERRIDE",
+    metavar="REV",
+    help=(
+        "Git revision (tree-ish) to checkout for the tenant config repo "
+        + "(overrides configuration in Lieutenant cluster)"
+    ),
+)
 @verbosity
 @pass_config
 # pylint: disable=too-many-arguments
@@ -120,6 +140,8 @@ def compile_catalog(
     verbose,
     git_author_name,
     git_author_email,
+    global_repo_revision_override,
+    tenant_repo_revision_override,
 ):
     config.update_verbosity(verbose)
     config.api_url = api_url
@@ -129,6 +151,14 @@ def compile_catalog(
     config.interactive = interactive
     config.username = git_author_name
     config.usermail = git_author_email
+    config.global_repo_revision_override = global_repo_revision_override
+    config.tenant_repo_revision_override = tenant_repo_revision_override
+    if config.push and (
+        config.global_repo_revision_override or config.tenant_repo_revision_override
+    ):
+        raise click.ClickException(
+            "Cannot push changes when local global or tenant repo override is specified"
+        )
     _compile(config, cluster)
 
 

--- a/commodore/compile.py
+++ b/commodore/compile.py
@@ -33,6 +33,8 @@ def _fetch_global_config(cfg: Config, cluster: Cluster):
         cluster.global_git_repo_url, cfg.inventory.global_config_dir, cfg
     )
     rev = cluster.global_git_repo_revision
+    if cfg.global_repo_revision_override:
+        rev = cfg.global_repo_revision_override
     if rev:
         git.checkout_version(repo, rev)
     cfg.register_config("global", repo)
@@ -47,6 +49,8 @@ def _fetch_customer_config(cfg: Config, cluster: Cluster):
         repo_url, cfg.inventory.tenant_config_dir(cluster.tenant), cfg
     )
     rev = cluster.config_git_repo_revision
+    if cfg.tenant_repo_revision_override:
+        rev = cfg.tenant_repo_revision_override
     if rev:
         git.checkout_version(repo, rev)
     cfg.register_config("customer", repo)

--- a/commodore/config.py
+++ b/commodore/config.py
@@ -44,6 +44,8 @@ class Config:
         self.force = False
         self._inventory = Inventory(work_dir=self.work_dir)
         self._deprecation_notices = []
+        self._global_repo_revision_override = None
+        self._tenant_repo_revision_override = None
 
     @property
     def verbose(self):
@@ -105,6 +107,22 @@ class Config:
                 else:
                     raise
             self._api_token = api_token.strip()
+
+    @property
+    def global_repo_revision_override(self):
+        return self._global_repo_revision_override
+
+    @global_repo_revision_override.setter
+    def global_repo_revision_override(self, rev):
+        self._global_repo_revision_override = rev
+
+    @property
+    def tenant_repo_revision_override(self):
+        return self._tenant_repo_revision_override
+
+    @tenant_repo_revision_override.setter
+    def tenant_repo_revision_override(self, rev):
+        self._tenant_repo_revision_override = rev
 
     @property
     def inventory(self):

--- a/docs/modules/ROOT/pages/reference/cli.adoc
+++ b/docs/modules/ROOT/pages/reference/cli.adoc
@@ -79,6 +79,16 @@ See also xref:local-mode.adoc[local mode documentation].
 *--git-author-email* EMAIL::
   E-mail address of catalog commit author
 
+*--global-repo-revision-override* REV::
+  Git tree-ish to checkout for the global config repository.
+  This command line parameter overrides the global git repository revision configured on the cluster or tenant object in Lieutenant.
+  When this option is provided, Commodore will abort without compiling the catalog if `--push` is also provided.
+
+*--tenant-repo-revision-override* REV::
+  Git tree-ish to checkout for the tenant config repository.
+  This command line parameter overrides the tenant git repository revision configured on the cluster object in Lieutenant.
+  When this option is provided, Commodore will abort without compiling the catalog if `--push` is also provided.
+
 *--help*::
   Show catalog clean usage and options then exit.
 

--- a/tests/mock_git.py
+++ b/tests/mock_git.py
@@ -1,0 +1,51 @@
+from commodore import git
+
+
+class Head:
+    def __init__(self):
+        self._reference = None
+        self.call_counts = {
+            "reference": 0,
+            "reference.setter": 0,
+            "reset": 0,
+        }
+
+    @property
+    def reference(self):
+        self.call_counts["reference"] += 1
+        return self._reference
+
+    @reference.setter
+    def reference(self, ref):
+        self.call_counts["reference.setter"] += 1
+        self._reference = ref
+
+    def reset(self, **kwargs):
+        self.call_counts["reset"] += 1
+        pass
+
+
+class Repo:
+    def __init__(self, url, directory, cfg):
+        self.url = url
+        self.directory = directory
+        self.config = cfg
+        self.head = Head()
+
+        self.call_counts = {
+            "commit": 0,
+            "checkout_version": 0,
+        }
+
+    def commit(self, rev):
+        self.call_counts["commit"] += 1
+        return rev
+
+
+def clone_repository(url, directory, cfg):
+    return Repo(url, directory, cfg)
+
+
+def checkout_version(repo, rev):
+    repo.call_counts["checkout_version"] += 1
+    git.checkout_version(repo, rev)

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -1,0 +1,120 @@
+import pytest
+
+from pathlib import Path as P
+from unittest.mock import patch
+
+from commodore import compile
+from commodore.config import Config
+from commodore.cluster import Cluster
+
+import mock_git
+
+
+@pytest.fixture
+def config(tmp_path):
+    """
+    Setup test config object
+    """
+    return Config(
+        tmp_path,
+        api_url="https://syn.example.com",
+        api_token="token",
+    )
+
+
+def setup_cluster(globalrev=None, tenantrev=None):
+    """
+    Setup test cluster object
+    """
+    cluster_apiresp = {
+        "id": "c-cluster",
+        "tenant": "t-tenant",
+        "annotations": {
+            "monitoring.syn.tools/sla": "24/7 Reactive",
+            "syn.tools/tenant": "t-tenant",
+        },
+        "displayName": "My very important cluster",
+        "facts": {
+            "cloud": "aws",
+            "distribution": "openshift4",
+            "region": "eu-west-1",
+        },
+        "gitRepo": {
+            "deployKey": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDG9a5WwLuwcxMRydNqI4ofuzXucrBKpGOvPV9PO4guj\n",
+            # Truncated hostKeys content to only ed25519
+            "hostKeys": "gitlab.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAfuCHKVTjquxvt6CM6tdG4SLp1Btn/nOeHHE5UOzRdf",
+            "type": "auto",
+            "url": "ssh://git@git.example.com/acmecorp/gitops-mycluster.git",
+        },
+        "installURL": "https://api.syn.vshn.net/install/steward.json?token=<secretToken>",
+    }
+    tenant_apiresp = {
+        "id": "t-tenant",
+        "annotations": {
+            "monitoring.syn.tools/sla": "24/7 Reactive",
+            "syn.tools/tenant": "t-nameless-pond-1234",
+        },
+        "displayName": "Acme Corp.",
+        "gitRepo": {
+            "type": "auto",
+            "url": "ssh://git@git.example.com/acmecorp/tenant-repo.git",
+        },
+        "globalGitRepoURL": "ssh://git@git.example.com/acmecorp/gitops-global.git",
+    }
+
+    if globalrev is not None:
+        cluster_apiresp["globalGitRepoRevision"] = globalrev
+    if tenantrev is not None:
+        cluster_apiresp["tenantGitRepoRevision"] = tenantrev
+
+    return Cluster(cluster_apiresp, tenant_apiresp)
+
+
+def assert_result(cluster, repo, repourl, revision, override_revision):
+    # Calculate effective checked out revision
+    effective_revision = revision
+    if override_revision is not None:
+        effective_revision = override_revision
+
+    assert repo.url == repourl
+    assert repo.head.reference == effective_revision
+    if effective_revision is not None:
+        cc = 1
+    else:
+        cc = 0
+    assert repo.call_counts["commit"] == cc
+    assert repo.call_counts["checkout_version"] == cc
+    assert repo.head.call_counts["reference.setter"] == cc
+    assert repo.head.call_counts["reset"] == cc
+
+
+@patch.object(compile, "git", new=mock_git)
+@pytest.mark.parametrize("revision", [None, "ref"])
+@pytest.mark.parametrize("override_revision", [None, "oref"])
+def test_fetch_global_config(tmp_path: P, config, revision, override_revision):
+    # Set revision values
+    cluster = setup_cluster(globalrev=revision)
+    config.global_repo_revision_override = override_revision
+
+    compile._fetch_global_config(config, cluster)
+
+    repo = config.get_configs()["global"]
+
+    assert_result(
+        cluster, repo, cluster.global_git_repo_url, revision, override_revision
+    )
+
+
+@patch.object(compile, "git", new=mock_git)
+@pytest.mark.parametrize("revision", [None, "ref"])
+@pytest.mark.parametrize("override_revision", [None, "oref"])
+def test_fetch_customer_config(tmp_path: P, config, revision, override_revision):
+    # Set revision values
+    cluster = setup_cluster(tenantrev=revision)
+    config.tenant_repo_revision_override = override_revision
+
+    compile._fetch_customer_config(config, cluster)
+
+    repo = config.get_configs()["customer"]
+
+    assert_result(cluster, repo, cluster.config_repo_url, revision, override_revision)


### PR DESCRIPTION
These options are intended to be used to test changes to the global/tenant repo without relying on local compilation.

When either of the repo revisions are overridden using the command line flag, the resulting catalog cannot be pushed.

If a cluster catalog should actually be compiled and pushed using a different revision of the global or tenant repo, set the override in Lieutenant.

Relates to #198.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update tests.
- [x] Update the ./CHANGELOG.md.
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
