### PR TITLE
Pin Kapitan to v0.29.4 to avoid regressions in v0.29.5

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -82,7 +82,7 @@ six = ">=1.11.0"
 
 [[package]]
 name = "azure-identity"
-version = "1.5.0"
+version = "1.4.1"
 description = "Microsoft Azure Identity Library for Python"
 category = "main"
 optional = false
@@ -91,8 +91,8 @@ python-versions = "*"
 [package.dependencies]
 azure-core = ">=1.0.0,<2.0.0"
 cryptography = ">=2.1.4"
-msal = ">=1.6.0,<2.0.0"
-msal-extensions = ">=0.3.0,<0.4.0"
+msal = ">=1.3.0,<2.0.0"
+msal-extensions = ">=0.2.2,<0.3.0"
 six = ">=1.6"
 
 [[package]]
@@ -493,7 +493,7 @@ format_nongpl = ["idna", "jsonpointer (>1.13)", "webcolors", "rfc3986-validator 
 
 [[package]]
 name = "kapitan"
-version = "0.29.5"
+version = "0.29.4"
 description = "Generic templated configuration management for Kubernetes, Terraform and other things"
 category = "main"
 optional = false
@@ -501,7 +501,7 @@ python-versions = ">=3.6"
 
 [package.dependencies]
 addict = "2.2.1"
-azure-identity = "1.5.0"
+azure-identity = "1.4.1"
 azure-keyvault-keys = "4.2.0"
 boto3 = ">=1.14.3"
 cffi = "*"
@@ -554,7 +554,7 @@ requests = ">=2.0.0,<3"
 
 [[package]]
 name = "msal-extensions"
-version = "0.3.0"
+version = "0.2.2"
 description = ""
 category = "main"
 optional = false
@@ -1101,7 +1101,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "bc513ad9ffd4125df307b95bbe6e6a0a296694a8bfe76ac38214dc8a256858a5"
+content-hash = "e8713813b87fa5b405e111440c52c1d9906580bee4d769628202c78f9e680590"
 
 [metadata.files]
 addict = [
@@ -1137,8 +1137,8 @@ azure-core = [
     {file = "azure_core-1.15.0-py2.py3-none-any.whl", hash = "sha256:74631dff314fd44419ac6a3a38e8af68418b08a1b6e6793128555db20501dd07"},
 ]
 azure-identity = [
-    {file = "azure-identity-1.5.0.zip", hash = "sha256:872adfa760b2efdd62595659b283deba92d47b7a67557eb9ff48f0b5d04ee396"},
-    {file = "azure_identity-1.5.0-py2.py3-none-any.whl", hash = "sha256:1575972d19fe6651256554b2be4c009d2c996d0e86fb8ab4b0a10cc1ee2ef80a"},
+    {file = "azure-identity-1.4.1.zip", hash = "sha256:7b071089faf0789059ac24052e311e2b096a002c173d42b96896db09c6e2ba5d"},
+    {file = "azure_identity-1.4.1-py2.py3-none-any.whl", hash = "sha256:6f95b3505fc134ad16bd16da053456e1933188ac43161704d48ddb4edebf72c9"},
 ]
 azure-keyvault-keys = [
     {file = "azure-keyvault-keys-4.2.0.zip", hash = "sha256:e47b76ca5d99b12436c64ce4431271cd6744fba017f282991b84ce303e0b9eaa"},
@@ -1313,8 +1313,8 @@ jsonschema = [
     {file = "jsonschema-3.2.0.tar.gz", hash = "sha256:c8a85b28d377cc7737e46e2d9f2b4f44ee3c0e1deac6bf46ddefc7187d30797a"},
 ]
 kapitan = [
-    {file = "kapitan-0.29.5-py3-none-any.whl", hash = "sha256:c89bf0c150094e17e1d2aaad8936ed3d638fa8b15b29d77298adb4bc5352c5a7"},
-    {file = "kapitan-0.29.5.tar.gz", hash = "sha256:634c8da97974a18d1026c58cd214d297368d40d9e47563054c11038d064d71c7"},
+    {file = "kapitan-0.29.4-py3-none-any.whl", hash = "sha256:593a6536c7882faa8a0e827a3055246d90252af70615362af8850ec1eebeaa5c"},
+    {file = "kapitan-0.29.4.tar.gz", hash = "sha256:0c3c514c5ac0c48b163d6b507537ac620feca2aeeab4c743b18d52427815df4c"},
 ]
 markupsafe = [
     {file = "MarkupSafe-2.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51"},
@@ -1361,8 +1361,8 @@ msal = [
     {file = "msal-1.12.0.tar.gz", hash = "sha256:5cc93f09523c703d4e00a901cf719ade4faf2c3d14961ba52060ae78d5b25327"},
 ]
 msal-extensions = [
-    {file = "msal-extensions-0.3.0.tar.gz", hash = "sha256:5523dfa15da88297e90d2e73486c8ef875a17f61ea7b7e2953a300432c2e7861"},
-    {file = "msal_extensions-0.3.0-py2.py3-none-any.whl", hash = "sha256:a530c2d620061822f2ced8e29da301bc928b146970df635c852907423e8ddddc"},
+    {file = "msal-extensions-0.2.2.tar.gz", hash = "sha256:31414753c484679bb3b6c6401623eb4c3ccab630af215f2f78c1d5c4f8e1d1a9"},
+    {file = "msal_extensions-0.2.2-py2.py3-none-any.whl", hash = "sha256:f092246787145ec96d6c3c9f7bedfb837830fe8a79b56180e531fbf28b8de532"},
 ]
 msrest = [
     {file = "msrest-0.6.21-py2.py3-none-any.whl", hash = "sha256:c840511c845330e96886011a236440fafc2c9aff7b2df9c0a92041ee2dee3782"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,9 @@ include = [
 
 [tool.poetry.dependencies]
 python = "^3.6"
-# Require kapitan >= 0.27 to help poetry to resolve dependencies
-kapitan = ">=0.29"
+# Pin Kapitan to 0.29.4, since 0.29.5 has regressions in reclass which break our usage of the
+# `applications` array.
+kapitan = "=0.29.4"
 click = "*"
 cookiecutter = "*"
 gitpython = "*"


### PR DESCRIPTION
Go back to Kapitan v0.29.4 because v0.29.5 has regressions in the bundled reclass module which break our usage of the `applications` array for adding and removing components in the hierarchy.

This regression is also the cause for #326.

This regression is fixed in Kapitan as of https://github.com/kapicorp/kapitan/pull/703, but there's no release including this PR yet.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
