### PR TITLE
Provide dynamic facts in Reclass hierarchy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ MAKEFLAGS += -j4
 docker_cmd  ?= docker
 docker_opts ?= --rm --tty --user "$$(id -u)"
 
-vale_cmd           ?= $(docker_cmd) run $(docker_opts) --volume "$${PWD}"/docs/modules/ROOT/pages:/pages vshn/vale:2.6.1 --minAlertLevel=error /pages
+vale_cmd           ?= $(docker_cmd) run $(docker_opts) --volume "$${PWD}"/docs/modules/ROOT/pages:/pages vshn/vale:2.6.1 --minAlertLevel=error --config=/pages/.vale.ini /pages
 antora_preview_cmd ?= $(docker_cmd) run --rm --publish 35729:35729 --publish 2020:2020 --volume "${PWD}":/preview/antora vshn/antora-preview:2.3.7 --style=syn --antora=docs
 
 UNAME := $(shell uname)

--- a/commodore/cluster.py
+++ b/commodore/cluster.py
@@ -1,6 +1,6 @@
 import os
 
-from typing import Iterable, Tuple, Dict, Optional, Union
+from typing import Any, Iterable, Tuple, Dict, Optional, Union
 
 import click
 
@@ -91,6 +91,10 @@ class Cluster:
     @property
     def facts(self) -> Dict[str, str]:
         return self._cluster.get("facts", {})
+
+    @property
+    def dynamic_facts(self) -> Dict[str, Any]:
+        return self._cluster.get("dynamicFacts", {})
 
 
 def load_cluster_from_api(cfg: Config, cluster_id: str) -> Cluster:
@@ -186,6 +190,7 @@ def update_target(cfg: Config, target: str, component: Optional[str] = None):
 
 def render_params(inv: Inventory, cluster: Cluster):
     facts = cluster.facts
+    dynfacts = cluster.dynamic_facts
     for fact in ["distribution", "cloud"]:
         if fact not in facts or not facts[fact]:
             raise click.ClickException(f"Required fact '{fact}' not set")
@@ -210,6 +215,7 @@ def render_params(inv: Inventory, cluster: Cluster):
                 "dist": facts["distribution"],
             },
             "facts": facts,
+            "dynamic_facts": dynfacts,
             # TODO Remove the cloud and customer parameters after deprecation phase.
             "cloud": cloud,
             "customer": {

--- a/commodore/cluster.py
+++ b/commodore/cluster.py
@@ -90,9 +90,7 @@ class Cluster:
 
     @property
     def facts(self) -> Dict[str, str]:
-        if "facts" not in self._cluster:
-            return {}
-        return self._cluster["facts"]
+        return self._cluster.get("facts", {})
 
 
 def load_cluster_from_api(cfg: Config, cluster_id: str) -> Cluster:

--- a/docs/modules/ROOT/pages/.vale.ini
+++ b/docs/modules/ROOT/pages/.vale.ini
@@ -1,0 +1,9 @@
+StylesPath = /styles
+MinAlertLevel = warning # suggestion, warning or error
+
+# Only check Asciidoc files
+[*.adoc]
+
+# Using the Microsoft style
+BasedOnStyles = Microsoft
+Microsoft.GenderBias = warning

--- a/docs/modules/ROOT/pages/reference/architecture.adoc
+++ b/docs/modules/ROOT/pages/reference/architecture.adoc
@@ -15,7 +15,7 @@ calls to the Lieutenant API.
 
 Commodore fetches the following dependencies:
 
-* Cluster facts from Lieutenant API
+* Static and dynamic cluster facts from Lieutenant API
 * Global configuration
 * Tenant configuration
 * Components as discovered in global and tenant configuration

--- a/docs/modules/ROOT/pages/reference/parameters.adoc
+++ b/docs/modules/ROOT/pages/reference/parameters.adoc
@@ -41,3 +41,30 @@ The Kubernetes distribution of the cluster.
 The cluster's dynamic facts as reported by Steward on the cluster.
 
 There are currently no mandatory dynamic facts.
+
+[NOTE]
+====
+Components shouldn't directly consume dynamic facts.
+Instead, components should expose a parameter which can be configured with a dynamic fact if information from dynamic facts should be used in a component.
+This minimizes the coupling between components and the presence of dynamic facts, and allows components to degrade gracefully when a dynamic fact is missing for a Project Syn installation.
+
+This could look something like
+
+.Component `defaults.yml`
+[source,yaml]
+----
+parameters:
+  component_name:
+    kubernetes_version: '1.20' <1>
+----
+<1> The component defaults to K8s version 1.20 when the parameter isn't overwritten in the configuration hierarchy
+
+.Project Syn global configuration repository
+[source,yaml]
+----
+parameters:
+  component_name:
+    kubernetes_version: '${dynamic_facts:kubernetes_version:major}.${dynamic_facts.kubernetes_version.minor}' <1>
+----
+<1> The parameter is overwritten using dynamic facts in the Project Syn installation's global configuration repository.
+====

--- a/docs/modules/ROOT/pages/reference/parameters.adoc
+++ b/docs/modules/ROOT/pages/reference/parameters.adoc
@@ -25,7 +25,7 @@ The cluster catalog Git repository URL.
 
 === `facts`
 
-The cluster's facts, as stored in the cluster's Lieutenant object.
+The cluster's static facts, as stored in the cluster's Lieutenant object.
 
 The following facts are mandatory:
 
@@ -35,3 +35,9 @@ The cloud region on which the cluster is installed.
 Mandatory only for clouds which have multiple regions.
 `distribution`::
 The Kubernetes distribution of the cluster.
+
+=== `dynamic_facts`
+
+The cluster's dynamic facts as reported by Steward on the cluster.
+
+There are currently no mandatory dynamic facts.

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -158,3 +158,15 @@ def test_facts(data):
     data["cluster"]["facts"] = facts.copy()
     cluster = Cluster(data["cluster"], data["tenant"])
     assert facts == cluster.facts
+
+
+def test_dynamic_facts(data):
+    cluster = Cluster(data["cluster"], data["tenant"])
+    assert {} == cluster.dynamic_facts
+
+    dynamic_facts = {
+        "kubernetes_version": {"major": "1", "minor": "21", "gitVersion": "v1.21.3"}
+    }
+    data["cluster"]["dynamicFacts"] = dynamic_facts.copy()
+    cluster = Cluster(data["cluster"], data["tenant"])
+    assert dynamic_facts == cluster.dynamic_facts

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -160,13 +160,45 @@ def test_facts(data):
     assert facts == cluster.facts
 
 
-def test_dynamic_facts(data):
+@pytest.mark.parametrize(
+    "dynamic_facts",
+    [
+        {
+            "kubernetes_version": {
+                "major": "1",
+                "minor": "21",
+                "gitVersion": "v1.21.3",
+            }
+        },
+        {
+            "kubernetes_version": {
+                "major": "1",
+                "minor": "20",
+                "gitVersion": "v1.20.0+558d959",
+            }
+        },
+        {
+            "kubernetes_version": {
+                "major": "1",
+                "minor": "20",
+                "gitVersion": "v1.20.7-eks-d88609",
+            }
+        },
+        {
+            "nodes": 20,
+            "node_labels": {
+                "node1": {"a": "a"},
+                "node2": {"b": "b"},
+                "node3": {"c": "c"},
+            },
+            "test_list": [1, 2, 3],
+        },
+    ],
+)
+def test_dynamic_facts(data, dynamic_facts):
     cluster = Cluster(data["cluster"], data["tenant"])
     assert {} == cluster.dynamic_facts
 
-    dynamic_facts = {
-        "kubernetes_version": {"major": "1", "minor": "21", "gitVersion": "v1.21.3"}
-    }
     data["cluster"]["dynamicFacts"] = dynamic_facts.copy()
     cluster = Cluster(data["cluster"], data["tenant"])
     assert dynamic_facts == cluster.dynamic_facts


### PR DESCRIPTION
Implement a new property `dynamic_facts` on the `Cluster` class and use this property to populate a new Reclass parameter
`parameters.dynamic_facts`.

This is in preparation to allow components to consume the cluster version as reported by Steward, cf. https://github.com/projectsyn/steward/issues/63

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
