### PR TITLE
Implement support for deprecating components

### DIFF
--- a/commodore/compile.py
+++ b/commodore/compile.py
@@ -159,6 +159,7 @@ def compile(config, cluster_id):
 
     # Verify that all aliased components support instantiation
     config.verify_component_aliases(cluster_parameters)
+    config.register_component_deprecations(cluster_parameters)
 
     for component in config.get_components().values():
         ckey = component.parameters_key

--- a/commodore/component-template/{{ cookiecutter.slug }}/class/defaults.yml
+++ b/commodore/component-template/{{ cookiecutter.slug }}/class/defaults.yml
@@ -1,3 +1,4 @@
 parameters:
   {{ cookiecutter.parameter_key }}:
+    =_metadata: {}
     namespace: syn-{{ cookiecutter.slug }}

--- a/commodore/config.py
+++ b/commodore/config.py
@@ -189,6 +189,6 @@ class Config:
                 msg = f"Component {cname} is deprecated."
                 if "replaced_by" in cmeta:
                     msg += f" Use component {cmeta['replaced_by']} instead."
-                if "deprecation_guide" in cmeta:
-                    msg += f" See {cmeta['deprecation_guide']} for a migration guide."
+                if "deprecation_notice" in cmeta:
+                    msg += f" {cmeta['deprecation_notice']}"
                 self.register_deprecation_notice(msg)

--- a/docs/modules/ROOT/pages/reference/component-deprecation.adoc
+++ b/docs/modules/ROOT/pages/reference/component-deprecation.adoc
@@ -1,0 +1,46 @@
+= Component deprecation
+
+Commodore supports components being marked as deprecated.
+Components can be marked as "deprecated" by adding `deprecated: True` to parameter `parameters.<component_name>._metadata`.
+To avoid allowing the inventory hierarchy to overwrite a component's `_metadata` parameter, it must be labeled as https://github.com/kapicorp/reclass/blob/develop/README-extensions.rst#constant-parameters[constant] by prefixing it with a `=`.
+The component template adds the `_metadata` parameter (with no content) for new components.
+
+.class/defaults.yml
+[source,yaml]
+----
+parameters:
+  component_name:
+    =_metadata:
+      deprecated: True
+----
+
+If the component is deprecated in favor of a new component, the new component can be indicated by adding `replaced_by: another-component` in the component's `_metadata` parameter.
+The value of `replaced_by` isn't verified to be an existing component.
+
+.class/defaults.yml
+[source,yaml]
+----
+parameters:
+  component_name:
+    =_metadata:
+      deprecated: True
+      replaced_by: another-component
+----
+
+If a migration guide from the deprecated component to the new component exists, the URL of that guide can be provided in field `deprecation_guide` in the component's `_metadata` parameter.
+
+.class/defaults.yml
+[source,yaml]
+----
+parameters:
+  component_name:
+    =_metadata:
+      deprecated: True
+      replaced_by: another-component
+      deprecation_guide: https://github.com/projectsyn/component-another-component/docs/.../how-tos/migrating-from-component-name.adoc
+----
+
+Commodore will print a deprecation notice for each component which has `parameters.<component_name>._metadata.deprecated` set to `True`.
+
+* If field `replaced_by` in the component's `_metadata` parameter isn't empty, the deprecation notice will use the field's value as the name of the replacement component.
+* If field `deprecation_guide` in the component's `_metadata` parameter isn't empty, the deprecation notice will treat the field's value as a URL to a migration documentation.

--- a/docs/modules/ROOT/pages/reference/component-deprecation.adoc
+++ b/docs/modules/ROOT/pages/reference/component-deprecation.adoc
@@ -27,7 +27,9 @@ parameters:
       replaced_by: another-component
 ----
 
-If a migration guide from the deprecated component to the new component exists, the URL of that guide can be provided in field `deprecation_guide` in the component's `_metadata` parameter.
+Commodore will append the contents of field `deprecation_notice` in the component's `_metadata` parameter to the deprecation notice.
+This field is intended to be used to give extended information about the deprecation.
+This could be a link to a migration guide, if a replacement component exists, or simply a link to a longer deprecation notice in the component's documentation.
 
 .class/defaults.yml
 [source,yaml]
@@ -37,10 +39,12 @@ parameters:
     =_metadata:
       deprecated: True
       replaced_by: another-component
-      deprecation_guide: https://github.com/projectsyn/component-another-component/docs/.../how-tos/migrating-from-component-name.adoc
+      deprecation_guide: >-
+        See https://github.com/projectsyn/component-another-component/docs/.../how-tos/migrating-from-component-name.adoc
+        for a migration guide.
 ----
 
 Commodore will print a deprecation notice for each component which has `parameters.<component_name>._metadata.deprecated` set to `True`.
 
 * If field `replaced_by` in the component's `_metadata` parameter isn't empty, the deprecation notice will use the field's value as the name of the replacement component.
-* If field `deprecation_guide` in the component's `_metadata` parameter isn't empty, the deprecation notice will treat the field's value as a URL to a migration documentation.
+* If field `deprecation_notice` in the component's `_metadata` parameter isn't empty, the value of the field will be appended to the deprecation notice.

--- a/docs/modules/ROOT/partials/nav-reference.adoc
+++ b/docs/modules/ROOT/partials/nav-reference.adoc
@@ -9,3 +9,4 @@
 * Feature deprecation
 ** xref:commodore:ROOT:reference/deprecation-policy.adoc[Deprecation policy]
 ** xref:commodore:ROOT:reference/deprecation-notices.adoc[Deprecation notices]
+** xref:commodore:ROOT:reference/component-deprecation.adoc[Component deprecation]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -80,7 +80,7 @@ def test_verify_component_aliases_error(config):
                     "_metadata": {
                         "deprecated": True,
                         "replaced_by": "foo",
-                        "deprecation_guide": "https://example.com/migrate-from-bar.html",
+                        "deprecation_notice": "See https://example.com/migrate-from-bar.html for a migration guide.",
                     },
                 },
                 "foo": {},

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -33,6 +33,93 @@ def test_verify_component_aliases_error(config):
         config.verify_component_aliases(params)
 
 
+@pytest.mark.parametrize(
+    "params,expected",
+    [
+        (
+            {
+                "bar": {"namespace": "syn-bar"},
+                "foo": {},
+            },
+            [],
+        ),
+        (
+            {
+                "bar": {
+                    "namespace": "syn-bar",
+                    "_metadata": {"deprecated": False, "replaced_by": "irrelevant"},
+                },
+                "foo": {},
+            },
+            [],
+        ),
+        (
+            {
+                "bar": {
+                    "namespace": "syn-bar",
+                    "_metadata": {"deprecated": True},
+                },
+                "foo": {},
+            },
+            ["Component bar is deprecated."],
+        ),
+        (
+            {
+                "bar": {
+                    "namespace": "syn-bar",
+                    "_metadata": {"deprecated": True, "replaced_by": "foo"},
+                },
+                "foo": {},
+            },
+            ["Component bar is deprecated. Use component foo instead."],
+        ),
+        (
+            {
+                "bar": {
+                    "namespace": "syn-bar",
+                    "_metadata": {
+                        "deprecated": True,
+                        "replaced_by": "foo",
+                        "deprecation_guide": "https://example.com/migrate-from-bar.html",
+                    },
+                },
+                "foo": {},
+            },
+            [
+                "Component bar is deprecated. Use component foo instead. "
+                + "See https://example.com/migrate-from-bar.html for a migration guide."
+            ],
+        ),
+        (
+            {
+                "bar": {
+                    "namespace": "syn-bar",
+                    "_metadata": {
+                        "deprecated": True,
+                    },
+                },
+                "foo": {
+                    "namespace": "syn-foo",
+                    "_metadata": {
+                        "deprecated": True,
+                    },
+                },
+            },
+            ["Component bar is deprecated.", "Component foo is deprecated."],
+        ),
+    ],
+)
+def test_register_component_deprecations(config, params, expected):
+    alias_data = {"baz": "bar", "qux": "foo"}
+    config.register_component_aliases(alias_data)
+
+    config.register_component_deprecations(params)
+
+    assert len(expected) == len(config._deprecation_notices)
+    for en, an in zip(sorted(expected), sorted(config._deprecation_notices)):
+        assert en == an
+
+
 def _setup_deprecation_notices(config):
     config.register_deprecation_notice("test 1")
     config.register_deprecation_notice("test 2")


### PR DESCRIPTION
This PR introduces a new component parameter `_metadata` which is defined as constant in the component template. When adding the parameter to existing components users are responsible to ensure that they mark the parameter as constant (with the `=` prefix).

Further, this PR changes Commodore will print out deprecation notices for all components for which `parameters.<component-name>._metadata.deprecated` is `True`.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
