### PR TITLE
component-template: Add 'main' as default branch

### DIFF
--- a/commodore/component-template/{{ cookiecutter.slug }}/.github/workflows/test.yaml
+++ b/commodore/component-template/{{ cookiecutter.slug }}/.github/workflows/test.yaml
@@ -2,6 +2,7 @@ name: Pull Request
 on:
   pull_request:
     branches:
+      - main
       - master
 
 jobs:


### PR DESCRIPTION
Most tools and platforms are swaying towards using `main` as the default
branch name. This change makes sure the template works with 'main' as
the default branch out of the box, while retaining backwards
compatibility.

Unfortunately it is not possible to express "default branch" in a GitHub
action.

**Note:** I would also be fine with removing `master` entirely.


## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [ ] ~Update the documentation.~
- [ ] ~Update tests.~
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] ~Link this PR to related issues.~

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
