### PR TITLE
Fix unreliable path type conversion in `commodore inventory components`

### DIFF
--- a/commodore/cli.py
+++ b/commodore/cli.py
@@ -377,7 +377,7 @@ def inventory(config: Config, verbose):
         + "Can be repeated."
     ),
     multiple=True,
-    type=click.Path(exists=True, file_okay=True, dir_okay=False, path_type=Path),
+    type=click.Path(exists=True, file_okay=True, dir_okay=False),
 )
 @click.option(
     " / -A",
@@ -394,14 +394,15 @@ def component_versions(
     verbose,
     global_config: str,
     output_format: str,
-    values: Iterable[Path],
+    values: Iterable[str],
     allow_missing_classes: bool,
 ):
     config.update_verbosity(verbose)
+    extra_values = [Path(v) for v in values]
     try:
         components = extract_components(
             config,
-            InventoryFacts(global_config, None, values, allow_missing_classes),
+            InventoryFacts(global_config, None, extra_values, allow_missing_classes),
         )
     except ValueError as e:
         raise click.ClickException(f"While extracting components: {e}") from e


### PR DESCRIPTION
We used `click.Path()` with `path_type=pathlib.Path` but this somehow didn't work as expected when I installed the Commodore package from PyPI.

Instead of spending a considerable amount of time investigating the root cause and trying to fix it, we just don't tell `click` to do the conversion and convert the provided path strings to `pathlib.Path` ourselves.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
