### PR TITLE
Update `component compile` to provide expected parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 * Fix component template GitHub workflow to correctly lint docs ([#295])
+* Fix mock cluster parameters provided by `component compile` ([#304])
 
 ## [v0.5.0] - 2021-03-12
 
@@ -367,3 +368,4 @@ Initial implementation
 [#301]: https://github.com/projectsyn/commodore/pull/301
 [#302]: https://github.com/projectsyn/commodore/pull/302
 [#303]: https://github.com/projectsyn/commodore/pull/303
+[#304]: https://github.com/projectsyn/commodore/pull/304

--- a/commodore/component/compile.py
+++ b/commodore/component/compile.py
@@ -47,14 +47,19 @@ def compile_component(
                     f"""
                 parameters:
                   cloud:
-                    provider: cloudscale
-                    region: rma1
+                    provider: ${{facts:cloud}}
+                    region: ${{facts:region}}
                   cluster:
                     catalog_url: ssh://git@git.example.com/org/repo.git
                     dist: test-distribution
                     name: c-green-test-1234
+                    tenant: t-silent-test-1234
                   customer:
-                    name: t-silent-test-1234
+                    name: ${{cluster:tenant}}
+                  facts:
+                    distribution: test-distribution
+                    cloud: cloudscale
+                    region: rma1
                   argocd:
                     namespace: test
 


### PR DESCRIPTION
Update `component compile` to provide correct set of parameters that must be available, such as `cluster.tenant` and the mandatory `facts`.

This ensures that all components using only non-deprecated parameters can be compiled with `component compile`.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the ./CHANGELOG.md.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
