### PR TITLE
Ensure Commodore exits with exit code 1 on catalog push failures

### DIFF
--- a/commodore/catalog.py
+++ b/commodore/catalog.py
@@ -69,6 +69,49 @@ def clean_catalog(repo):
         rm_tree_contents(repo.working_tree_dir)
 
 
+def _push_catalog(cfg: Config, repo, commit_message):
+    """Push catalog to catalog repo if conditions to allow push are met.
+
+    Conditions to allow pushing are:
+    * Commodore doesn't run in local mode
+    * User has requested pushing with `--push`
+
+    Ask user to confirm push if `--interactive` is specified
+    """
+    if not cfg.local:
+        if cfg.interactive and cfg.push:
+            cfg.push = click.confirm(" > Should the push be done?")
+
+        if cfg.push:
+            click.echo(" > Commiting changes...")
+            git.commit(repo, commit_message, cfg)
+            click.echo(" > Pushing catalog to remote...")
+            try:
+                pushinfos = repo.remotes.origin.push()
+            except git.GitCommandError as e:
+                raise click.ClickException(
+                    "Failed to push to the catalog repository: "
+                    + f"Git exited with status code {e.status}"
+                ) from e
+            for pi in pushinfos:
+                # Any error has pi.ERROR set in the `flags` bitmask
+                # We just forward the summary from the pushinfo
+                summary = pi.summary.strip()
+                if (pi.flags & pi.ERROR) != 0:
+                    raise click.ClickException(
+                        f"Failed to push to the catalog repository: {summary}"
+                    )
+        else:
+            click.echo(" > Skipping commit+push to catalog...")
+            click.echo(" > Use flag --push to commit and push the catalog repo")
+            click.echo(
+                " > Add flag --interactive to show the diff and decide on the push"
+            )
+    else:
+        repo.head.reset(working_tree=False)
+        click.echo(" > Skipping commit+push to catalog in local mode...")
+
+
 def update_catalog(cfg: Config, targets: Iterable[str], repo):
     click.secho("Updating catalog repository...", bold=True)
     # pylint: disable=import-outside-toplevel
@@ -92,38 +135,7 @@ def update_catalog(cfg: Config, targets: Iterable[str], repo):
         click.echo(" > Commit message will be")
         click.echo(textwrap.indent(commit_message, "   "))
     if changed:
-        if not cfg.local:
-            if cfg.interactive and cfg.push:
-                cfg.push = click.confirm(" > Should the push be done?")
-
-            if cfg.push:
-                click.echo(" > Commiting changes...")
-                git.commit(repo, commit_message, cfg)
-                click.echo(" > Pushing catalog to remote...")
-                try:
-                    pushinfos = repo.remotes.origin.push()
-                except git.GitCommandError as e:
-                    raise click.ClickException(
-                        "Failed to push to the catalog repository: " +
-                        f"Git exited with status code {e.status}"
-                    ) from e
-                for pi in pushinfos:
-                    # Any error has pi.ERROR set in the `flags` bitmask
-                    # We just forward the summary from the pushinfo
-                    summary = pi.summary.strip()
-                    if (pi.flags & pi.ERROR) != 0:
-                        raise click.ClickException(
-                            f"Failed to push to the catalog repository: {summary}"
-                        )
-            else:
-                click.echo(" > Skipping commit+push to catalog...")
-                click.echo(" > Use flag --push to commit and push the catalog repo")
-                click.echo(
-                    " > Add flag --interactive to show the diff and decide on the push"
-                )
-        else:
-            repo.head.reset(working_tree=False)
-            click.echo(" > Skipping commit+push to catalog in local mode...")
+        _push_catalog(cfg, repo, commit_message)
     else:
         click.echo(" > Skipping commit+push to catalog...")
 


### PR DESCRIPTION
Fixes #370 

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
