### PR TITLE
Introduce inventory parameters for cluster and tenant display names

### DIFF
--- a/commodore/cluster.py
+++ b/commodore/cluster.py
@@ -33,11 +33,15 @@ class Cluster:
         return self._cluster["id"]
 
     @property
+    def display_name(self) -> str:
+        return self._cluster["displayName"]
+
+    @property
     def global_git_repo_url(self) -> str:
         field = "globalGitRepoURL"
         if field not in self._tenant:
             raise click.ClickException(
-                f"URL of the global git repository is missing on tenant '{self.tenant}'"
+                f"URL of the global git repository is missing on tenant '{self.tenant_id}'"
             )
         return self._tenant[field]
 
@@ -77,8 +81,12 @@ class Cluster:
         return repo_url
 
     @property
-    def tenant(self) -> str:
+    def tenant_id(self) -> str:
         return self._tenant["id"]
+
+    @property
+    def tenant_display_name(self) -> str:
+        return self._tenant["displayName"]
 
     @property
     def facts(self) -> Dict[str, str]:
@@ -195,8 +203,10 @@ def render_params(inv: Inventory, cluster: Cluster):
         "parameters": {
             inv.bootstrap_target: {
                 "name": cluster.id,
+                "display_name": cluster.display_name,
                 "catalog_url": cluster.catalog_repo_url,
-                "tenant": cluster.tenant,
+                "tenant": cluster.tenant_id,
+                "tenant_display_name": cluster.tenant_display_name,
                 # TODO Remove dist after deprecation phase.
                 "dist": facts["distribution"],
             },
@@ -204,7 +214,7 @@ def render_params(inv: Inventory, cluster: Cluster):
             # TODO Remove the cloud and customer parameters after deprecation phase.
             "cloud": cloud,
             "customer": {
-                "name": cluster.tenant,
+                "name": cluster.tenant_id,
             },
             # Merge component_versions into components in params.cluster for
             # backwards-compatibility.

--- a/commodore/compile.py
+++ b/commodore/compile.py
@@ -47,7 +47,7 @@ def _fetch_customer_config(cfg: Config, cluster: Cluster):
     if cfg.debug:
         click.echo(f" > Cloning customer config {repo_url}")
     repo = git.clone_repository(
-        repo_url, cfg.inventory.tenant_config_dir(cluster.tenant), cfg
+        repo_url, cfg.inventory.tenant_config_dir(cluster.tenant_id), cfg
     )
     rev = cluster.config_git_repo_revision
     if cfg.tenant_repo_revision_override:

--- a/docs/modules/ROOT/pages/reference/parameters.adoc
+++ b/docs/modules/ROOT/pages/reference/parameters.adoc
@@ -1,0 +1,37 @@
+= Commodore-managed inventory parameters
+
+This page provides a reference for all inventory parameters which are injected into the hierarchy by Commodore.
+The parameters are injected using the class `params.cluster`.
+This class is created by Commodore in file `inventory/classes/params/cluster.yml`.
+
+The class is included in each Kapitan target with the lowest precedence of all classes.
+
+== Parameters
+
+=== `cluster`
+
+The key `cluster` holds the following information about the cluster and its tenant:
+
+`name`::
+The cluster's ID (the name of the cluster object managed by Lieutenant).
+`display_name`::
+The cluster's display name.
+`tenant`::
+The ID of the cluster's tenant.
+`tenant_display_name`::
+The display name of the cluster's tenant.
+`catalog_url`::
+The cluster catalog Git repository URL.
+
+=== `facts`
+
+The cluster's facts, as stored in the cluster's Lieutenant object.
+
+The following facts are mandatory:
+
+`cloud`:: The cloud provider on which the cluster is installed.
+`region`::
+The cloud region on which the cluster is installed.
+Mandatory only for clouds which have multiple regions.
+`distribution`::
+The Kubernetes distribution of the cluster.

--- a/docs/modules/ROOT/partials/nav-reference.adoc
+++ b/docs/modules/ROOT/partials/nav-reference.adoc
@@ -1,7 +1,11 @@
 * xref:commodore:ROOT:reference/concepts.adoc[Concepts]
 * xref:commodore:ROOT:reference/architecture.adoc[Architecture]
-* xref:commodore:ROOT:reference/commands.adoc[Commands]
-* xref:commodore:ROOT:reference/cli.adoc[Command Line Options]
-* xref:commodore:ROOT:reference/hierarchy.adoc[Inventory Hierarchy]
-* xref:commodore:ROOT:reference/deprecation-policy.adoc[Deprecation policy]
-* xref:commodore:ROOT:reference/deprecation-notices.adoc[Deprecation notices]
+* User interface
+** xref:commodore:ROOT:reference/commands.adoc[Commands]
+** xref:commodore:ROOT:reference/cli.adoc[Command Line Options]
+* Configuration hierarchy
+** xref:commodore:ROOT:reference/hierarchy.adoc[Inventory Hierarchy]
+** xref:commodore:ROOT:reference/parameters.adoc[Commodore-managed inventory parameters]
+* Feature deprecation
+** xref:commodore:ROOT:reference/deprecation-policy.adoc[Deprecation policy]
+** xref:commodore:ROOT:reference/deprecation-notices.adoc[Deprecation notices]

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -14,8 +14,12 @@ from commodore.config import Config
 @pytest.fixture
 def data():
     return {
-        "cluster": {"id": "c-bar", "tenant": "t-foo"},
-        "tenant": {"id": "t-foo"},
+        "cluster": {
+            "id": "c-bar",
+            "tenant": "t-foo",
+            "displayName": "Foo Inc. Bar cluster",
+        },
+        "tenant": {"id": "t-foo", "displayName": "Foo Inc."},
     }
 
 
@@ -123,14 +127,24 @@ def test_catalog_repo_url(data):
     assert "ssh://git@example.com/catalog.git" == cluster.catalog_repo_url
 
 
-def test_tenant(data):
+def test_tenant_id(data):
     cluster = Cluster(data["cluster"], data["tenant"])
-    assert "t-foo" == cluster.tenant
+    assert "t-foo" == cluster.tenant_id
+
+
+def test_tenant_display_name(data):
+    cluster = Cluster(data["cluster"], data["tenant"])
+    assert "Foo Inc." == cluster.tenant_display_name
 
 
 def test_id(data):
     cluster = Cluster(data["cluster"], data["tenant"])
     assert "c-bar" == cluster.id
+
+
+def test_display_name(data):
+    cluster = Cluster(data["cluster"], data["tenant"])
+    assert "Foo Inc. Bar cluster" == cluster.display_name
 
 
 def test_facts(data):


### PR DESCRIPTION
This commit adds parameters `cluster.display_name` and `cluster.tenant_display_name` which can be used to insert the cluster's and tenant's display name in manifests.

The commit also adds a new documentation page which lists all the inventory parameters which are managed by Commodore and injected during catalog compilation.

Fixes #307.

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.