### PR TITLE
Fix postprocessing for instantiated components 

### DIFF
--- a/docs/modules/ROOT/pages/reference/architecture.adoc
+++ b/docs/modules/ROOT/pages/reference/architecture.adoc
@@ -229,8 +229,12 @@ For builtin filters, the `filter` field holds the name of the builtin filter.
 For jsonnet filters, the `filter` field holds a the path to the jsonnet file defining the filter.
 The path to the jsonnet filter is relative to the component repository.
 
+The field `path` is interpreted relative to the component instance's Kapitan output, which is always in `compiled/<instance-name>`.
+Therefore, field `path` needs to use the same prefix as is used for the entry in `parameters.kapitan.compile` for which the postprocessing filter should be applied.
+
 Filters can be disabled by setting the optional field `enabled` in the filter definition to `false`.
 If this field isn't present, filters are treated as enabled.
+
 
 A component can use the `helm_namespace` filter by providing the following filter configuration:
 

--- a/tests/test_postprocess.py
+++ b/tests/test_postprocess.py
@@ -30,7 +30,7 @@ def _make_ns_filter(ns, enabled=None):
 def _setup(tmp_path, filter, invfilter=False, alias="test-component"):
     test_run_component_new_command(tmp_path=tmp_path)
 
-    targetdir = tmp_path / "compiled" / "test-component" / "test"
+    targetdir = tmp_path / "compiled" / alias / "test"
     os.makedirs(targetdir, exist_ok=True)
     testf = targetdir / "object.yaml"
     with open(testf, "w") as objf:


### PR DESCRIPTION
Previously Commodore postprocessing filters had the hard-coded assumption that each component's output would appear in `compiled/<component-name>`. This is not true for instantiated components, whose output appears in `compiled/<instance-name>`.

This commit fixes the postprocessing implementation to correctly use `compiled/<instance-name>` rather than `compiled/<component-name>` as the base directory in which postprocessing filters are executed.

Replaces #355 
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
