### PR TITLE
Fix command `inventory components` for inventories which use `${_instance}`

### DIFF
--- a/commodore/inventory/parameters.py
+++ b/commodore/inventory/parameters.py
@@ -249,7 +249,12 @@ class InventoryFactory:
         # - global.commodore
         classes = ["base"] + invfacts.extra_classes + ["global.commodore"]
         yaml_dump(
-            {"classes": classes},
+            {
+                "classes": classes,
+                "parameters": {
+                    "_instance": "global",
+                },
+            },
             self.targets_dir / "global.yml",
         )
 

--- a/tests/test_inventory_parameters.py
+++ b/tests/test_inventory_parameters.py
@@ -46,6 +46,8 @@ DIST_PARAMS = {
     },
     "c": {"other_key": {}},
     "d": {"test": "testing"},
+    # Test that multi-instance related params work correctly
+    "e": {"namespace": "${_instance}"},
 }
 
 CLOUD_REGION_PARAMS = {


### PR DESCRIPTION
We inject `_instance: global` when rendering the inventory to ensure that multi-instance related configurations which use `${_instance}` are rendered correctly.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
