### PR TITLE
Always fetch Kapitan dependencies

### DIFF
--- a/commodore/helpers.py
+++ b/commodore/helpers.py
@@ -177,6 +177,7 @@ def kapitan_compile(
         cache=False,
         cache_paths=None,
         fetch_dependencies=fetch_dependencies,
+        force_fetch=True,
         validate=False,
         schemas_path=config.work_dir / "schemas",
         jinja2_filters=defaults.DEFAULT_JINJA2_FILTERS_PATH,


### PR DESCRIPTION
Kapitan has an option `force_fetch` to always fetch and update dependencies specified in `parameters.kapitan.dependencies`.

This commit sets that option to `True` to ensure component dependencies are always updated to their latest upstream variants.

This change removes the sometimes unwanted Kapitan behavior to keep stale dependencies, if the component either doesn't properly store dependencies in a version-specific directory, or if dependencies are specified with moving versions (e.g. `release-4.x` for OCP4 alert rule manifests).

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
