### PR TITLE
Remove support for deprecated parameter `commodore.jsonnet_libs`

### DIFF
--- a/commodore/compile.py
+++ b/commodore/compile.py
@@ -12,7 +12,6 @@ from .cluster import (
 from .config import Config
 from .dependency_mgmt import (
     fetch_components,
-    fetch_jsonnet_libs,
     fetch_jsonnet_libraries,
     register_components,
     jsonnet_dependencies,
@@ -164,14 +163,6 @@ def compile(config, cluster_id):
     for component in config.get_components().values():
         ckey = component.parameters_key
         component.render_jsonnetfile_json(cluster_parameters[ckey])
-
-    jsonnet_libs = cluster_parameters.get("commodore", {}).get("jsonnet_libs", None)
-    if jsonnet_libs and config.fetch_dependencies:
-        config.register_deprecation_notice(
-            "Parameter `commodore.jsonnet_libs` is deprecated. "
-            + "If your component needs Jsonnet dependencies, specify them in the component's `jsonnetfile.json`"
-        )
-        fetch_jsonnet_libs(config, jsonnet_libs)
 
     if config.fetch_dependencies:
         fetch_jsonnet_libraries(config.work_dir, deps=jsonnet_dependencies(config))

--- a/commodore/dependency_mgmt.py
+++ b/commodore/dependency_mgmt.py
@@ -6,7 +6,6 @@ from typing import Dict, Iterable, List, Optional, Tuple
 
 import click
 
-from . import git
 from .config import Config
 from .component import Component, component_dir
 from .helpers import relsymlink, kapitan_inventory
@@ -129,38 +128,6 @@ def fetch_components(cfg: Config):
         c.checkout()
         cfg.register_component(c)
         create_component_symlinks(cfg, c)
-
-
-def fetch_jsonnet_libs(config: Config, libs):
-    """
-    Download all libraries specified in list `libs`.
-    Each entry in `libs` is assumed to be a dict with keys
-      * 'repository', the value of which is interpreted as a git repository to
-                      clone.
-      * 'files', a list of dicts which defines which files in the repository
-                 should be installed as template libraries.
-    Each entry in files is assumed to have the keys
-      * 'libfile', indicating a filename relative to the repository of the
-                   library to install
-      * 'targetfile', the file name to use as the symlink target when
-                      installing the library
-    """
-
-    click.secho("Updating Jsonnet libraries...", bold=True)
-    config.inventory.ensure_dirs()
-    for lib in libs:
-        libname = lib["name"]
-        if config.debug:
-            filestext = " ".join([f["targetfile"] for f in lib["files"]])
-            click.echo(f" > {libname}: {filestext}")
-        library_dir = config.inventory.libs_dir / libname
-        git.clone_repository(lib["repository"], library_dir, config)
-        for file in lib["files"]:
-            relsymlink(
-                library_dir / file["libfile"],
-                config.inventory.lib_dir,
-                dest_name=file["targetfile"],
-            )
 
 
 def jsonnet_dependencies(config: Config) -> Iterable:

--- a/docs/modules/ROOT/pages/reference/deprecation-notices.adoc
+++ b/docs/modules/ROOT/pages/reference/deprecation-notices.adoc
@@ -5,6 +5,12 @@ We include a link to relevant documentation, if applicable.
 
 == Unreleased
 
+== https://github.com/projectsyn/commodore/releases/tag/v0.13.0[v0.13.0]
+
+=== `parameters.commodore.jsonnet_libs` is removed
+
+The parameter has been deprecated since Commodore v0.6.0, and is removed in v0.13.0.
+
 == https://github.com/projectsyn/commodore/releases/tag/v0.6.0[v0.6.0]
 
 === `parameters.commodore.jsonnet_libs` is deprecated


### PR DESCRIPTION
The parameter has been deprecated since Commodore v0.6.0.

Fixes #255

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
