### PR TITLE
Fix unit tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Extract Python minor version from matrix python-version
       run: echo "PYVER=$(echo ${{ matrix.python-version}} |cut -d. -f1,2)" >> $GITHUB_ENV
     - name: Run tests on Python ${{ matrix.python-version }}
-      run: make bench_py${PYVER}
+      run: make test_py${PYVER}
   benchs:
     runs-on: ubuntu-latest
     strategy:

--- a/tests/test_component_compile.py
+++ b/tests/test_component_compile.py
@@ -15,11 +15,11 @@ from git import Repo
 from commodore.config import Config
 from commodore.component import component_parameters_key
 from commodore.component.compile import compile_component
-from test_component_template import test_run_component_new_command
+from test_component_template import call_component_new
 
 
 def _prepare_component(tmp_path, component_name="test-component"):
-    test_run_component_new_command(tmp_path=tmp_path)
+    call_component_new(tmp_path)
 
     with open(
         tmp_path / "dependencies" / component_name / "component/main.jsonnet", "a"

--- a/tests/test_component_template.py
+++ b/tests/test_component_template.py
@@ -11,6 +11,21 @@ from git import Repo
 from test_component import setup_directory
 
 
+def call_component_new(
+    tmp_path: P,
+    component_name="test-component",
+    lib="--no-lib",
+    pp="--no-pp",
+    golden="--no-golden-tests",
+    matrix="--no-matrix-tests",
+):
+    exit_status = call(
+        f"commodore -d '{tmp_path}' -vvv component new {component_name} {lib} {pp} {golden} {matrix}",
+        shell=True,
+    )
+    assert exit_status == 0
+
+
 @pytest.mark.parametrize("lib", ["--no-lib", "--lib"])
 @pytest.mark.parametrize(
     "pp",
@@ -34,11 +49,14 @@ def test_run_component_new_command(
     setup_directory(tmp_path)
 
     component_name = "test-component"
-    exit_status = call(
-        f"commodore -d '{tmp_path}' -vvv component new {component_name} {lib} {pp} {golden} {matrix}",
-        shell=True,
+    call_component_new(
+        tmp_path,
+        component_name=component_name,
+        lib=lib,
+        pp=pp,
+        golden=golden,
+        matrix=matrix,
     )
-    assert exit_status == 0
 
     expected_files = [
         P("README.md"),

--- a/tests/test_postprocess.py
+++ b/tests/test_postprocess.py
@@ -9,7 +9,7 @@ from textwrap import dedent
 from commodore.config import Config
 from commodore.component import Component
 from commodore.postprocess import postprocess_components
-from test_component_template import test_run_component_new_command
+from test_component_template import call_component_new
 
 
 def _make_builtin_filter(ns, enabled=None):
@@ -156,7 +156,7 @@ def _expected_ns(enabled):
 @pytest.mark.parametrize("alias", ["test-component", "component-alias"])
 @pytest.mark.parametrize("jsonnet", [False, True])
 def test_postprocess_components(tmp_path, capsys, enabled, invfilter, jsonnet, alias):
-    test_run_component_new_command(tmp_path=tmp_path)
+    call_component_new(tmp_path=tmp_path)
 
     f = _make_ns_filter(
         tmp_path, "myns", enabled=enabled, jsonnet=jsonnet, invfilter=invfilter
@@ -186,7 +186,7 @@ def test_postprocess_components(tmp_path, capsys, enabled, invfilter, jsonnet, a
 # render the inventory with reclass in the test above.
 @pytest.mark.parametrize("enabledref", [True, False])
 def test_postprocess_components_enabledref(tmp_path, capsys, enabledref):
-    test_run_component_new_command(tmp_path=tmp_path)
+    call_component_new(tmp_path=tmp_path)
 
     f = _make_builtin_filter("myns", enabled="${test_component:filter:enabled}")
 


### PR DESCRIPTION
#358, commit https://github.com/projectsyn/commodore/commit/8670c014bb1cf4b583965a70ed2a5dc65f99c42c, introduced a copy-paste error in the test GitHub action, which from then on mistakenly ran the `bench` target instead of the `test` target.

As a consequence we didn't catch some test failures in #364.

This PR fixes both the copy-paste error in the action and the broken tests.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
