### PR TITLE
Correctly inject Git version in CI package builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,12 +58,12 @@ docker:
 inject-version:
 	@if [ -n "${CI}" ]; then\
 		echo "In CI";\
-		echo "GITVERSION=${GITVERSION}" >> "${GITHUB_ENV}";\
 		echo "PYVERSION=${PYVERSION}" >> "${GITHUB_ENV}";\
 	else\
-		sed -i "s/^__git_version__.*$$/__git_version__ = '${GITVERSION}'/" commodore/__init__.py;\
 		poetry version "${PYVERSION}";\
 	fi
+	# Always inject Git version
+	sed -i "s/^__git_version__.*$$/__git_version__ = '${GITVERSION}'/" commodore/__init__.py
 
 .PHONY: test_integration
 test_integration:


### PR DESCRIPTION
We always want to set the variable `__git_version__` in `commodore/__init__.py` to the Git version generated with `git describe` in make target `inject-version`, since we don't actually do this in the "Publish to PyPI" GitHub action.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
