### PR TITLE
Implement optional `output_dir` postprocess filter argument

### DIFF
--- a/commodore/postprocess/__init__.py
+++ b/commodore/postprocess/__init__.py
@@ -58,6 +58,7 @@ class Filter:
         self.type = fd["type"]
         self.filter = fd["filter"]
         self.path = P(fd["path"])
+        self.output_dir = fd.get("output_dir", "")
         self.enabled = fd.get("enabled", True)
         self.filterargs = fd.get("filterargs", {})
         self._runner: FilterFunc = self._run_handlers[self.type]
@@ -72,8 +73,19 @@ class Filter:
             )
             return
 
+        path = self.path
+        if self.output_dir != "":
+            path = P(self.output_dir) / path
+        else:
+            path = P(component.name) / path
+
         self._runner(
-            config, inventory, component, self.filter, self.path, **self.filterargs
+            config,
+            inventory,
+            component,
+            self.filter,
+            path,
+            **self.filterargs,
         )
 
     @classmethod

--- a/commodore/postprocess/jsonnet.py
+++ b/commodore/postprocess/jsonnet.py
@@ -96,7 +96,7 @@ def jsonnet_runner(
     _native_cb["inventory"] = ((), _inventory)
     kwargs["target"] = component
     kwargs["component"] = component
-    output_dir = work_dir / "compiled" / component / path
+    output_dir = work_dir / "compiled" / path
     kwargs["output_path"] = str(output_dir)
     output = jsonnet_func(
         str(jsonnet_input),

--- a/docs/modules/ROOT/pages/reference/architecture.adoc
+++ b/docs/modules/ROOT/pages/reference/architecture.adoc
@@ -232,6 +232,11 @@ The path to the jsonnet filter is relative to the component repository.
 Filters can be disabled by setting the optional field `enabled` in the filter definition to `false`.
 If this field isn't present, filters are treated as enabled.
 
+Filters can instruct Commodore to search for the compiled output in a different directory than the default `compiled/<component-name>` by setting the optional field `output_dir` in the filter definition to the directory in `compiled` in which the Kapitan output is expected to be.
+This can be useful when instance-aware components want to create an individual ArgoCD app and manifests directory for each instance.
+In that case, the `output_dir` field must be set to the name of the manifests directory created for the instance.
+If the component simply uses the instance name for the manifests directory, `output_dir: ${_instance}` should be sufficient.
+
 A component can use the `helm_namespace` filter by providing the following filter configuration:
 
 .component-metrics-server/class/metrics-server.yml

--- a/tests/test_postprocess.py
+++ b/tests/test_postprocess.py
@@ -27,10 +27,16 @@ def _make_ns_filter(ns, enabled=None):
     return filter
 
 
-def _setup(tmp_path, filter, invfilter=False, alias="test-component"):
+def _setup(
+    tmp_path, filter, invfilter=False, alias="test-component", aliased_output=False
+):
     test_run_component_new_command(tmp_path=tmp_path)
 
-    targetdir = tmp_path / "compiled" / "test-component" / "test"
+    targetdir = "test-component"
+    if aliased_output:
+        targetdir = alias
+
+    targetdir = tmp_path / "compiled" / targetdir / "test"
     os.makedirs(targetdir, exist_ok=True)
     testf = targetdir / "object.yaml"
     with open(testf, "w") as objf:
@@ -197,6 +203,23 @@ def test_postprocess_components_aliased_component_invfilter(tmp_path, capsys):
     f = _make_ns_filter("myns")
     testf, config, inventory, components = _setup(
         tmp_path, f, invfilter=True, alias="component-alias"
+    )
+
+    postprocess_components(config, inventory, components)
+
+    assert testf.exists()
+    with open(testf) as objf:
+        obj = yaml.safe_load(objf)
+        assert obj["metadata"]["namespace"] == "myns"
+
+
+def test_postprocess_components_aliased_component_invfilter_custom_output(
+    tmp_path, capsys
+):
+    f = _make_ns_filter("myns")
+    f["filters"][0]["output_dir"] = "component-alias"
+    testf, config, inventory, components = _setup(
+        tmp_path, f, invfilter=True, alias="component-alias", aliased_output=True
     )
 
     postprocess_components(config, inventory, components)


### PR DESCRIPTION
Previously Commodore postprocessing filters had the hard-coded assumption that each component's output would appear in `compiled/<component-name>`. This is not necessarily true, e.g. when an instance-aware component creates individual ArgoCD apps and folders for each instance.

This PR introduces an optional parameter `output_dir` for postprocessing filter definitions which allows users to override the default directory in `compiled` in which Commodore applies postprocessing filters for the component.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Rebase after #353 has been merged
- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
