### PR TITLE
Add local dependencies search path in commodore test compile

### DIFF
--- a/commodore/component-template/{{ cookiecutter.slug }}/Makefile
+++ b/commodore/component-template/{{ cookiecutter.slug }}/Makefile
@@ -42,6 +42,7 @@ docs-serve: ## Preview the documentation
 
 .PHONY: compile
 .compile:
+	mkdir -p dependencies
 	$(COMMODORE_CMD)
 
 .PHONY: test

--- a/commodore/component-template/{{ cookiecutter.slug }}/Makefile
+++ b/commodore/component-template/{{ cookiecutter.slug }}/Makefile
@@ -45,7 +45,7 @@ docs-serve: ## Preview the documentation
 	$(COMMODORE_CMD)
 
 .PHONY: test
-test: commodore_args = -f tests/$(instance).yml
+test: commodore_args = -f tests/$(instance).yml --search-paths ./dependencies
 test: .compile ## Compile the component
 
 .PHONY: clean


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

See also / same as projectsyn/modulesync-control/pull/9.

Currently the `parameters.kapitan.dependencies.[].output_path` needs to be overridden for all dependencies in test compiles (`make test`).

See:
- https://github.com/projectsyn/component-cert-manager/blob/master/tests/defaults.yml#L9
- https://github.com/projectsyn/component-keycloak/blob/master/tests/builtin.yml#L10
- https://github.com/projectsyn/component-keycloak/blob/master/tests/external.yml#L10

This is not optimal. It can lead to errors if a developer forgets to update the `tests/` file. The "real" output can now differ from the test output. Additionally it won't scale for components like [`component-argocd`](https://github.com/projectsyn/component-argocd/blob/master/class/argocd.yml) where there are many dependecies.

This PR adds the local directory `./dependencies` to the search path, which allows tests to run without overriding the output path.

<details>
  <summary>Example: `component-cert-manager`</summary>
  
```diff
diff --git a/Makefile b/Makefile
index 59972dd..b76fb8e 100644
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ docs-serve: ## Preview the documentation
 	$(COMMODORE_CMD)
 
 .PHONY: test
-test: commodore_args = -f tests/$(instance).yml
+test: commodore_args = -f tests/$(instance).yml --search-paths ./dependencies
 test: .compile ## Compile the component
 
 .PHONY: clean
diff --git a/tests/defaults.yml b/tests/defaults.yml
index 8971146..739347e 100644
--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -1,12 +1,3 @@
 parameters:
-  kapitan:
-    dependencies:
-      - type: helm
-        source: https://charts.jetstack.io
-        chart_name: cert-manager
-        version: ${cert_manager:charts:cert-manager}
-        # This is the required overrride
-        output_path: /cert-manager/helmcharts/cert-manager/${cert_manager:charts:cert-manager}/
-
   cert_manager:
     letsencrypt_email: test@syn.tools
```
</details>


## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
