### PR TITLE
Use current working directory when searching for .env

### DIFF
--- a/commodore/cli.py
+++ b/commodore/cli.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import click
 
-from dotenv import load_dotenv
+from dotenv import load_dotenv, find_dotenv
 from importlib_metadata import version
 from commodore import __git_version__
 from .catalog import catalog_list
@@ -302,5 +302,5 @@ def component_compile(config: Config, path, values, search_paths, output, verbos
 
 
 def main():
-    load_dotenv()
+    load_dotenv(dotenv_path=find_dotenv(usecwd=True))
     commodore.main(prog_name="commodore", auto_envvar_prefix="COMMODORE")


### PR DESCRIPTION
The `.env` was only found if it is placed next to the virtualenv.
If the virtualenv is in another directory, then the `.env` was ignored and `commodore` failed.
Fix it by searching the `.env` in current directory.

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog