### PR TITLE
Use f-strings for repo_url errors in `Cluster` class

### DIFF
--- a/commodore/cluster.py
+++ b/commodore/cluster.py
@@ -61,8 +61,7 @@ class Cluster:
         repo_url = self._tenant.get("gitRepo", {}).get("url", None)
         if repo_url is None:
             raise click.ClickException(
-                " > API did not return a repository URL for tenant '%s'"
-                % self._cluster["tenant"]
+                f" > API did not return a repository URL for tenant '{self._cluster['tenant']}'"
             )
         return repo_url
 
@@ -75,8 +74,7 @@ class Cluster:
         repo_url = self._cluster.get("gitRepo", {}).get("url", None)
         if repo_url is None:
             raise click.ClickException(
-                " > API did not return a repository URL for cluster '%s'"
-                % self._cluster["id"]
+                f" > API did not return a repository URL for cluster '{self._cluster['id']}'"
             )
         return repo_url
 


### PR DESCRIPTION
Pylint now suggests f-strings over regular string formatting, cf. https://github.com/projectsyn/commodore/pull/368/checks?check_run_id=3675123805

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
