### PR TITLE
Implement option to specify target alias for `commodore component compile`

### DIFF
--- a/commodore/cli.py
+++ b/commodore/cli.py
@@ -277,6 +277,12 @@ def component_delete(config: Config, slug, force, verbose):
     help="Specify inventory class in a YAML file (can specify multiple).",
 )
 @click.option(
+    "-a",
+    "--alias",
+    metavar="ALIAS",
+    help="Provide component alias to use when compiling component.",
+)
+@click.option(
     "-J",
     "--search-paths",
     multiple=True,
@@ -294,9 +300,11 @@ def component_delete(config: Config, slug, force, verbose):
 @verbosity
 @pass_config
 # pylint: disable=too-many-arguments
-def component_compile(config: Config, path, values, search_paths, output, verbose):
+def component_compile(
+    config: Config, path, values, alias, search_paths, output, verbose
+):
     config.update_verbosity(verbose)
-    compile_component(config, path, values, search_paths, output)
+    compile_component(config, path, alias, values, search_paths, output)
 
 
 def main():

--- a/docs/modules/ROOT/pages/reference/cli.adoc
+++ b/docs/modules/ROOT/pages/reference/cli.adoc
@@ -114,6 +114,9 @@ This command doesn't have any command line options.
   provide multiple files. Files specified later win when resolving inventory
   values.
 
+*-a, --alias* ALIAS::
+  Provide component alias to use when compiling component.
+
 *-J, --search-paths* DIRECTORY::
   Specify additional search paths.
 

--- a/docs/modules/ROOT/pages/reference/commands.adoc
+++ b/docs/modules/ROOT/pages/reference/commands.adoc
@@ -77,3 +77,5 @@ included in a cluster's configuration.
 The command takes so called values files which provide custom configuration
 values for any configuration that could be provided from the hierarchical
 configuration repositories.
+
+The option `--alias` (or `-a`) can be used to compile an instance-aware component with a specific instance.

--- a/tests/test_component_compile.py
+++ b/tests/test_component_compile.py
@@ -146,5 +146,5 @@ def test_run_component_compile_command_postprocess(tmp_path):
 
 def test_no_component_compile_command(tmp_path):
     with pytest.raises(ClickException) as excinfo:
-        compile_component(Config(tmp_path), tmp_path / "foo", [], [], "./")
+        compile_component(Config(tmp_path), tmp_path / "foo", None, [], [], "./")
     assert "Could not find component class file" in str(excinfo)

--- a/tests/test_component_compile.py
+++ b/tests/test_component_compile.py
@@ -5,7 +5,7 @@ import yaml
 import pytest
 
 from pathlib import Path as P
-from subprocess import call
+from subprocess import call, run, PIPE
 from textwrap import dedent
 
 
@@ -13,6 +13,7 @@ from click import ClickException
 from git import Repo
 
 from commodore.config import Config
+from commodore.component import component_parameters_key
 from commodore.component.compile import compile_component
 from test_component_template import test_run_component_new_command
 
@@ -63,8 +64,26 @@ def _add_postprocessing_filter(tmp_path, component_name="test-component"):
         yaml.dump(file_contents, file)
 
 
-def _cli_command_string(p: P, component: str) -> str:
-    return f"commodore -d '{p}' component compile -o '{p}/testdir' '{p}/dependencies/{component}'"
+def _make_instance_aware(tmp_path, component_name="test-component"):
+    component_defaults = (
+        tmp_path / "dependencies" / component_name / "class" / "defaults.yml"
+    )
+    with open(component_defaults, "r") as file:
+        file_contents = yaml.safe_load(file)
+
+    file_contents["parameters"][component_parameters_key(component_name)][
+        "multi_instance"
+    ] = True
+
+    with open(component_defaults, "w") as file:
+        yaml.dump(file_contents, file)
+
+
+def _cli_command_string(p: P, component: str, instance: str = None) -> str:
+    cmd = f"commodore -d '{p}' component compile -o '{p}/testdir' '{p}/dependencies/{component}'"
+    if instance is not None:
+        cmd = f"{cmd} -a {instance}"
+    return cmd
 
 
 def test_run_component_compile_command(tmp_path: P):
@@ -142,6 +161,58 @@ def test_run_component_compile_command_postprocess(tmp_path):
         target = yaml.safe_load(file)
         assert target["kind"] == "ServiceAccount"
         assert target["metadata"]["namespace"] == "test-component-ns"
+
+
+@pytest.mark.parametrize("instance_aware", [True, False])
+def test_run_component_compile_command_instance(tmp_path, capsys, instance_aware):
+    """
+    Run the component compile command for a component with a postprocessing
+    filter
+    """
+    component_name = "test-component"
+    instance_name = "test-instance"
+    _prepare_component(tmp_path, component_name)
+    if instance_aware:
+        _make_instance_aware(tmp_path, component_name)
+
+    result = run(
+        _cli_command_string(tmp_path, component_name, instance_name),
+        shell=True,
+        stdout=PIPE,
+        stderr=PIPE,
+    )
+
+    exit_status = result.returncode
+
+    if not instance_aware:
+        assert exit_status == 1
+        assert (
+            f"Error: Component {component_name} with alias {instance_name} does not support instantiation.\n"
+            in result.stderr.decode("utf-8")
+        )
+    else:
+        assert exit_status == 0
+        assert (
+            tmp_path
+            / "testdir"
+            / "compiled"
+            / instance_name
+            / "apps"
+            / f"{component_name}.yaml"
+        ).exists()
+        rendered_yaml = (
+            tmp_path
+            / "testdir"
+            / "compiled"
+            / instance_name
+            / component_name
+            / "test_service_account.yaml"
+        )
+        assert rendered_yaml.exists()
+        with open(rendered_yaml) as file:
+            target = yaml.safe_load(file)
+            assert target["kind"] == "ServiceAccount"
+            assert target["metadata"]["namespace"] == f"syn-{component_name}"
 
 
 def test_no_component_compile_command(tmp_path):


### PR DESCRIPTION
Previously we faked "instances" when compiling components by just setting `parameters._instance`, but kept the target for component compilation as the component name. This leads to differences in the resulting files as seen by the postprocessing step depending on whether a component is compiled independently or as part of a cluster catalog.

This commit introduces an additional command line option to specify the target component alias to use when compiling a single component with `commodore component compile`.

When this option is given, `component compile` correctly configures an aliased component and creates a target for the alias instead of the component. This ensures that postprocessing sees identical paths in `compiled` regardless of whether the component is being compiled as part of a cluster catalog or independently.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
