### PR TITLE
Disable Renovate dependency dashboard

### DIFF
--- a/commodore/component-template/{{ cookiecutter.slug }}/renovate.json
+++ b/commodore/component-template/{{ cookiecutter.slug }}/renovate.json
@@ -1,6 +1,8 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    ":gitSignOff",
+    ":disableDependencyDashboard"
   ],
   "labels": [
     "dependency"

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,8 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    ":gitSignOff",
+    ":disableDependencyDashboard"
   ],
   "python": {
     "enabled": false


### PR DESCRIPTION
* Disables Renovate Dependency dashboard for commodore and component template
* Follows https://github.com/projectsyn/modulesync-control/pull/51

(Value of this Dashboard isn't that great)

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
