### PR TITLE
Fix releases to show "x commits to master since this release"

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -46,11 +46,10 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Create Release
       if: startsWith(github.ref, 'refs/tags/v')
-      uses: actions/create-release@v1
+      uses: ncipollo/release-action@v1
       with:
-        tag_name: ${{ github.ref }}
-        release_name: ${{ github.ref }}
         body: ${{steps.build_changelog.outputs.changelog}}
         prerelease: "${{ contains(github.ref, '-rc') }}"
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # Ensure target branch for release is "master"
+        commit: master
+        token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This notice is only shown when the release is created from a branch, and not if it's created from a commit id or tag, see [this discussion].

This PR ensures that all releases are created from branch "master" and therefore have the message showing how many commits have been added to "master" since the release.

[this discussion]: https://github.community/t/x-commits-to-branch-since-this-release-is-missing-part-2/1806

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
