### PR TITLE
Set explicit encoding to fix pylint warnings

### DIFF
--- a/commodore/component/__init__.py
+++ b/commodore/component/__init__.py
@@ -214,7 +214,7 @@ class Component:
                 str(jsonnetfile_jsonnet),
                 ext_vars=component_params.get("jsonnetfile_parameters", {}),
             )
-            with open(self._dir / "jsonnetfile.json", "w") as fp:
+            with open(self._dir / "jsonnetfile.json", "w", encoding="utf-8") as fp:
                 fp.write(output)
 
 

--- a/commodore/component/compile.py
+++ b/commodore/component/compile.py
@@ -55,7 +55,7 @@ def compile_component(
         _prepare_fake_inventory(inv, component, value_files)
 
         # Create class for fake parameters
-        with open(inv.params_file, "w") as file:
+        with open(inv.params_file, "w", encoding="utf-8") as file:
             file.write(
                 dedent(
                     f"""
@@ -85,7 +85,7 @@ def compile_component(
             )
 
         # Create test target
-        with open(inv.target_file(instance_name), "w") as file:
+        with open(inv.target_file(instance_name), "w", encoding="utf-8") as file:
             value_classes = "\n".join([f"- {c.stem}" for c in value_files])
             file.write(
                 dedent(
@@ -104,7 +104,7 @@ def compile_component(
         # Fake Argo CD lib
         # We plug "fake" Argo CD library here because every component relies on it
         # and we don't want to provide it every time when compiling a single component.
-        with open(inv.lib_dir / "argocd.libjsonnet", "w") as file:
+        with open(inv.lib_dir / "argocd.libjsonnet", "w", encoding="utf-8") as file:
             file.write(
                 dedent(
                     """

--- a/commodore/config.py
+++ b/commodore/config.py
@@ -98,7 +98,7 @@ class Config:
             try:
                 p = P(api_token)
                 if p.is_file():
-                    with open(p) as apitoken:
+                    with open(p, encoding="utf-8") as apitoken:
                         api_token = apitoken.read()
             except OSError as e:
                 # File name too long, assume token is not configured as file

--- a/commodore/dependency_mgmt.py
+++ b/commodore/dependency_mgmt.py
@@ -208,7 +208,7 @@ def write_jsonnetfile(file: P, deps: Iterable):
         "legacyImports": True,
     }
 
-    with open(file, "w") as f:
+    with open(file, "w", encoding="utf-8") as f:
         f.write(json.dumps(data, indent=4))
 
 
@@ -249,7 +249,7 @@ def inject_essential_libraries(file: P):
     Ensures essential libraries are added to `jsonnetfile.json`.
     :param file: The path to `jsonnetfile.json`.
     """
-    with open(file, "r") as f:
+    with open(file, "r", encoding="utf-8") as f:
         data = json.load(f)
 
     deps = data["dependencies"]
@@ -268,7 +268,7 @@ def inject_essential_libraries(file: P):
             },
         )
 
-    with open(file, "w") as j:
+    with open(file, "w", encoding="utf-8") as j:
         json.dump(data, j, indent=4)
 
 

--- a/commodore/helpers.py
+++ b/commodore/helpers.py
@@ -44,7 +44,7 @@ def yaml_load(file):
     """
     Load single-document YAML and return document
     """
-    with open(file, "r") as f:
+    with open(file, "r", encoding="utf-8") as f:
         return yaml.safe_load(f)
 
 
@@ -52,7 +52,7 @@ def yaml_load_all(file):
     """
     Load multi-document YAML and return documents in list
     """
-    with open(file, "r") as f:
+    with open(file, "r", encoding="utf-8") as f:
         return list(yaml.safe_load_all(f))
 
 
@@ -78,7 +78,7 @@ def yaml_dump(obj, file):
     Dump obj as single-document YAML
     """
     yaml.add_representer(str, _represent_str)
-    with open(file, "w") as outf:
+    with open(file, "w", encoding="utf-8") as outf:
         yaml.dump(obj, outf)
 
 
@@ -87,7 +87,7 @@ def yaml_dump_all(obj, file):
     Dump obj as multi-document YAML
     """
     yaml.add_representer(str, _represent_str)
-    with open(file, "w") as outf:
+    with open(file, "w", encoding="utf-8") as outf:
         yaml.dump_all(obj, outf)
 
 

--- a/commodore/postprocess/jsonnet.py
+++ b/commodore/postprocess/jsonnet.py
@@ -28,7 +28,7 @@ def _try_path(basedir: P, rel: str):
 
     if not full_path.is_file():
         return full_path.name, None
-    with open(full_path) as f:
+    with open(full_path, encoding="utf-8") as f:
         return full_path.name, f.read()
 
 


### PR DESCRIPTION
This PR fixes newly added pylint warnings:

```
commodore/helpers.py:47:9: W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
```

Should we start to pin `pylint` to a fixed version?

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
