### PR TITLE
Correctly postprocess aliased components

### DIFF
--- a/commodore/component/compile.py
+++ b/commodore/component/compile.py
@@ -38,6 +38,7 @@ def compile_component(
         search_paths.append(inv.dependencies_dir)
         component = Component(component_name, directory=component_path)
         config.register_component(component)
+        config.register_component_aliases({component_name: component_name})
         _prepare_fake_inventory(inv, component, value_files)
 
         # Create class for fake parameters

--- a/commodore/postprocess/__init__.py
+++ b/commodore/postprocess/__init__.py
@@ -158,7 +158,10 @@ def postprocess_components(
 ):
     click.secho("Postprocessing...", bold=True)
 
-    for cn, c in components.items():
+    aliases = config.get_component_aliases()
+
+    for a, cn in aliases.items():
+        c = components[cn]
         inv = kapitan_inventory.get(a)
         if not inv:
             click.echo(f" > No target exists for component {cn}, skipping...")

--- a/commodore/postprocess/builtin_filters.py
+++ b/commodore/postprocess/builtin_filters.py
@@ -58,7 +58,7 @@ class UnknownBuiltinFilter(ValueError):
 
 def run_builtin_filter(
     config: Config,
-    inventory: Dict,
+    inv: Dict,
     component: str,
     filterid: str,
     path: P,
@@ -66,9 +66,7 @@ def run_builtin_filter(
 ):
     if filterid not in _builtin_filters:
         raise UnknownBuiltinFilter(filterid)
-    _builtin_filters[filterid](
-        config.work_dir, inventory, component, path, **filterargs
-    )
+    _builtin_filters[filterid](config.work_dir, inv, component, path, **filterargs)
 
 
 def validate_builtin_filter(config: Config, cn: str, fd: Dict):

--- a/commodore/postprocess/jsonnet.py
+++ b/commodore/postprocess/jsonnet.py
@@ -122,7 +122,7 @@ def _filter_file(work_dir: P, component: str, filterpath: str) -> P:
 
 def run_jsonnet_filter(
     config: Config,
-    inventory: Dict,
+    inv: Dict,
     component: str,
     filterid: str,
     path: P,
@@ -136,7 +136,7 @@ def run_jsonnet_filter(
     # pylint: disable=c-extension-no-member
     jsonnet_runner(
         config.work_dir,
-        inventory,
+        inv,
         component,
         path,
         _jsonnet.evaluate_file,

--- a/tests/test_postprocess.py
+++ b/tests/test_postprocess.py
@@ -159,6 +159,16 @@ def test_postprocess_components_invfilter(tmp_path, capsys):
         assert obj["metadata"]["namespace"] == "myns"
 
 
+def test_postprocess_components_invfilter_explicit_enabled(tmp_path, capsys):
+    f = _make_ns_filter("myns", enabled=True)
+    testf, config, inventory, components = _setup(tmp_path, f, invfilter=True)
+    postprocess_components(config, inventory, components)
+    assert testf.exists()
+    with open(testf) as objf:
+        obj = yaml.safe_load(objf)
+        assert obj["metadata"]["namespace"] == "myns"
+
+
 def test_postprocess_components_invfilter_disabled(tmp_path, capsys):
     f = _make_ns_filter("myns", enabled=False)
     testf, config, inventory, components = _setup(tmp_path, f, invfilter=True)


### PR DESCRIPTION
Previously, we didn't respect component aliases when determining whether we need to run postprocessing.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
