### PR TITLE
Properly handle 403 replies from Lieutenant

### DIFF
--- a/commodore/catalog.py
+++ b/commodore/catalog.py
@@ -8,7 +8,7 @@ import click
 import yaml
 
 from . import git
-from .helpers import rm_tree_contents, lieutenant_query, sliding_window
+from .helpers import ApiError, rm_tree_contents, lieutenant_query, sliding_window
 from .cluster import Cluster
 from .config import Config, Migration
 from .k8sobject import K8sObject
@@ -226,7 +226,10 @@ def update_catalog(cfg: Config, targets: Iterable[str], repo):
 
 
 def catalog_list(cfg):
-    clusters = lieutenant_query(cfg.api_url, cfg.api_token, "clusters", "")
+    try:
+        clusters = lieutenant_query(cfg.api_url, cfg.api_token, "clusters", "")
+    except ApiError as e:
+        raise click.ClickException(f"While listing clusters on Lieutenant: {e}") from e
     for cluster in clusters:
         display_name = cluster["displayName"]
         catalog_id = cluster["id"]

--- a/commodore/helpers.py
+++ b/commodore/helpers.py
@@ -102,8 +102,8 @@ def lieutenant_query(api_url, api_token, api_endpoint, api_id):
         raise ApiError(f"Unable to connect to Lieutenant at {api_url}") from e
     try:
         resp = json.loads(r.text)
-    except json.JSONDecodeError:
-        resp = {"message": "Client error: Unable to parse JSON"}
+    except json.JSONDecodeError as e:
+        raise ApiError("Client error: Unable to parse JSON") from e
     try:
         r.raise_for_status()
     except HTTPError as e:

--- a/commodore/helpers.py
+++ b/commodore/helpers.py
@@ -109,7 +109,10 @@ def lieutenant_query(api_url, api_token, api_endpoint, api_id):
     except HTTPError as e:
         extra_msg = "."
         if r.status_code >= 400:
-            extra_msg = f": {resp['reason']}"
+            if "reason" in resp:
+                extra_msg = f": {resp['reason']}"
+            else:
+                extra_msg = f": {e}"
         raise ApiError(f"API returned {r.status_code}{extra_msg}") from e
     else:
         return resp

--- a/poetry.lock
+++ b/poetry.lock
@@ -1021,6 +1021,22 @@ requests = ">=2.0.0"
 rsa = ["oauthlib[signedtoken] (>=3.0.0)"]
 
 [[package]]
+name = "responses"
+version = "0.16.0"
+description = "A utility library for mocking out the `requests` Python library."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[package.dependencies]
+requests = ">=2.0"
+six = "*"
+urllib3 = ">=1.25.10"
+
+[package.extras]
+tests = ["coverage (>=3.7.1,<6.0.0)", "pytest-cov", "pytest-localserver", "flake8", "types-mock", "types-requests", "types-six", "pytest (>=4.6,<5.0)", "pytest (>=4.6)", "mypy"]
+
+[[package]]
 name = "rfc3987"
 version = "1.3.8"
 description = "Parsing and validation of URIs (RFC 3986) and IRIs (RFC 3987)"
@@ -1211,7 +1227,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7, <=3.9.6"
-content-hash = "5222fa96f27e54c339dc5f0ed68f3cca7bcef851632f992c3b7207dfd9f0adab"
+content-hash = "83209ae7ff1d7d2618c587b6c44c4922b555f39ae5c67be2c98bb704995df1d7"
 
 [metadata.files]
 addict = [
@@ -1708,6 +1724,10 @@ requests-oauthlib = [
     {file = "requests-oauthlib-1.3.0.tar.gz", hash = "sha256:b4261601a71fd721a8bd6d7aa1cc1d6a8a93b4a9f5e96626f8e4d91e8beeaa6a"},
     {file = "requests_oauthlib-1.3.0-py2.py3-none-any.whl", hash = "sha256:7f71572defaecd16372f9006f33c2ec8c077c3cfa6f5911a9a90202beb513f3d"},
     {file = "requests_oauthlib-1.3.0-py3.7.egg", hash = "sha256:fa6c47b933f01060936d87ae9327fead68768b69c6c9ea2109c48be30f2d4dbc"},
+]
+responses = [
+    {file = "responses-0.16.0-py2.py3-none-any.whl", hash = "sha256:f358ef75e8bf431b0aa203cc62625c3a1c80a600dbe9de91b944bf4e9c600b92"},
+    {file = "responses-0.16.0.tar.gz", hash = "sha256:a2e3aca2a8277e61257cd3b1c154b1dd0d782b1ae3d38b7fa37cbe3feb531791"},
 ]
 rfc3987 = [
     {file = "rfc3987-1.3.8-py2.py3-none-any.whl", hash = "sha256:10702b1e51e5658843460b189b185c0366d2cf4cff716f13111b0ea9fd2dce53"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ autopep8 = "*"
 pytest = "^5.4.3"
 pytest-xdist = "^1.32.0"
 pytest-benchmark = "^3.2.3"
+responses = "^0.16.0"
 
 [tool.poetry.scripts]
 commodore = 'commodore.cli:main'

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -5,6 +5,8 @@ from pathlib import Path
 from typing import Callable
 import textwrap
 import pytest
+import responses
+from url_normalize import url_normalize
 
 import commodore.helpers as helpers
 from commodore.config import Config
@@ -164,3 +166,89 @@ def test_yaml_dump_all(tmp_path: Path, input, expected):
 def test_sliding_window(sequence, winsize, expected):
     windows = list(helpers.sliding_window(sequence, winsize))
     assert windows == expected
+
+
+def _verify_call_status(query_url):
+    assert len(responses.calls) == 1
+    call = responses.calls[0]
+    assert "Authorization" in call.request.headers
+    assert call.request.headers["Authorization"] == "Bearer token"
+    assert call.request.url == query_url
+
+
+@responses.activate
+def test_lieutenant_query_connection_error():
+    api_url = "https://syn.example.com"
+    with pytest.raises(
+        helpers.ApiError, match=f"Unable to connect to Lieutenant at {api_url}"
+    ):
+        helpers.lieutenant_query(api_url, "token", "clusters", "c-cluster-id-1234")
+
+    _verify_call_status(f"{api_url}/clusters/c-cluster-id-1234")
+
+
+@pytest.mark.parametrize(
+    "response,expected",
+    [
+        (
+            {
+                "status": 403,
+                "json": {"reason": "Unauthorized"},
+            },
+            "API returned 403: Unauthorized",
+        ),
+        (
+            {
+                "status": 403,
+                "json": {},
+            },
+            "API returned 403: ",
+        ),
+        (
+            {
+                "status": 500,
+                "json": {"reason": "Unexpected frobulation"},
+            },
+            "API returned 500: Unexpected frobulation",
+        ),
+        (
+            {
+                "status": 200,
+                "body": "No JSON in response",
+            },
+            "Client error: Unable to parse JSON",
+        ),
+        (
+            {
+                "status": 403,
+                "body": "No JSON in response",
+            },
+            "Client error: Unable to parse JSON",
+        ),
+    ],
+)
+@responses.activate
+def test_lieutenant_query_response_errors(response, expected):
+    base_url = "https://syn.example.com/"
+
+    query_url = url_normalize(f"{base_url}/clusters/")
+
+    if "json" in response:
+        responses.add(
+            responses.GET,
+            query_url,
+            status=response["status"],
+            json=response["json"],
+        )
+    elif "body" in response:
+        responses.add(
+            responses.GET,
+            query_url,
+            status=response["status"],
+            body=response["body"],
+        )
+
+    with pytest.raises(helpers.ApiError, match=expected):
+        helpers.lieutenant_query(base_url, "token", "clusters", "")
+
+    _verify_call_status(query_url)

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ description = Unit tests and doctests
 deps =
     cli-test-helpers
     pytest
+    responses
     !bench: pytest-xdist
     bench: pytest-benchmark
 commands = \


### PR DESCRIPTION
We previously assumed that any 4xx replies from Lieutenant would be Lieutenant errors, and would therefore contain key `reason` in the response.

However, if you try to compile a cluster to which you don't have access with a restricted Lieutenant API token (e.g. a cluster or tenant SA token), you get a 403 response which doesn't contain a `reason` field.

This commit correctly handles this case, and produces a legible error message in this case.

Fixes #367

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
