### PR TITLE
Fix component template

### DIFF
--- a/commodore/component-template/{{ cookiecutter.slug }}/.github/workflows/test.yaml
+++ b/commodore/component-template/{{ cookiecutter.slug }}/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
         command:
           - lint_jsonnet
           - lint_yaml
-          - docs-vale
+          - lint_adoc
     steps:
       - uses: actions/checkout@v2
       - name: Run {% raw %}${{ matrix.command }}{% endraw %}

--- a/commodore/component-template/{{ cookiecutter.slug }}/class/{{ cookiecutter.slug }}.yml
+++ b/commodore/component-template/{{ cookiecutter.slug }}/class/{{ cookiecutter.slug }}.yml
@@ -13,4 +13,4 @@ parameters:
   commodore:
     postprocess:
       filters: []
-{% endif %}
+{% endif -%}

--- a/tests/test_component_template.py
+++ b/tests/test_component_template.py
@@ -154,3 +154,35 @@ def test_deleting_inexistant_component(tmp_path: P):
         shell=True,
     )
     assert exit_status == 2
+
+
+@pytest.mark.parametrize(
+    "extra_args",
+    [
+        "",
+        "--lib",
+        "--pp",
+        "--lib --pp",
+    ],
+)
+def test_check_component_template(tmp_path: P, extra_args: str):
+    """
+    Run integrated lints in freshly created component
+    """
+
+    setup_directory(tmp_path)
+
+    component_name = "test-component"
+    exit_status = call(
+        f"commodore -d {tmp_path} -vvv component new {component_name} {extra_args}",
+        shell=True,
+    )
+    assert exit_status == 0
+
+    # Call `make lint` in component directory
+    exit_status = call(
+        "make lint",
+        shell=True,
+        cwd=tmp_path / "dependencies" / component_name,
+    )
+    assert exit_status == 0


### PR DESCRIPTION
* Use correct make target for linting documentation
* Don't emit trailing empty line in `component/<component>.yml` when creating a component without post-processing filters
* Adds tests which run `make lint` on all variants of the rendered component template

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
