### PR TITLE
Fix prereleases not being applied when using release candidates

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -51,5 +51,6 @@ jobs:
         tag_name: ${{ github.ref }}
         release_name: ${{ github.ref }}
         body: ${{steps.build_changelog.outputs.changelog}}
+        prerelease: "${{ contains(github.ref, '-rc') }}"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/commodore/component-template/{{ cookiecutter.slug }}/.github/workflows/release.yaml
+++ b/commodore/component-template/{{ cookiecutter.slug }}/.github/workflows/release.yaml
@@ -29,6 +29,7 @@ jobs:
           tag_name: ${{ github.ref }}
           release_name: ${{ github.ref }}
           body: ${{steps.build_changelog.outputs.changelog}}
+          prerelease: "${{ contains(github.ref, '-rc') }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 {% endraw -%}


### PR DESCRIPTION
* Adds a missing flag for detecting prereleases when releasing components. 
  * Affects also the component template resp. generator, thus labelled "bug"

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
