### PR TITLE
Fix `render_target` to ensure instantiated components always compile

### DIFF
--- a/commodore/cluster.py
+++ b/commodore/cluster.py
@@ -166,6 +166,7 @@ def render_target(
         if component != target:
             ckey = component_parameters_key(component)
             tkey = component_parameters_key(target)
+            parameters[tkey] = {}
             parameters[ckey] = f"${{{tkey}}}"
 
     return {

--- a/tests/test_render_inventory.py
+++ b/tests/test_render_inventory.py
@@ -1,0 +1,98 @@
+import os
+
+from pathlib import Path
+
+from commodore.cluster import update_target
+from commodore.component import Component
+from commodore.config import Config
+from commodore.dependency_mgmt import create_component_symlinks
+from commodore.helpers import kapitan_inventory, yaml_dump, yaml_load
+
+
+def _setup(tmp_path: Path):
+    cfg = Config(
+        work_dir=tmp_path,
+        api_url="https://syn.example.com",
+        api_token="abcd1234",
+    )
+
+    os.makedirs(cfg.inventory.defaults_dir)
+    os.makedirs(cfg.inventory.components_dir)
+    os.makedirs(cfg.inventory.global_config_dir)
+    os.makedirs(cfg.inventory.params_dir)
+
+    os.makedirs(tmp_path / "dependencies" / "test")
+    c = Component("test", work_dir=tmp_path, force_init=True)
+    os.makedirs(c.class_file.parent)
+
+    yaml_dump(
+        {
+            "parameters": {
+                "kapitan": {
+                    "compile": [
+                        {
+                            "input_paths": ["input/path/file.txt"],
+                            "input_type": "copy",
+                            "output_path": "test",
+                        }
+                    ]
+                }
+            }
+        },
+        c.class_file,
+    )
+    yaml_dump(
+        {
+            "parameters": {
+                "test": {
+                    "multi_instance": True,
+                    "namespace": "syn-test",
+                    "instance_value": "${_instance}",
+                }
+            }
+        },
+        c.defaults_file,
+    )
+    yaml_dump(
+        {
+            "parameters": {
+                "cluster": {
+                    "name": "c-cluster-id-1234",
+                    "tenant": "t-tenant-id-1234",
+                },
+            },
+        },
+        cfg.inventory.params_file,
+    )
+    yaml_dump({"classes": []}, cfg.inventory.global_config_dir / "commodore.yml")
+
+    cfg.register_component(c)
+    create_component_symlinks(cfg, c)
+    cfg.register_component_aliases({"test-1": "test"})
+
+    for alias, component in cfg.get_component_aliases().items():
+        update_target(cfg, alias, component=component)
+
+    return cfg
+
+
+def test_render_inventory_instantiated_component_no_custom_config(tmp_path: Path):
+    cfg = _setup(tmp_path)
+
+    inv = kapitan_inventory(cfg)
+
+    assert inv["test-1"]["parameters"]["test"]["instance_value"] == "test-1"
+
+    pass
+
+
+def test_render_inventory_instantiated_component_custom_config(tmp_path: Path):
+    cfg = _setup(tmp_path)
+    # Add parameter in test_1
+    params = yaml_load(cfg.inventory.params_file)
+    params["parameters"]["test_1"] = {"instance_value": "testing"}
+    yaml_dump(params, cfg.inventory.params_file)
+
+    inv = kapitan_inventory(cfg)
+
+    assert inv["test-1"]["parameters"]["test"]["instance_value"] == "testing"


### PR DESCRIPTION
Previously, an error could occur when compiling a catalog containing an instantiated component for which no configurations were adjusted.

This commit ensures that the instance's key in `parameters` always exists.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
