### PR TITLE
Implement simple regression tests for Kapitan's bundled Reclass

### DIFF
--- a/tests/test_kapitan_reclass.py
+++ b/tests/test_kapitan_reclass.py
@@ -1,0 +1,59 @@
+from pathlib import Path as P
+
+from commodore.helpers import kapitan_inventory
+
+
+class MockInventory:
+    def __init__(self, invdir: P):
+        self.invdir = invdir
+
+    @property
+    def inventory_dir(self):
+        return self.invdir
+
+
+class MockConfig:
+    def __init__(self, invdir: P):
+        self.inv = MockInventory(P(__file__).parent.absolute() / "testdata" / invdir)
+
+    @property
+    def inventory(self):
+        return self.inv
+
+
+def test_yml_yaml(tmp_path: P):
+    config = MockConfig(invdir="inventory_yml_yaml")
+
+    inv = kapitan_inventory(config)
+
+    assert "test" in inv
+    inv = inv["test"]
+    assert "parameters" in inv
+    assert "test" in inv["parameters"]
+    assert "key1" in inv["parameters"]["test"]
+    assert "value1" == inv["parameters"]["test"]["key1"]
+    assert "key2" in inv["parameters"]["test"]
+    assert "value2" == inv["parameters"]["test"]["key2"]
+
+
+def test_applications(tmp_path: P):
+    config = MockConfig("inventory_apps")
+
+    apps = kapitan_inventory(config, key="applications")
+
+    apps = apps.keys()
+    assert "app1" in apps
+    assert "app2" not in apps
+
+
+def test_relative_refs(tmp_path: P):
+    config = MockConfig("inventory_relative_refs")
+
+    inv = kapitan_inventory(config)
+
+    assert "test" in inv
+    inv = inv["test"]
+    assert "parameters" in inv
+    assert "test" in inv["parameters"]
+    assert "key1" in inv["parameters"]["test"]
+    assert "value1" == inv["parameters"]["test"]["key1"]

--- a/tests/testdata/inventory_apps/classes/test.yml
+++ b/tests/testdata/inventory_apps/classes/test.yml
@@ -1,0 +1,3 @@
+classes:
+  - test.params
+  - test.specific

--- a/tests/testdata/inventory_apps/classes/test/params.yml
+++ b/tests/testdata/inventory_apps/classes/test/params.yml
@@ -1,0 +1,3 @@
+applications:
+  - app1
+  - app2

--- a/tests/testdata/inventory_apps/classes/test/specific.yml
+++ b/tests/testdata/inventory_apps/classes/test/specific.yml
@@ -1,0 +1,2 @@
+applications:
+  - ~app2

--- a/tests/testdata/inventory_apps/targets/test.yml
+++ b/tests/testdata/inventory_apps/targets/test.yml
@@ -1,0 +1,2 @@
+classes:
+  - test

--- a/tests/testdata/inventory_relative_refs/classes/test.yml
+++ b/tests/testdata/inventory_relative_refs/classes/test.yml
@@ -1,0 +1,2 @@
+classes:
+  - test.specific

--- a/tests/testdata/inventory_relative_refs/classes/test/common.yml
+++ b/tests/testdata/inventory_relative_refs/classes/test/common.yml
@@ -1,0 +1,3 @@
+parameters:
+  test:
+    key1: value1

--- a/tests/testdata/inventory_relative_refs/classes/test/specific.yml
+++ b/tests/testdata/inventory_relative_refs/classes/test/specific.yml
@@ -1,0 +1,2 @@
+classes:
+  - .common

--- a/tests/testdata/inventory_relative_refs/targets/test.yml
+++ b/tests/testdata/inventory_relative_refs/targets/test.yml
@@ -1,0 +1,2 @@
+classes:
+  - test

--- a/tests/testdata/inventory_yml_yaml/classes/a.yml
+++ b/tests/testdata/inventory_yml_yaml/classes/a.yml
@@ -1,0 +1,3 @@
+parameters:
+  test:
+    key1: value1

--- a/tests/testdata/inventory_yml_yaml/classes/b.yaml
+++ b/tests/testdata/inventory_yml_yaml/classes/b.yaml
@@ -1,0 +1,3 @@
+parameters:
+  test:
+    key2: value2

--- a/tests/testdata/inventory_yml_yaml/targets/test.yml
+++ b/tests/testdata/inventory_yml_yaml/targets/test.yml
@@ -1,0 +1,3 @@
+classes:
+  - a
+  - b


### PR DESCRIPTION
0Implement tests to catch regressions in Kapitan's Reclass for features we actively use in Commodore.

This commit covers the following Reclass features:

* Support for mixed `.yml` and `.yaml` file extensions for classes
* Support for relative class references
* Support for removing entries from the `applications` array in classes included at the same hierarchy level. See https://github.com/kapicorp/reclass/pull/5 for a detailed explanation of this reclass feature.

Resolves #330

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
