### PR TITLE
Improved local mode for `catalog compile`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Deprecation notice for parameter `commodore.jsonnet_libs` ([#300])
 * Command line options to override global and tenant repo revisions ([#301])
 * Tests and benchmarks on Python 3.9 ([#302])
+* Kapitan targets are created from scratch in local mode ([#303])
+* Command line option to disable Jsonnet and Kapitan dependency fetching in local mode ([#303])
+
+### Changed
+
+* `component new` and `component delete` don't add or remove the new component in the inventory and `jsonnetfile.json` anymore ([#303])
 
 ### Fixed
 
@@ -360,3 +366,4 @@ Initial implementation
 [#300]: https://github.com/projectsyn/commodore/pull/300
 [#301]: https://github.com/projectsyn/commodore/pull/301
 [#302]: https://github.com/projectsyn/commodore/pull/302
+[#303]: https://github.com/projectsyn/commodore/pull/303

--- a/commodore/cli.py
+++ b/commodore/cli.py
@@ -126,6 +126,12 @@ def clean(config: Config, verbose):
         + "(overrides configuration in Lieutenant cluster)"
     ),
 )
+@click.option(
+    " / -F",
+    "--fetch-dependencies/--no-fetch-dependencies",
+    default=True,
+    help="Whether to fetch Jsonnet and Kapitan dependencies in local mode. By default dependencies are fetched.",
+)
 @verbosity
 @pass_config
 # pylint: disable=too-many-arguments
@@ -142,6 +148,7 @@ def compile_catalog(
     git_author_email,
     global_repo_revision_override,
     tenant_repo_revision_override,
+    fetch_dependencies,
 ):
     config.update_verbosity(verbose)
     config.api_url = api_url
@@ -159,6 +166,15 @@ def compile_catalog(
         raise click.ClickException(
             "Cannot push changes when local global or tenant repo override is specified"
         )
+
+    if not local:
+        if not fetch_dependencies:
+            click.echo(
+                "--no-fetch-dependencies doesn't take effect unless --local is specified"
+            )
+        # Ensure we always fetch dependencies in regular mode
+        fetch_dependencies = True
+    config.fetch_dependencies = fetch_dependencies
     _compile(config, cluster)
 
 

--- a/commodore/cluster.py
+++ b/commodore/cluster.py
@@ -136,6 +136,8 @@ def render_target(
     for c in components:
         if inv.defaults_file(c).is_file():
             classes.append(f"defaults.{c}")
+        else:
+            click.secho(f" > Default file for class {c} missing", fg="yellow")
 
     classes.append("global.commodore")
 

--- a/commodore/compile.py
+++ b/commodore/compile.py
@@ -23,6 +23,7 @@ from .helpers import (
     clean_working_tree,
     kapitan_compile,
     kapitan_inventory,
+    rm_tree_contents,
 )
 from .postprocess import postprocess_components
 from .refs import update_refs
@@ -110,6 +111,10 @@ def _local_setup(config: Config, cluster_id):
     config.register_config(
         "customer", git.init_repository(config.inventory.tenant_config_dir(tenant))
     )
+
+    click.secho("Resetting targets...", bold=True)
+    rm_tree_contents(config.inventory.targets_dir)
+    update_target(config, config.inventory.bootstrap_target)
 
     register_components(config)
 

--- a/commodore/compile.py
+++ b/commodore/compile.py
@@ -158,8 +158,7 @@ def compile(config, cluster_id):
         )
         fetch_jsonnet_libs(config, jsonnet_libs)
 
-    if not config.local:
-        fetch_jsonnet_libraries(config.work_dir, deps=jsonnet_dependencies(config))
+    fetch_jsonnet_libraries(config.work_dir, deps=jsonnet_dependencies(config))
 
     clean_catalog(catalog_repo)
 

--- a/commodore/compile.py
+++ b/commodore/compile.py
@@ -11,6 +11,7 @@ from .cluster import (
 )
 from .config import Config
 from .dependency_mgmt import (
+    create_component_symlinks,
     fetch_components,
     fetch_jsonnet_libs,
     fetch_jsonnet_libraries,
@@ -105,6 +106,12 @@ def _local_setup(config: Config, cluster_id):
     )
 
     register_components(config)
+
+    components = config.get_components()
+    for alias, component in config.get_component_aliases().items():
+        create_component_symlinks(config, components[component])
+        update_target(config, alias, component=component)
+    update_target(config, config.inventory.bootstrap_target)
 
     click.secho("Configuring catalog repo...", bold=True)
     return git.init_repository(config.catalog_dir)

--- a/commodore/compile.py
+++ b/commodore/compile.py
@@ -82,7 +82,13 @@ def _regular_setup(config: Config, cluster_id):
 
 def _local_setup(config: Config, cluster_id):
     click.secho("Running in local mode", bold=True)
-    click.echo(" > Will use existing inventory, dependencies, and catalog")
+    click.echo(" > Will use existing inventory, components, and catalog")
+    if not config.fetch_dependencies:
+        click.echo(" > Will use existing Jsonnet and Kapitan dependencies")
+        click.echo(
+            "   > Use --fetch-dependencies at least once if you're trying to enable a new component in local mode,"
+            + " otherwise Kapitan will fail to find the component"
+        )
 
     file = config.inventory.target_file(config.inventory.bootstrap_target)
     if not file.is_file():
@@ -151,14 +157,15 @@ def compile(config, cluster_id):
         component.render_jsonnetfile_json(cluster_parameters[ckey])
 
     jsonnet_libs = cluster_parameters.get("commodore", {}).get("jsonnet_libs", None)
-    if jsonnet_libs and not config.local:
+    if jsonnet_libs and config.fetch_dependencies:
         config.register_deprecation_notice(
             "Parameter `commodore.jsonnet_libs` is deprecated. "
             + "If your component needs Jsonnet dependencies, specify them in the component's `jsonnetfile.json`"
         )
         fetch_jsonnet_libs(config, jsonnet_libs)
 
-    fetch_jsonnet_libraries(config.work_dir, deps=jsonnet_dependencies(config))
+    if config.fetch_dependencies:
+        fetch_jsonnet_libraries(config.work_dir, deps=jsonnet_dependencies(config))
 
     clean_catalog(catalog_repo)
 
@@ -170,7 +177,12 @@ def compile(config, cluster_id):
     # parameters
     update_refs(config, aliases, inventory)
 
-    kapitan_compile(config, targets, search_paths=[config.vendor_dir])
+    kapitan_compile(
+        config,
+        targets,
+        search_paths=[config.vendor_dir],
+        fetch_dependencies=config.fetch_dependencies,
+    )
 
     postprocess_components(config, inventory, components)
 

--- a/commodore/compile.py
+++ b/commodore/compile.py
@@ -11,7 +11,6 @@ from .cluster import (
 )
 from .config import Config
 from .dependency_mgmt import (
-    create_component_symlinks,
     fetch_components,
     fetch_jsonnet_libs,
     fetch_jsonnet_libraries,
@@ -114,13 +113,17 @@ def _local_setup(config: Config, cluster_id):
 
     click.secho("Resetting targets...", bold=True)
     rm_tree_contents(config.inventory.targets_dir)
+
+    click.secho("Resetting component symlinks in inventory...", bold=True)
+    rm_tree_contents(config.inventory.defaults_dir)
+    rm_tree_contents(config.inventory.components_dir)
+
+    click.secho("Creating bootstrap target...", bold=True)
     update_target(config, config.inventory.bootstrap_target)
 
     register_components(config)
 
-    components = config.get_components()
     for alias, component in config.get_component_aliases().items():
-        create_component_symlinks(config, components[component])
         update_target(config, alias, component=component)
     update_target(config, config.inventory.bootstrap_target)
 

--- a/commodore/component/template.py
+++ b/commodore/component/template.py
@@ -1,9 +1,6 @@
 import datetime
-import json
-import os
 import re
 
-from pathlib import Path as P
 from shutil import rmtree
 
 import click
@@ -13,14 +10,7 @@ from cookiecutter.main import cookiecutter
 from commodore import git, __install_dir__
 from commodore import config as CommodoreConfig
 from commodore.component import Component, component_dir
-from commodore.cluster import update_target
-from commodore.dependency_mgmt import (
-    create_component_symlinks,
-    delete_component_symlinks,
-    fetch_jsonnet_libraries,
-    register_components,
-    write_jsonnetfile,
-)
+from commodore.dependency_mgmt import delete_component_symlinks
 
 slug_regex = re.compile("^[a-z][a-z0-9-]+[a-z0-9]$")
 
@@ -110,29 +100,9 @@ class ComponentTemplater:
         index.add(".editorconfig")
         git.commit(repo, "Initial commit", self.config)
 
-        register_components(self.config)
-        self.config.register_component(component)
-
-        click.echo(" > Installing component")
-        try:
-            create_component_symlinks(self.config, component)
-            update_target(self.config, self.slug)
-            insert_into_jsonnetfile(self.config, component.target_directory)
-            # call fetch_jsonnet_libraries after updating jsonnetfile to
-            # symlink new component into vendor/
-            fetch_jsonnet_libraries(self.config.work_dir)
-        except FileNotFoundError:
-            # TODO: This should maybe cleanup the "dependencies" subdirectory
-            # (since we just created it).
-            click.echo(
-                "Cannot find catalog files. Did you forget to run "
-                "'catalog compile' in the current directory?"
-            )
-        else:
-            click.secho(f"Component {self.name} successfully added 🎉", bold=True)
+        click.secho(f"Component {self.name} successfully added 🎉", bold=True)
 
     def delete(self):
-        inv = self.config.inventory
         if component_dir(self.config.work_dir, self.slug).exists():
             component = Component(self.slug, work_dir=self.config.work_dir)
 
@@ -145,60 +115,8 @@ class ComponentTemplater:
             delete_component_symlinks(self.config, component)
             rmtree(component.target_directory)
 
-            os.unlink(inv.target_file(component))
-            remove_from_jsonnetfile(self.config, component.target_directory)
-            # Fetch jsonnet libs after removing component from jsonnetfile to
-            # remove symlink to removed component in vendor/
-            fetch_jsonnet_libraries(self.config.work_dir)
-
             click.secho(f"Component {self.slug} successfully deleted 🎉", bold=True)
         else:
             raise click.BadParameter(
                 "Cannot find component with slug " f"'{self.slug}'."
             )
-
-
-def insert_into_jsonnetfile(cfg: CommodoreConfig.Config, componentdir: P):
-    """
-    Insert new component into jsonnetfile
-    """
-    if not cfg.jsonnet_file.exists():
-        write_jsonnetfile(cfg.config_file, [])
-
-    with open(cfg.jsonnet_file, "r") as jf:
-        jsonnetf = json.load(jf)
-
-    jsonnetf["dependencies"].append(
-        {
-            "source": {
-                "local": {"directory": _component_rel_path(cfg.work_dir, componentdir)}
-            }
-        }
-    )
-
-    with open(cfg.jsonnet_file, "w") as jf:
-        json.dump(jsonnetf, jf, indent=4)
-
-
-def remove_from_jsonnetfile(cfg: CommodoreConfig.Config, componentdir: P):
-    """
-    Remove component from jsonnetfile
-    """
-    with open(cfg.jsonnet_file, "r") as jf:
-        jsonnetf = json.load(jf)
-
-    deps = jsonnetf["dependencies"]
-    deps = list(
-        filter(
-            lambda d: d.get("source", {}).get("local", {}).get("directory", {})
-            != _component_rel_path(cfg.work_dir, componentdir),
-            deps,
-        )
-    )
-    jsonnetf["dependencies"] = deps
-    with open(cfg.jsonnet_file, "w") as jf:
-        json.dump(jsonnetf, jf, indent=4)
-
-
-def _component_rel_path(work_dir: P, path: P) -> str:
-    return os.path.relpath(path, start=work_dir)

--- a/commodore/component/template.py
+++ b/commodore/component/template.py
@@ -10,7 +10,6 @@ from cookiecutter.main import cookiecutter
 from commodore import git, __install_dir__
 from commodore import config as CommodoreConfig
 from commodore.component import Component, component_dir
-from commodore.dependency_mgmt import delete_component_symlinks
 
 slug_regex = re.compile("^[a-z][a-z0-9-]+[a-z0-9]$")
 
@@ -112,7 +111,6 @@ class ComponentTemplater:
                     f"{self.slug}? This action cannot be undone",
                     abort=True,
                 )
-            delete_component_symlinks(self.config, component)
             rmtree(component.target_directory)
 
             click.secho(f"Component {self.slug} successfully deleted 🎉", bold=True)

--- a/commodore/config.py
+++ b/commodore/config.py
@@ -42,6 +42,7 @@ class Config:
         self.push = None
         self.interactive = None
         self.force = False
+        self.fetch_dependencies = True
         self._inventory = Inventory(work_dir=self.work_dir)
         self._deprecation_notices = []
         self._global_repo_revision_override = None

--- a/commodore/dependency_mgmt.py
+++ b/commodore/dependency_mgmt.py
@@ -9,7 +9,7 @@ import click
 from . import git
 from .config import Config
 from .component import Component, component_dir
-from .helpers import relsymlink, delsymlink, kapitan_inventory
+from .helpers import relsymlink, kapitan_inventory
 
 
 def create_component_symlinks(cfg, component: Component):
@@ -31,21 +31,6 @@ def create_component_symlinks(cfg, component: Component):
         if cfg.debug:
             click.echo(f"     > installing template library: {file}")
         relsymlink(file, cfg.inventory.lib_dir)
-
-
-def delete_component_symlinks(cfg, component: Component):
-    """
-    Remove the component symlinks in the inventory subdirectory.
-
-    This is the reverse from the create_component_symlinks method and is used
-    when deleting a component.
-    """
-    delsymlink(cfg.inventory.component_file(component), cfg.debug)
-    delsymlink(cfg.inventory.defaults_file(component), cfg.debug)
-
-    # If the component has a lib/ subdir, remove the links to the dependencies/lib.
-    for file in component.lib_files:
-        delsymlink(file, cfg.debug)
 
 
 def _discover_components(cfg) -> Tuple[List[str], Dict[str, str]]:

--- a/commodore/dependency_mgmt.py
+++ b/commodore/dependency_mgmt.py
@@ -289,8 +289,10 @@ def inject_essential_libraries(file: P):
 
 def register_components(cfg: Config):
     """
-    Register all targets which are currently available in `inventory/targets`
-    in the Commodore config.
+    Discover components in the inventory, and register them if the
+    corresponding directory in `dependencies/` exists.
+
+    Create component symlinks for discovered components which exist.
     """
     click.secho("Discovering included components...", bold=True)
     components, component_aliases = _discover_components(cfg)
@@ -307,6 +309,7 @@ def register_components(cfg: Config):
             continue
         component = Component(cn, work_dir=cfg.work_dir)
         cfg.register_component(component)
+        create_component_symlinks(cfg, component)
 
     registered_components = cfg.get_components().keys()
     pruned_aliases = {

--- a/commodore/helpers.py
+++ b/commodore/helpers.py
@@ -227,21 +227,3 @@ def relsymlink(src: P, dest_dir: P, dest_name: Optional[str] = None):
     if link_dst.exists():
         os.remove(link_dst)
     os.symlink(link_src, link_dst)
-
-
-def delsymlink(linkname: P, debug=False):
-    """
-    A convenience function to remove a symlink.
-
-    Ensures the target path actually exists and is a symlink before deleting, or
-    noops.
-    """
-
-    # This will also be False in case it doesn't exist.
-    if linkname.is_symlink():
-        if debug:
-            click.echo(f"Deleting symlink: {linkname}")
-        linkname.unlink()
-    else:
-        if debug:
-            click.echo(f"Trying to delete non-symlink path {linkname}. No deleting!")

--- a/docs/modules/ROOT/pages/local-mode.adoc
+++ b/docs/modules/ROOT/pages/local-mode.adoc
@@ -1,25 +1,81 @@
 = Local mode
 
-Commodore provides a local mode for the `compile` command. Local mode is
-intended for local development, and won't fetch information from the
-SYNventory API or clone Git repositories for the inventory and components.
+[NOTE]
+====
+This document assumes that you have your local environment set up to run Commodore as `commodore`.
+See xref:running-commodore.adoc[Running Commodore] for a guide to get your local environment set up.
+====
 
+Commodore provides a local mode for the `catalog compile` command.
+Local mode can be enabled with the `--local` flag.
 
-Local mode can be enabled with the `--local` flag of the `compile` command.
-
-[source,bash]
---
-poetry run commodore catalog compile <cluster-id> --local
---
-
-In local mode, the existing directory structure in the working directory is
-used. This allows local development on components and also allows testing
-local modifications to the inventory. The user is responsible for ensuring
-that all the moving parts are where they should be. It's recommended to run
-Commodore in regular mode once to fetch all the inputs which are required to
-compile the catalog for the selected cluster.
+Local mode is intended for local development, and won't fetch information from the SYNventory API or clone Git repositories for the inventory and components.
+However, by default Commodore will fetch Jsonnet dependencies in local mode (using jsonnet-bundler) and will configure Kapitan to fetch dependencies.
+This dependency fetching can be disabled with the `--no-fetch-dependencies` command line flag.
 
 [source,bash]
 --
-poetry run commodore catalog compile <cluster-id>
+commodore catalog compile <cluster-id> --local [--no-fetch-dependencies]
 --
+
+In local mode, the existing directory structure in the working directory is used.
+This allows local development on components and also allows testing local modifications to the inventory.
+
+[NOTE]
+====
+The user is responsible for preparing the working directory to hold a directory structure which Commodore understands.
+We recommend running Commodore in regular mode once to fetch all the inputs which are required to compile the catalog for the selected cluster.
+
+[source,bash]
+--
+commodore catalog compile <cluster-id>
+--
+====
+
+[NOTE]
+====
+Local mode will perform component discovery and will create Kapitan targets for discovered components.
+However, Commodore will only create targets for components which are present in `dependencies/`.
+See <<_add_existing_component_to_a_cluster_in_local_mode,the next section>> for a set of steps to add existing components to a cluster in local mode.
+====
+
+== Add existing component to a cluster in local mode
+
+To add an existing component to a cluster in local mode for testing purposes, the following steps can be used.
+This example uses the https://github.com/projectsyn/component-nfs-subdir-external-provisioner/[nfs-subdir-external-provisioner] component.
+
+. Clone the component, if it's not present in `dependencies/`
++
+[source,bash]
+--
+test -d dependencies/nfs-subdir-external-provisioner || \
+git clone https://github.com/projectsyn/component-nfs-subdir-external-provisioner.git \
+    dependencies/nfs-subdir-external-provisioner
+--
+
+. Add the component to the cluster, by adding it in the `applications` array in the cluster config:
++
+[source,yaml]
+--
+applications:
+  - nfs-subdir-external-provisioner
+--
+
+. Run Commodore in local mode with dependency fetching enabled
++
+[source,bash]
+--
+commodore catalog compile <cluster-id> --local
+--
+
+. Now you can configure the component and test changes with dependency fetching disabled
++
+[source,bash]
+--
+commodore catalog compile <cluster-id> --local --no-fetch-dependencies
+--
+
+== Testing a new component in local mode
+
+Commodore's `component new` command won't insert the component into the current cluster configuration.
+In order to test a new component in local mode, you need to explicitly add the component to the cluster by following the steps in <<_add_existing_component_to_a_cluster_in_local_mode,the previous section>>.

--- a/docs/modules/ROOT/pages/reference/cli.adoc
+++ b/docs/modules/ROOT/pages/reference/cli.adoc
@@ -65,6 +65,17 @@ a "regular" `catalog compile` for the cluster you want to work against.
 +
 See also xref:local-mode.adoc[local mode documentation].
 
+*--fetch-dependencies/--no-fetch-dependencies*::
+  Whether to fetch Jsonnet and Kapitan dependencies in local mode.
++
+This flag doesn't have an effect in regular mode, but speeds up local mode by not fetching Jsonnet dependencies, and disabling Kapitan's dependency fetching.
+By default, Jsonnet and Kapitan dependencies are fetched in local mode, to make local testing of component and configuration changes easier.
+Additionally, having Jsonnet and Kapitan dependency fetching enabled in local mode is required to test some types of changes such as upgrading versions.
++
+When you want to test adding a new component in local mode, you *must* run local mode with dependency fetching enabled at least once.
+After that, all the symlinks and dependencies which are required to compile the component will be present and you can disable dependency fetching.
+
+
 *--push*::
   Push catalog to remote repository as discovered in the cluster configuration
   fetched from the Lieutenant API.

--- a/tests/test_component_template.py
+++ b/tests/test_component_template.py
@@ -35,20 +35,6 @@ def test_run_component_new_command(tmp_path: P):
         P("docs", "modules", "ROOT", "pages", "index.adoc"),
     ]:
         assert (tmp_path / "dependencies" / component_name / file).exists()
-    for file in [
-        P("inventory", "classes", "components", f"{component_name}.yml"),
-        P("inventory", "classes", "defaults", f"{component_name}.yml"),
-        P("dependencies", "lib", f"{component_name}.libsonnet"),
-        P("vendor", component_name),
-    ]:
-        assert (tmp_path / file).is_symlink()
-    targetyml = tmp_path / "inventory" / "targets" / f"{component_name}.yml"
-    assert targetyml.exists()
-    with open(targetyml) as file:
-        target = yaml.safe_load(file)
-        assert f"defaults.{component_name}" in target["classes"]
-        assert target["classes"][-1] == f"components.{component_name}"
-        assert target["parameters"]["kapitan"]["vars"]["target"] == component_name
     # Check that there are no uncommited files in the component repo
     repo = Repo(tmp_path / "dependencies" / component_name)
     assert not repo.is_dirty()


### PR DESCRIPTION
Since we moved to the target-per-component architecture in Commodore, the local mode of `catalog compile` got less usable, and required more manual steps for some changes (e.g. adding an additional component, cf. #297).

This PR changes local mode to discover components using the same mechanism as regular catalog compilation and also ensures Kapitan targets and component class symlinks in the Kapitan inventory are handled identically to regular catalog compilation.

This change also has the (wanted) side-effect that catalog compilation will fail in local mode if the config hierarchy uses parameter references which are not resolvable during inventory bootstrapping.

Additionally, this PR introduces a new command line flag for `catalog compile`, `--no-fetch-dependencies`, which turns off Jsonnet and Kapitan dependency fetching in local mode. This flag has no effect during a regular `catalog compile`. Note that by default dependency fetching is enabled in local mode.

Finally, this PR simplifies `component new` and `component delete` by removing all the code that was previously present to allow local mode to compile freshly created components by creating component symlinks and targets in the Kapitan inventory. With the new component discovery implementation in local mode, these steps are no longer required in `component new` and `component delete`.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update tests.
- [x] Update the ./CHANGELOG.md.
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
