### PR TITLE
Show number of commits to master since the release in component releases

### DIFF
--- a/commodore/component-template/{{ cookiecutter.slug }}/.github/workflows/release.yaml
+++ b/commodore/component-template/{{ cookiecutter.slug }}/.github/workflows/release.yaml
@@ -24,12 +24,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create Release
-        uses: actions/create-release@v1
+        uses: ncipollo/release-action@v1
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
           body: ${{steps.build_changelog.outputs.changelog}}
           prerelease: "${{ contains(github.ref, '-rc') }}"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Ensure target branch for release is "master"
+          commit: master
+          token: ${{ secrets.GITHUB_TOKEN }}
 {% endraw -%}


### PR DESCRIPTION
Change the release GitHub action in the component template to show "x commits to master since this release" by ensuring the releases are referencing branch "master" of the component repo.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
