### PR TITLE
Update compile make targets in component template to support components with library

### DIFF
--- a/commodore/component-template/{{ cookiecutter.slug }}/Makefile
+++ b/commodore/component-template/{{ cookiecutter.slug }}/Makefile
@@ -46,7 +46,7 @@ docs-serve: ## Preview the documentation
 	$(COMMODORE_CMD)
 
 .PHONY: test
-test: commodore_args = -f tests/$(instance).yml --search-paths ./dependencies
+test: commodore_args += -f tests/$(instance).yml
 test: .compile ## Compile the component
 
 .PHONY: clean

--- a/commodore/component-template/{{ cookiecutter.slug }}/Makefile.vars.mk
+++ b/commodore/component-template/{{ cookiecutter.slug }}/Makefile.vars.mk
@@ -4,6 +4,7 @@ COMPONENT_NAME ?= $(shell basename ${PWD} | sed s/component-//)
 compiled_path   ?= compiled/$(COMPONENT_NAME)/$(COMPONENT_NAME)
 root_volume     ?= -v "$${PWD}:/$(COMPONENT_NAME)"
 compiled_volume ?= -v "$${PWD}/$(compiled_path):/$(COMPONENT_NAME)"
+commodore_args  ?= --search-paths ./dependencies --search-paths .
 
 DOCKER_CMD   ?= docker
 DOCKER_ARGS  ?= run --rm -u "$$(id -u)" -w /$(COMPONENT_NAME)


### PR DESCRIPTION
Default search paths for component compilation to `./dependencies` and the component directory. This ensures that the component's own component lib can be found during component compilation.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
