### PR TITLE
Add CLI command to extract component versions and URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,13 @@
 ## Ignore commodore output
-catalog
-compiled
-dependencies
-inventory
+/catalog
+/compiled
+/dependencies
+/inventory
 
 ## jsonnet-bundler
 
 jsonnetfile.*
-vendor/
+/vendor
 
 ## From here: GitHub's gitignore template for Python
 # Byte-compiled / optimized / DLL files

--- a/commodore/cli.py
+++ b/commodore/cli.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import Optional
+from typing import Iterable
 
 import click
 import yaml
@@ -361,29 +361,29 @@ def inventory(config: Config, verbose):
     short_help="Extract component URLs and versions from the inventory",
 )
 @click.option(
-    "-d",
-    "--distribution",
-    metavar="DIST",
-    help="Specify the distribution for which to extract component versions",
-)
-@click.option(
-    "-c",
-    "--cloud",
-    metavar="CLOUD",
-    help="Specify the cloud provider for which to extract component versions",
-)
-@click.option(
-    "-r",
-    "--cloud-region",
-    metavar="REGION",
-    help="Specify the cloud region for which to extract component versions",
-)
-@click.option(
     "-o",
     "--output-format",
     help="Output format",
     type=click.Choice(["json", "yaml"]),
     default="yaml",
+)
+@click.option(
+    "-f",
+    "--values",
+    help=(
+        "Extra values file to use when rendering inventory. "
+        + "Used as additional reclass class. "
+        + "Use a values file to specify any cluster facts. "
+        + "Can be repeated."
+    ),
+    multiple=True,
+    type=click.Path(exists=True, file_okay=True, dir_okay=False, path_type=Path),
+)
+@click.option(
+    " / -A",
+    "--allow-missing-classes/--no-allow-missing-classes",
+    default=True,
+    help="Whether to allow missing classes when rendering the inventory. Defaults to true.",
 )
 @click.argument("global-config")
 @verbosity
@@ -393,16 +393,15 @@ def component_versions(
     config: Config,
     verbose,
     global_config: str,
-    distribution: Optional[str],
-    cloud: Optional[str],
-    cloud_region: Optional[str],
     output_format: str,
+    values: Iterable[Path],
+    allow_missing_classes: bool,
 ):
     config.update_verbosity(verbose)
     try:
         components = extract_components(
             config,
-            InventoryFacts(global_config, None, distribution, cloud, cloud_region),
+            InventoryFacts(global_config, None, values, allow_missing_classes),
         )
     except ValueError as e:
         raise click.ClickException(f"While extracting components: {e}") from e

--- a/commodore/cli.py
+++ b/commodore/cli.py
@@ -379,9 +379,6 @@ def inventory(config: Config, verbose):
     help="Specify the cloud region for which to extract component versions",
 )
 @click.option(
-    "-t", "--tenant-config", help="URL or path to tenant repo", metavar="URL/PATH"
-)
-@click.option(
     "-o",
     "--output-format",
     help="Output format",
@@ -399,16 +396,13 @@ def component_versions(
     distribution: Optional[str],
     cloud: Optional[str],
     cloud_region: Optional[str],
-    tenant_config: Optional[str],
     output_format: str,
 ):
     config.update_verbosity(verbose)
     try:
         components = extract_components(
             config,
-            InventoryFacts(
-                global_config, tenant_config, distribution, cloud, cloud_region
-            ),
+            InventoryFacts(global_config, None, distribution, cloud, cloud_region),
         )
     except ValueError as e:
         raise click.ClickException(f"While extracting components: {e}") from e

--- a/commodore/inventory/__init__.py
+++ b/commodore/inventory/__init__.py
@@ -1,5 +1,4 @@
 from os import makedirs
-
 from pathlib import Path as P
 from typing import Union
 

--- a/commodore/inventory/parameters.py
+++ b/commodore/inventory/parameters.py
@@ -1,11 +1,12 @@
 import os
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, Iterable, Optional
+from typing import Any, Dict, Iterable, List, Optional
 
 from kapitan.reclass import reclass
 from kapitan.reclass.reclass import settings as reclass_settings
 from kapitan.reclass.reclass import core as reclass_core
+from kapitan.reclass.reclass import errors as reclass_errors
 
 from commodore.cluster import Cluster, render_params
 from commodore.component import component_parameters_key
@@ -13,58 +14,80 @@ from commodore.helpers import yaml_dump
 from commodore.inventory import Inventory
 
 
+class ClassNotFound(reclass_errors.ClassNotFound):
+    """
+    Create a wrapper around kapitan.reclass's ClassNotFound exception.
+
+    This allows us to have clean exception handling outside of this file, because we
+    unfortunately can't catch ClassNotFound directly in our code if we import
+    and use Kapitan reclass's ClassNotFound with any import which doesn't map the class
+    to `reclass.errors.ClassNotFound`. This is the case because Python's implementation
+    doesn't try to figure out if two imports are the same if they have different import
+    paths, cf. https://docs.python.org/3/reference/import.html.
+
+    The only import that should work (in my understanding) would be
+    `from kapitan.reclass import reclass` but with that import we get the error
+    "AttributeError: module 'kapitan.reclass.reclass' has no attribute 'errors'"
+    """
+
+    @classmethod
+    def from_reclass(cls, e: reclass_errors.ClassNotFound):
+        """Wrap a reclass.errors.ClassNotFound instance in our wrapper."""
+        return ClassNotFound(e.storage, e.name, e.path)
+
+
 class InventoryFacts:
-    # pylint: disable=too-many-arguments
-    def __init__(self, global_config, tenant_config, distribution, cloud, region):
+    def __init__(
+        self,
+        global_config: str,
+        tenant_config: Optional[str],
+        extra_class_files: Iterable[Path],
+        allow_missing_classes: bool,
+    ):
         self._global_config = global_config
         self._tenant_config = tenant_config
-        self._distribution = distribution
-        self._cloud = cloud
-        self._region = region
+        self._extra_class_files = extra_class_files
+        self._allow_missing_classes = allow_missing_classes
 
     @property
-    def global_config(self):
+    def global_config(self) -> str:
         return self._global_config
 
     @property
-    def tenant_config(self):
+    def tenant_config(self) -> Optional[str]:
         return self._tenant_config
 
     @property
-    def distribution(self):
-        return self._distribution
+    def extra_classes(self) -> List[str]:
+        return [cf.stem for cf in self._extra_class_files]
 
     @property
-    def cloud(self):
-        return self._cloud
+    def extra_class_files(self) -> Iterable[Path]:
+        return self._extra_class_files
 
     @property
-    def region(self):
-        return self._region
+    def allow_missing_classes(self) -> bool:
+        return self._allow_missing_classes
 
 
 class InventoryParameters:
-    def __init__(self, inv, node, invfacts: InventoryFacts):
+    def __init__(self, inv):
         self._inventory = inv
-        self._node = node
-        self._distribution = invfacts.distribution
-        self._cloud = invfacts.cloud
-        self._region = invfacts.region
 
     @property
     def distribution(self):
-        return self._distribution
+        return self._inventory["parameters"]["facts"]["distribution"]
 
     @property
     def cloud(self):
-        return self._cloud
+        return self._inventory["parameters"]["facts"]["cloud"]
 
     @property
     def region(self):
-        return self._region
+        return self._inventory["parameters"]["facts"]["region"]
 
     def parameters(self, param: Optional[str] = None):
-        params = self._inventory["nodes"][self._node]["parameters"]
+        params = self._inventory["parameters"]
         if param is not None:
             params = params.get(component_parameters_key(param), {})
 
@@ -72,7 +95,7 @@ class InventoryParameters:
 
     @property
     def applications(self):
-        return self._inventory["nodes"][self._node]["applications"]
+        return self._inventory["applications"]
 
 
 class DefaultsFact(Enum):
@@ -82,6 +105,9 @@ class DefaultsFact(Enum):
 
 
 class InventoryFactory:
+    _FAKE_TENANT_ID = "t-foo"
+    _FAKE_CLUSTER_ID = "c-bar"
+
     def __init__(self, work_dir: Path, global_dir: Path):
         self._global_dir = global_dir
         self._inventory = Inventory(work_dir=work_dir)
@@ -108,7 +134,7 @@ class InventoryFactory:
     def global_dir(self) -> Path:
         return self._global_dir
 
-    def _reclass_config(self) -> Dict:
+    def _reclass_config(self, allow_missing_classes: bool) -> Dict:
         return {
             "storage_type": "yaml_fs",
             "inventory_base_uri": str(self.directory.absolute()),
@@ -116,65 +142,13 @@ class InventoryFactory:
             "classes_uri": str(self.classes_dir.absolute()),
             "compose_node_name": False,
             "allow_none_override": True,
-            "ignore_class_notfound": True,
+            "ignore_class_notfound": allow_missing_classes,
         }
 
-    def reclass(self, invfacts: InventoryFacts) -> InventoryParameters:
-        distribution = invfacts.distribution
-        cloud = invfacts.cloud
-        region = invfacts.region
-        if distribution is None:
-            distribution = "x-fake-distribution"
-        if cloud is None:
-            cloud = "x-fake-cloud"
-        if region is None:
-            region = "x-fake-region"
-
-        c: Dict[str, Any] = {
-            "id": "c-bar",
-            "tenant": "t-foo",
-            "displayName": "Foo Inc. Bar cluster",
-            "facts": {
-                "distribution": distribution,
-                "cloud": cloud,
-                "lieutenant-instance": "lieutenant-prod",
-                f"{distribution}_version": "1.20",
-            },
-            "gitRepo": {
-                "url": "not-a-real-repo",
-            },
-        }
-        if region:
-            c["facts"]["region"] = region
-
-        cluster = Cluster(
-            cluster_response=c,
-            tenant_response={
-                "id": "t-foo",
-                "displayName": "Foo Inc.",
-                "gitRepo": {
-                    "url": "not-a-real-repo",
-                },
-            },
-        )
-        params = render_params(self._inventory, cluster)
-        # don't support legacy component_versions key
-        del params["parameters"]["components"]
-        del params["parameters"]["component_versions"]
-        params["parameters"]["openshift"] = {
-            "infraID": "infra-id",
-            "clusterID": "cluster-id",
-            "registryBucket": "x-fake-registry-bucket",
-        }
-        params["parameters"]["cloud"]["availabilityZones"] = []
-        params["parameters"]["cloud"]["projectName"] = "x-fake-project"
-
-        yaml_dump(params, self.classes_dir / "target.yml")
-        yaml_dump(
-            {"classes": ["target", "global.commodore"]},
-            self.targets_dir / "global.yml",
-        )
-        rc = self._reclass_config()
+    def _render_inventory(
+        self, target: Optional[str] = None, allow_missing_classes: bool = True
+    ) -> Dict[str, Any]:
+        rc = self._reclass_config(allow_missing_classes)
         storage = reclass.get_storage(
             rc["storage_type"],
             rc["nodes_uri"],
@@ -185,10 +159,78 @@ class InventoryFactory:
         _reclass = reclass_core.Core(
             storage, class_mappings, reclass_settings.Settings(rc)
         )
+
+        try:
+            if target:
+                return _reclass.nodeinfo(target)
+
+            return _reclass.inventory()
+        except Exception as e:
+            if type(e).__name__ == "ClassNotFound":
+                # Wrap Kapitan reclass's ClassNotFound with ours so we can cleanly
+                # catch it. See docsstring for our ClassNotFound for a more detailed
+                # explanation why this is necessary.
+                raise ClassNotFound.from_reclass(e)
+            raise
+
+    def reclass(self, invfacts: InventoryFacts) -> InventoryParameters:
+        cluster_response: Dict[str, Any] = {
+            "id": self._FAKE_CLUSTER_ID,
+            "tenant": self._FAKE_TENANT_ID,
+            "displayName": "Foo Inc. Bar cluster",
+            "facts": {
+                "distribution": "x-fake-distribution",
+                "cloud": "x-fake-cloud",
+                "region": "x-fake-region",
+                "lieutenant-instance": "lieutenant-prod",
+            },
+            "gitRepo": {
+                "url": "not-a-real-repo",
+            },
+        }
+        cluster = Cluster(
+            cluster_response=cluster_response,
+            tenant_response={
+                "id": self._FAKE_TENANT_ID,
+                "displayName": "Foo Inc.",
+                "gitRepo": {
+                    "url": "not-a-real-repo",
+                },
+            },
+        )
+        params = render_params(self._inventory, cluster)
+
+        # Don't support legacy component_versions key
+        # TODO: remove this when implementing issue #375
+        del params["parameters"]["components"]
+        del params["parameters"]["component_versions"]
+
+        yaml_dump(params, self.classes_dir / "base.yml")
+
+        # Create the following fake hierarchy for the render target:
+        # classes:
+        # - base
+        # - user-supplied-file-1
+        # - user-supplied-file-2
+        # - ...
+        # - global.commodore
+        classes = ["base"] + invfacts.extra_classes + ["global.commodore"]
+        yaml_dump(
+            {"classes": classes},
+            self.targets_dir / "global.yml",
+        )
+
+        # Create fake cluster class, this allows rendering the inventory with
+        # allow-missing-classes=False to work.
+        yaml_dump(
+            {},
+            self.classes_dir / self._FAKE_TENANT_ID / f"{self._FAKE_CLUSTER_ID}.yml",
+        )
+
         return InventoryParameters(
-            _reclass.inventory(),
-            "global",
-            InventoryFacts(None, None, distribution, cloud, region),
+            self._render_inventory(
+                "global", allow_missing_classes=invfacts.allow_missing_classes
+            )
         )
 
     def _find_values(self, fact: DefaultsFact, cloud: str = None) -> Iterable[str]:
@@ -219,11 +261,15 @@ class InventoryFactory:
     @classmethod
     def _make_directories(cls, work_dir: Path):
         os.makedirs(work_dir / "inventory" / "targets", exist_ok=True)
-        os.makedirs(work_dir / "inventory" / "classes", exist_ok=True)
+        os.makedirs(
+            work_dir / "inventory" / "classes" / cls._FAKE_TENANT_ID, exist_ok=True
+        )
 
     @classmethod
-    def from_repo_dir(cls, work_dir: Path, global_dir: Path):
+    def from_repo_dir(cls, work_dir: Path, global_dir: Path, invfacts: InventoryFacts):
         cls._make_directories(work_dir)
         classes_dir = work_dir / "inventory" / "classes"
         os.symlink(global_dir.absolute(), classes_dir / "global")
+        for cf in invfacts.extra_class_files:
+            os.symlink(cf.absolute(), classes_dir / cf.name)
         return InventoryFactory(work_dir=work_dir, global_dir=classes_dir / "global")

--- a/commodore/inventory/parameters.py
+++ b/commodore/inventory/parameters.py
@@ -82,8 +82,8 @@ class DefaultsFact(Enum):
 
 
 class InventoryFactory:
-    def __init__(self, work_dir: Path, repo_dir: Path):
-        self._repo = repo_dir
+    def __init__(self, work_dir: Path, global_dir: Path):
+        self._global_dir = global_dir
         self._inventory = Inventory(work_dir=work_dir)
         self._distributions = self._find_values(DefaultsFact.DISTRIBUTION)
         self._clouds = self._find_values(DefaultsFact.CLOUD)
@@ -105,8 +105,8 @@ class InventoryFactory:
         return self._inventory.targets_dir
 
     @property
-    def repo(self) -> Path:
-        return self._repo
+    def global_dir(self) -> Path:
+        return self._global_dir
 
     def _reclass_config(self) -> Dict:
         return {
@@ -193,11 +193,11 @@ class InventoryFactory:
 
     def _find_values(self, fact: DefaultsFact, cloud: str = None) -> Iterable[str]:
         values = []
-        value_path = self.repo / fact.value
+        value_path = self.global_dir / fact.value
         if fact == DefaultsFact.REGION:
             if not cloud:
                 raise ValueError(f"cloud must not be None if fact is {fact}")
-            value_path = self.repo / "cloud" / cloud
+            value_path = self.global_dir / "cloud" / cloud
         if value_path.is_dir():
             for f in value_path.iterdir():
                 if f.is_file() and f.suffix in (".yml", ".yaml"):
@@ -222,8 +222,8 @@ class InventoryFactory:
         os.makedirs(work_dir / "inventory" / "classes", exist_ok=True)
 
     @classmethod
-    def from_repo_dir(cls, work_dir: Path, repo_dir: Path):
+    def from_repo_dir(cls, work_dir: Path, global_dir: Path):
         cls._make_directories(work_dir)
         classes_dir = work_dir / "inventory" / "classes"
-        os.symlink(repo_dir.absolute(), classes_dir / "global")
-        return InventoryFactory(work_dir=work_dir, repo_dir=classes_dir / "global")
+        os.symlink(global_dir.absolute(), classes_dir / "global")
+        return InventoryFactory(work_dir=work_dir, global_dir=classes_dir / "global")

--- a/commodore/inventory/parameters.py
+++ b/commodore/inventory/parameters.py
@@ -1,0 +1,229 @@
+import os
+from enum import Enum
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional
+
+from kapitan.reclass import reclass
+from kapitan.reclass.reclass import settings as reclass_settings
+from kapitan.reclass.reclass import core as reclass_core
+
+from commodore.cluster import Cluster, render_params
+from commodore.component import component_parameters_key
+from commodore.helpers import yaml_dump
+from commodore.inventory import Inventory
+
+
+class InventoryFacts:
+    # pylint: disable=too-many-arguments
+    def __init__(self, global_config, tenant_config, distribution, cloud, region):
+        self._global_config = global_config
+        self._tenant_config = tenant_config
+        self._distribution = distribution
+        self._cloud = cloud
+        self._region = region
+
+    @property
+    def global_config(self):
+        return self._global_config
+
+    @property
+    def tenant_config(self):
+        return self._tenant_config
+
+    @property
+    def distribution(self):
+        return self._distribution
+
+    @property
+    def cloud(self):
+        return self._cloud
+
+    @property
+    def region(self):
+        return self._region
+
+
+class InventoryParameters:
+    def __init__(self, inv, node, invfacts: InventoryFacts):
+        self._inventory = inv
+        self._node = node
+        self._distribution = invfacts.distribution
+        self._cloud = invfacts.cloud
+        self._region = invfacts.region
+
+    @property
+    def distribution(self):
+        return self._distribution
+
+    @property
+    def cloud(self):
+        return self._cloud
+
+    @property
+    def region(self):
+        return self._region
+
+    def parameters(self, param: Optional[str] = None):
+        params = self._inventory["nodes"][self._node]["parameters"]
+        if param is not None:
+            params = params.get(component_parameters_key(param), {})
+
+        return params
+
+    @property
+    def applications(self):
+        return self._inventory["nodes"][self._node]["applications"]
+
+
+class DefaultsFact(Enum):
+    DISTRIBUTION = "distribution"
+    CLOUD = "cloud"
+    REGION = "region"
+
+
+class InventoryFactory:
+    def __init__(self, work_dir: Path, repo_dir: Path):
+        self._repo = repo_dir
+        self._inventory = Inventory(work_dir=work_dir)
+        self._distributions = self._find_values(DefaultsFact.DISTRIBUTION)
+        self._clouds = self._find_values(DefaultsFact.CLOUD)
+        self._cloud_regions: Dict[str, Iterable[str]] = {}
+        for cloud in self._clouds:
+            r = self._find_values(DefaultsFact.REGION, cloud=cloud)
+            self._cloud_regions[cloud] = [it for it in r if it != "params"]
+
+    @property
+    def directory(self) -> Path:
+        return self._inventory.inventory_dir
+
+    @property
+    def classes_dir(self) -> Path:
+        return self._inventory.classes_dir
+
+    @property
+    def targets_dir(self) -> Path:
+        return self._inventory.targets_dir
+
+    @property
+    def repo(self) -> Path:
+        return self._repo
+
+    def _reclass_config(self) -> Dict:
+        return {
+            "storage_type": "yaml_fs",
+            "inventory_base_uri": str(self.directory.absolute()),
+            "nodes_uri": str(self.targets_dir.absolute()),
+            "classes_uri": str(self.classes_dir.absolute()),
+            "compose_node_name": False,
+            "allow_none_override": True,
+            "ignore_class_notfound": True,
+        }
+
+    def reclass(self, invfacts: InventoryFacts) -> InventoryParameters:
+        distribution = invfacts.distribution
+        cloud = invfacts.cloud
+        region = invfacts.region
+        if distribution is None:
+            distribution = "x-fake-distribution"
+        if cloud is None:
+            cloud = "x-fake-cloud"
+        if region is None:
+            region = "x-fake-region"
+
+        c: Dict[str, Any] = {
+            "id": "c-bar",
+            "tenant": "t-foo",
+            "displayName": "Foo Inc. Bar cluster",
+            "facts": {
+                "distribution": distribution,
+                "cloud": cloud,
+                "lieutenant-instance": "lieutenant-prod",
+                f"{distribution}_version": "1.20",
+            },
+            "gitRepo": {
+                "url": "not-a-real-repo",
+            },
+        }
+        if region:
+            c["facts"]["region"] = region
+
+        cluster = Cluster(
+            cluster_response=c,
+            tenant_response={
+                "id": "t-foo",
+                "displayName": "Foo Inc.",
+                "gitRepo": {
+                    "url": "not-a-real-repo",
+                },
+            },
+        )
+        params = render_params(self._inventory, cluster)
+        # don't support legacy component_versions key
+        del params["parameters"]["components"]
+        del params["parameters"]["component_versions"]
+        params["parameters"]["openshift"] = {
+            "infraID": "infra-id",
+            "clusterID": "clutster-id",
+            "registryBucket": "x-fake-registry-bucket",
+        }
+        params["parameters"]["cloud"]["availabilityZones"] = []
+        params["parameters"]["cloud"]["projectName"] = "x-fake-project"
+
+        yaml_dump(params, self.classes_dir / "target.yml")
+        yaml_dump(
+            {"classes": ["target", "global.commodore"]},
+            self.targets_dir / "global.yml",
+        )
+        rc = self._reclass_config()
+        storage = reclass.get_storage(
+            rc["storage_type"],
+            rc["nodes_uri"],
+            rc["classes_uri"],
+            rc["compose_node_name"],
+        )
+        class_mappings = rc.get("class_mappings")
+        _reclass = reclass_core.Core(
+            storage, class_mappings, reclass_settings.Settings(rc)
+        )
+        return InventoryParameters(
+            _reclass.inventory(),
+            "global",
+            InventoryFacts(None, None, distribution, cloud, region),
+        )
+
+    def _find_values(self, fact: DefaultsFact, cloud: str = None) -> Iterable[str]:
+        values = []
+        value_path = self.repo / fact.value
+        if fact == DefaultsFact.REGION:
+            if not cloud:
+                raise ValueError(f"cloud must not be None if fact is {fact}")
+            value_path = self.repo / "cloud" / cloud
+        if value_path.is_dir():
+            for f in value_path.iterdir():
+                if f.is_file() and f.suffix in (".yml", ".yaml"):
+                    values.append(f.stem)
+        return values
+
+    @property
+    def distributions(self) -> Iterable[str]:
+        return self._distributions
+
+    @property
+    def clouds(self) -> Iterable[str]:
+        return self._clouds
+
+    @property
+    def cloud_regions(self) -> Dict[str, Iterable[str]]:
+        return self._cloud_regions
+
+    @classmethod
+    def _make_directories(cls, work_dir: Path):
+        os.makedirs(work_dir / "inventory" / "targets", exist_ok=True)
+        os.makedirs(work_dir / "inventory" / "classes", exist_ok=True)
+
+    @classmethod
+    def from_repo_dir(cls, work_dir: Path, repo_dir: Path):
+        cls._make_directories(work_dir)
+        classes_dir = work_dir / "inventory" / "classes"
+        os.symlink(repo_dir.absolute(), classes_dir / "global")
+        return InventoryFactory(work_dir=work_dir, repo_dir=classes_dir / "global")

--- a/commodore/inventory/parameters.py
+++ b/commodore/inventory/parameters.py
@@ -163,7 +163,7 @@ class InventoryFactory:
         del params["parameters"]["component_versions"]
         params["parameters"]["openshift"] = {
             "infraID": "infra-id",
-            "clusterID": "clutster-id",
+            "clusterID": "cluster-id",
             "registryBucket": "x-fake-registry-bucket",
         }
         params["parameters"]["cloud"]["availabilityZones"] = []

--- a/commodore/inventory/render.py
+++ b/commodore/inventory/render.py
@@ -38,12 +38,12 @@ def extract_components(
 
     if invfacts.cloud and invfacts.cloud not in invfactory.clouds:
         raise ValueError(
-            f"Unknown distribution '{invfacts.distribution}' in global defaults {global_dir}"
+            f"Unknown cloud '{invfacts.cloud}' in global defaults {global_dir}"
         )
 
     if invfacts.region and not invfacts.cloud:
         raise ValueError(
-            f"Unable to extract components for cloud region {invfacts.region}, no cloud name provided."
+            f"Unable to extract components for cloud region '{invfacts.region}', no cloud name provided."
         )
 
     if (

--- a/commodore/inventory/render.py
+++ b/commodore/inventory/render.py
@@ -24,6 +24,10 @@ def extract_components(
         )
 
     global_dir = Path(invfacts.global_config).resolve().absolute()
+    if invfacts.tenant_config:
+        raise NotImplementedError(
+            "Extracting component versions from tenant config not yet implemented"
+        )
     work_dir = Path(tempfile.mkdtemp(prefix="renovate-reclass-")).resolve()
 
     if global_dir.is_dir():

--- a/commodore/inventory/render.py
+++ b/commodore/inventory/render.py
@@ -38,6 +38,7 @@ def extract_components(
         inv = invfactory.reclass(invfacts)
         components = inv.parameters("components")
     except ClassNotFound as e:
+        print(e)
         raise ValueError(
             "Unable to render inventory with `--no-allow-missing-classes`. "
             + f"Class '{e.name}' not found. "

--- a/commodore/inventory/render.py
+++ b/commodore/inventory/render.py
@@ -1,0 +1,64 @@
+import shutil
+import tempfile
+
+from pathlib import Path
+from typing import Dict
+
+import click
+
+from commodore.config import Config
+
+from .parameters import InventoryFactory
+from .parameters import InventoryFacts
+
+
+def extract_components(
+    cfg: Config, invfacts: InventoryFacts
+) -> Dict[str, Dict[str, str]]:
+    if cfg.debug:
+        click.echo(
+            f"Called with: global_config={invfacts.global_config} "
+            + f"tenant_config={invfacts.tenant_config} "
+            + f"distribution={invfacts.distribution} "
+            + f"cloud={invfacts.cloud} region={invfacts.region}"
+        )
+
+    global_dir = Path(invfacts.global_config).resolve().absolute()
+    work_dir = Path(tempfile.mkdtemp(prefix="renovate-reclass-")).resolve()
+
+    if global_dir.is_dir():
+        invfactory = InventoryFactory.from_repo_dir(work_dir, global_dir)
+    else:
+        raise NotImplementedError("Cloning the inventory first not yet implemented")
+
+    if invfacts.distribution and invfacts.distribution not in invfactory.distributions:
+        raise ValueError(
+            f"Unknown distribution '{invfacts.distribution}' in global defaults {global_dir}"
+        )
+
+    if invfacts.cloud and invfacts.cloud not in invfactory.clouds:
+        raise ValueError(
+            f"Unknown distribution '{invfacts.distribution}' in global defaults {global_dir}"
+        )
+
+    if invfacts.region and not invfacts.cloud:
+        raise ValueError(
+            f"Unable to extract components for cloud region {invfacts.region}, no cloud name provided."
+        )
+
+    if (
+        invfacts.region
+        and invfacts.region not in invfactory.cloud_regions[invfacts.cloud]
+    ):
+        raise ValueError(
+            f"Unknown cloud region '{invfacts.region}' for cloud '{invfacts.cloud}'"
+        )
+
+    inv = invfactory.reclass(invfacts)
+    components = inv.parameters("components")
+
+    if not cfg.debug:
+        # Clean up work dir if we're not in debug mode
+        shutil.rmtree(work_dir)
+
+    return components

--- a/docs/modules/ROOT/pages/reference/cli.adoc
+++ b/docs/modules/ROOT/pages/reference/cli.adoc
@@ -155,14 +155,11 @@ This command doesn't have any command line options.
 
 == Inventory Components
 
-*-d, --distribution*::
-  Specify the distribution for which to extract component versions.
-
-*-c, --cloud*::
-  Specify the cloud provider for which to extract component versions.
-
-*-r, --cloud-region*::
-  Specify the cloud region for which to extract component versions.
+*-f, --values*::
+  Specify an additional inventory class in a YAML file.
+  This option can be repeated to provide multiple files.
+  Files specified later win when resolving inventory values.
+  Use this mechanism to specify any facts (such as the cluster's distribution) that should be taken into account when extracting component versions.
 
 *-o, --output-format*::
-    The output format for the command. Supported values are `json` and `yaml`. Defaults to `yaml`.
+  The output format for the command. Supported values are `json` and `yaml`. Defaults to `yaml`.

--- a/docs/modules/ROOT/pages/reference/cli.adoc
+++ b/docs/modules/ROOT/pages/reference/cli.adoc
@@ -152,3 +152,17 @@ This command doesn't have any command line options.
 
 *--help*::
   Show component new usage and options then exit.
+
+== Inventory Components
+
+*-d, --distribution*::
+  Specify the distribution for which to extract component versions.
+
+*-c, --cloud*::
+  Specify the cloud provider for which to extract component versions.
+
+*-r, --cloud-region*::
+  Specify the cloud region for which to extract component versions.
+
+*-o, --output-format*::
+    The output format for the command. Supported values are `json` and `yaml`. Defaults to `yaml`.

--- a/docs/modules/ROOT/pages/reference/commands.adoc
+++ b/docs/modules/ROOT/pages/reference/commands.adoc
@@ -79,3 +79,15 @@ values for any configuration that could be provided from the hierarchical
 configuration repositories.
 
 The option `--alias` (or `-a`) can be used to compile an instance-aware component with a specific instance.
+
+== Inventory Components
+
+  commodore inventory components GLOBAL_CONFIG
+
+This command lists all the components defined in `parameters.components` in the Commodore hierarchy in directory `GLOBAL_CONFIG`.
+
+The component takes optional argument which allow the user to specify a Kubernetes distribution, cloud provider and cloud region which should be considered when rendering the contents of `parameters.components`.
+
+The command supports both YAML and JSON output.
+
+NOTE: The command doesn't yet support taking into account a tenant repo when rendering the contents of `parameters.components`.

--- a/docs/modules/ROOT/pages/reference/commands.adoc
+++ b/docs/modules/ROOT/pages/reference/commands.adoc
@@ -86,7 +86,7 @@ The option `--alias` (or `-a`) can be used to compile an instance-aware componen
 
 This command lists all the components defined in `parameters.components` in the Commodore hierarchy in directory `GLOBAL_CONFIG`.
 
-The component takes optional argument which allow the user to specify a Kubernetes distribution, cloud provider and cloud region which should be considered when rendering the contents of `parameters.components`.
+The component takes a repeatable argument `-f / --values` which allows the user to specify additional files that should be used as classes when rendering the contents of `parameters.components`.
 
 The command supports both YAML and JSON output.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -50,3 +50,8 @@ def test_component_compile_command():
     """
     exit_status = call("commodore component compile --help", shell=True)
     assert exit_status == 0
+
+
+def test_component_inventory_components_command():
+    exit_status = call("commodore inventory components --help", shell=True)
+    assert exit_status == 0

--- a/tests/test_inventory_parameters.py
+++ b/tests/test_inventory_parameters.py
@@ -230,7 +230,7 @@ def test_inventoryfactory_find_values(tmp_path: Path):
     }
     global_dir = setup_global_repo_dir(tmp_path, {}, distributions, cloud_regions)
 
-    invfactory = parameters.InventoryFactory(work_dir=tmp_path, repo_dir=global_dir)
+    invfactory = parameters.InventoryFactory(work_dir=tmp_path, global_dir=global_dir)
 
     assert set(invfactory.distributions) == set(distributions.keys())
     assert set(invfactory.clouds) == set(cloud_regions.keys())

--- a/tests/test_inventory_parameters.py
+++ b/tests/test_inventory_parameters.py
@@ -1,0 +1,304 @@
+import os
+import pytest
+import random
+from pathlib import Path
+from typing import Dict
+
+from commodore.inventory import parameters
+from commodore.helpers import yaml_dump
+
+
+GLOBAL_PARAMS = {
+    "components": {
+        "tc1": {
+            "url": "tc1",
+            "version": "gp",
+        },
+        "tc2": {
+            "url": "tc2",
+            "version": "gp",
+        },
+        "tc3": {
+            "url": "tc3",
+            "version": "gp",
+        },
+        "tc4": {
+            "url": "tc4",
+            "version": "gp",
+        },
+        "tc5": {
+            "url": "tc5",
+            "version": "gp",
+        },
+    }
+}
+
+DIST_PARAMS = {
+    "a": {
+        "components": {
+            "tc1": {"version": "a_version"},
+        },
+    },
+    "b": {
+        "components": {
+            "tc2": {"url": "b_url"},
+        },
+    },
+    "c": {"other_key": {}},
+    "d": {"test": "testing"},
+}
+
+CLOUD_REGION_PARAMS = {
+    "x": {
+        "components": {
+            "tc1": {"version": "x_version"},
+        },
+    },
+    "y": [
+        (
+            "params",
+            {
+                "components": {
+                    "tc1": {"url": "y_params_url", "version": "y_params_version"},
+                }
+            },
+        ),
+        ("m", {"components": {"tc4": {"url": "y_m_url"}}}),
+        ("n", {"components": {"tc4": {"version": "y_n_version"}}}),
+        ("o", {}),
+    ],
+    "z": [("a", {})],
+}
+
+# Generate a list of tuples (cloud, region) from the CLOUD_REGION_PARAMS map, this
+# allows us to parametrize the cloud region reclass test in such a way that it only
+# tests valid combinations of cloud and region.
+CLOUD_REGION_TESTCASES = [
+    (cloud, region[0])
+    for cloud, regions in CLOUD_REGION_PARAMS.items()
+    for region in regions
+    if isinstance(regions, list)
+    if region[0] != "params"
+]
+
+
+def setup_global_repo_dir(
+    tmp_path: Path, global_params, distparams, cloud_region_params
+) -> Path:
+    global_path = tmp_path / "global-defaults"
+    os.makedirs(global_path)
+    os.makedirs(global_path / "distribution", exist_ok=True)
+    os.makedirs(global_path / "cloud", exist_ok=True)
+    ext = [".yml", ".yaml"]
+    for distribution, params in distparams.items():
+        # randomize extensions for distribution classes
+        fext = random.choice(ext)
+        yaml_dump(
+            {"parameters": params},
+            global_path / "distribution" / f"{distribution}{fext}",
+        )
+    for cloud, params in cloud_region_params.items():
+        if isinstance(params, dict):
+            yaml_dump({"parameters": params}, global_path / "cloud" / f"{cloud}.yml")
+        else:
+            assert isinstance(params, list)
+            os.makedirs(global_path / "cloud" / cloud, exist_ok=True)
+            rparams = {}
+            for region, params in params:
+                if region == "params":
+                    rparams = params
+                    continue
+                yaml_dump(
+                    {"parameters": params},
+                    global_path / "cloud" / cloud / f"{region}.yml",
+                )
+            # Write cloud-level params
+            yaml_dump(
+                {"parameters": rparams},
+                global_path / "cloud" / cloud / "params.yml",
+            )
+            # Configure cloud region hierarchy
+            yaml_dump(
+                {
+                    "classes": [
+                        f"global.cloud.{cloud}.params",
+                        f"global.cloud.{cloud}.${{facts:region}}",
+                    ],
+                },
+                global_path / "cloud" / f"{cloud}.yml",
+            )
+
+    # Write global params
+    yaml_dump(
+        {"parameters": global_params},
+        global_path / "params.yml",
+    )
+
+    # Write hierarchy config
+    yaml_dump(
+        {
+            "classes": [
+                "global.params",
+                "global.distribution.${facts:distribution}",
+                "global.cloud.${facts:cloud}",
+                "${cluster:tenant}.${cluster:name}",
+            ]
+        },
+        global_path / "commodore.yml",
+    )
+
+    return global_path
+
+
+def extract_cloud_region_params(cloud: str, region: str):
+    cparams = None
+    rparams = None
+    crp = CLOUD_REGION_PARAMS[cloud]
+    if isinstance(crp, dict):
+        return crp, {}
+
+    assert isinstance(crp, list)
+    for cr, params in crp:
+        if cr == region:
+            rparams = params
+        if cr == "params":
+            cparams = params
+    if not cparams:
+        cparams = {}
+    if not rparams:
+        rparams = {}
+
+    return cparams, rparams
+
+
+def _extract_component(params: Dict, cn: str):
+    return params.get("components", {}).get(cn, {})
+
+
+def get_component(distribution: str, cloud: str, region: str, cn: str):
+    if cloud:
+        cparams, rparams = extract_cloud_region_params(cloud, region)
+    else:
+        cparams = {}
+        rparams = {}
+
+    if region:
+        rc = _extract_component(rparams, cn)
+    else:
+        rc = {}
+
+    if cloud:
+        cc = _extract_component(cparams, cn)
+    else:
+        cc = {}
+
+    if distribution:
+        dparams = DIST_PARAMS[distribution]
+        dc = _extract_component(dparams, cn)
+    else:
+        dc = {}
+
+    curl = rc.get("url", cc.get("url", dc.get("url", cn)))
+    cver = rc.get("version", cc.get("version", dc.get("version", "gp")))
+
+    return {
+        "url": curl,
+        "version": cver,
+    }
+
+
+def verify_components(
+    components: Dict[str, Dict[str, str]], distribution: str, cloud: str, region: str
+):
+    for cn, c in components.items():
+        ec = get_component(distribution, cloud, region, cn)
+        assert c["url"] == ec["url"]
+        assert c["version"] == ec["version"]
+
+
+def test_inventoryfactory_find_values(tmp_path: Path):
+    distributions = {"a": {}, "b": {}, "c": {}, "d": {}}
+    cloud_regions = {
+        "x": {},
+        "y": [("params", {}), ("m", {}), ("n", {}), ("o", {})],
+        "z": [("a", {})],
+    }
+    expected_regions = {
+        "x": [],
+        "y": ["m", "n", "o"],
+        "z": ["a"],
+    }
+    global_dir = setup_global_repo_dir(tmp_path, {}, distributions, cloud_regions)
+
+    invfactory = parameters.InventoryFactory(work_dir=tmp_path, repo_dir=global_dir)
+
+    assert set(invfactory.distributions) == set(distributions.keys())
+    assert set(invfactory.clouds) == set(cloud_regions.keys())
+    for cloud in cloud_regions.keys():
+        assert set(invfactory.cloud_regions[cloud]) == set(expected_regions[cloud])
+
+
+def test_inventoryfactory_from_dir(tmp_path: Path):
+    distributions = {"a": {}, "b": {}, "c": {}, "d": {}}
+    cloud_regions = {
+        "x": {},
+        "y": [("params", {}), ("m", {}), ("n", {}), ("o", {})],
+        "z": [("a", {})],
+    }
+    global_dir = setup_global_repo_dir(tmp_path, {}, distributions, cloud_regions)
+
+    invfactory = parameters.InventoryFactory.from_repo_dir(tmp_path, global_dir)
+
+    assert invfactory.classes_dir == (tmp_path / "inventory" / "classes")
+    assert invfactory.targets_dir == (tmp_path / "inventory" / "targets")
+
+    assert invfactory.classes_dir.exists()
+    assert invfactory.classes_dir.is_dir()
+    assert invfactory.targets_dir.exists()
+    assert invfactory.targets_dir.is_dir()
+    assert (invfactory.classes_dir / "global").exists()
+    assert (invfactory.classes_dir / "global").is_symlink()
+
+
+@pytest.mark.parametrize("distribution", ["a", "b", "c", "d"])
+def test_inventoryfactory_reclass_distribution(tmp_path: Path, distribution: str):
+    global_dir = setup_global_repo_dir(
+        tmp_path, GLOBAL_PARAMS, DIST_PARAMS, CLOUD_REGION_PARAMS
+    )
+    invfactory = parameters.InventoryFactory.from_repo_dir(tmp_path, global_dir)
+
+    inv = invfactory.reclass(
+        parameters.InventoryFacts(None, None, distribution, None, None)
+    )
+    components = inv.parameters("components")
+
+    assert set(components.keys()) == set(GLOBAL_PARAMS["components"].keys())
+    verify_components(components, distribution, None, None)
+
+
+@pytest.mark.parametrize("cloud", ["x", "y", "z"])
+def test_inventoryfactory_reclass_cloud(tmp_path: Path, cloud: str):
+    global_dir = setup_global_repo_dir(
+        tmp_path, GLOBAL_PARAMS, DIST_PARAMS, CLOUD_REGION_PARAMS
+    )
+    invfactory = parameters.InventoryFactory.from_repo_dir(tmp_path, global_dir)
+
+    inv = invfactory.reclass(parameters.InventoryFacts(None, None, None, cloud, None))
+    components = inv.parameters("components")
+
+    assert set(components.keys()) == set(GLOBAL_PARAMS["components"].keys())
+    verify_components(components, None, cloud, None)
+
+
+@pytest.mark.parametrize("cloud,region", CLOUD_REGION_TESTCASES)
+def test_inventoryfactory_reclass_cloud_region(tmp_path: Path, cloud: str, region: str):
+    global_dir = setup_global_repo_dir(
+        tmp_path, GLOBAL_PARAMS, DIST_PARAMS, CLOUD_REGION_PARAMS
+    )
+    invfactory = parameters.InventoryFactory.from_repo_dir(tmp_path, global_dir)
+
+    inv = invfactory.reclass(parameters.InventoryFacts(None, None, None, cloud, region))
+    components = inv.parameters("components")
+
+    assert set(components.keys()) == set(GLOBAL_PARAMS["components"].keys())
+    verify_components(components, None, cloud, region)

--- a/tests/test_inventory_render.py
+++ b/tests/test_inventory_render.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+
+import pytest
+
+from commodore.config import Config
+from commodore.inventory import render
+from commodore.inventory.parameters import InventoryFacts
+
+from test_inventory_parameters import (
+    setup_global_repo_dir,
+    verify_components,
+    GLOBAL_PARAMS,
+    DIST_PARAMS,
+    CLOUD_REGION_PARAMS,
+    CLOUD_REGION_TESTCASES,
+)
+
+
+@pytest.mark.parametrize("distribution", DIST_PARAMS.keys())
+@pytest.mark.parametrize("cloud,region", CLOUD_REGION_TESTCASES)
+def test_extract_components(tmp_path: Path, distribution: str, cloud: str, region: str):
+    global_dir = setup_global_repo_dir(
+        tmp_path, GLOBAL_PARAMS, DIST_PARAMS, CLOUD_REGION_PARAMS
+    )
+    config = Config(tmp_path)
+
+    invfacts = InventoryFacts(global_dir, None, distribution, cloud, region)
+    components = render.extract_components(config, invfacts)
+
+    assert set(components.keys()) == set(GLOBAL_PARAMS["components"].keys())
+    verify_components(components, distribution, cloud, region)
+
+
+@pytest.mark.parametrize(
+    "invfacts,exception_message",
+    [
+        (
+            lambda g: InventoryFacts(g, None, "x-invalid-dist", None, None),
+            "Unknown distribution 'x-invalid-dist' in global defaults",
+        ),
+        (
+            lambda g: InventoryFacts(g, None, None, "x-invalid-cloud", None),
+            "Unknown cloud 'x-invalid-cloud' in global defaults",
+        ),
+        (
+            lambda g: InventoryFacts(g, None, None, "x", "x-invalid-region"),
+            "Unknown cloud region 'x-invalid-region' for cloud 'x'",
+        ),
+        (
+            lambda g: InventoryFacts(g, None, None, None, "region"),
+            "Unable to extract components for cloud region 'region', no cloud name provided.",
+        ),
+    ],
+)
+def test_extract_components_valueerror_on_invalid_args(
+    tmp_path: Path, invfacts, exception_message: str
+):
+    global_dir = setup_global_repo_dir(
+        tmp_path, GLOBAL_PARAMS, DIST_PARAMS, CLOUD_REGION_PARAMS
+    )
+    config = Config(tmp_path)
+
+    with pytest.raises(ValueError, match=exception_message):
+        render.extract_components(config, invfacts(global_dir))


### PR DESCRIPTION
This PR introduces a new command group called `inventory` and a new command in that group called `inventory components`.

The new command `inventory components` calls reclass to render an already checked-out Commodore defaults repo and returns all components (URLs and versions) defined in that repo. The command has a repeatable optional argument `-f / --values` to specify additional inventory classes in YAML files.

Users should use `-f` to provide additional facts (such as the cluster's K8s distribution) to the command as well as providing default values for parameters which are used in the global defaults repo without a configured default.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [ ] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
