### PR TITLE
Exclude jsonnet files from indent linter

### DIFF
--- a/commodore/component-template/{{ cookiecutter.slug }}/.editorconfig
+++ b/commodore/component-template/{{ cookiecutter.slug }}/.editorconfig
@@ -9,7 +9,7 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.{y*ml,*json*,*sonnet}]
+[*.{y*ml,*json}]
 indent_style = space
 indent_size = 2
 


### PR DESCRIPTION
`jsonnetfmt` already has a very opinionated formatter, which makes the linter superfluous and can lead to conflicts between `jsonnetfmt` and `editorconfig` linters.

See: https://github.com/projectsyn/component-backup-k8up/pull/36/checks?check_run_id=3221663321#step:3:10

It hit us again yesterday while onboarding https://github.com/projectsyn/component-system-upgrade-controller and today in https://github.com/projectsyn/component-kyverno. It is not possible to make both the jsonnet formatter and the editorconfig indent linter happy at the same time without ugly workarounds (putting everything in one line, append a character to the variable to get the correct indentation).

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
