### PR TITLE
Install type dependencies for mypy linting

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -49,6 +49,8 @@ commands =
 description = Run static analysis for typing
 deps =
      mypy
+     types-PyYAML
+     types-requests
 commands =
      # We ignore missing imports since some of our dependencies do not have type information.
      # Someday, it might be useful to try and import headers for them. ~chrisglass


### PR DESCRIPTION
Newer versions of mypy (>=0.900) require external packages for type information.

This commit installs the packages suggested by mypy:
    
```
commodore/helpers.py:9: error: Library stubs not installed for "requests" (or incompatible with Python 3.9)
commodore/helpers.py:9: note: Hint: "python3 -m pip install types-requests"
commodore/helpers.py:9: note: (or run "mypy --install-types" to install all missing stub packages)
commodore/helpers.py:9: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
commodore/helpers.py:10: error: Library stubs not installed for "yaml" (or incompatible with Python 3.9)
commodore/helpers.py:10: note: Hint: "python3 -m pip install types-PyYAML"
commodore/helpers.py:13: error: Library stubs not installed for "requests.exceptions" (or incompatible with Python 3.9)
```

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
