### PR TITLE
Add new command `inventory lint`

### DIFF
--- a/commodore/cli.py
+++ b/commodore/cli.py
@@ -419,30 +419,26 @@ def component_versions(
         click.echo(yaml.safe_dump(components))
 
 
-@inventory.group(
-    name="lint", short_help="Commands which lint the Commodore inventory structure"
-)
-@verbosity
-@pass_config
-def inventory_lint(config: Config, verbose):
-    config.update_verbosity(verbose)
-
-
-@inventory_lint.command(
-    name="components",
-    short_help="Lint component specifications in the provided paths (files and directories are accepted)",
+@inventory.command(
+    name="lint",
+    short_help="Lint YAML files for Commodore inventory structures in the provided paths",
+    no_args_is_help=True,
 )
 @click.argument(
     "target", type=click.Path(file_okay=True, dir_okay=True, exists=True), nargs=-1
 )
 @verbosity
 @pass_config
-def inventory_lint_components(
-    config: Config,
-    verbose,
-    target: Tuple[str],
-):
+def inventory_lint(config: Config, verbose: int, target: Tuple[str]):
+    """Lint YAML files in the provided paths.
+
+    The command assumes that any YAML file found in the provided paths is part of a
+    Commodore inventory structure."""
     config.update_verbosity(verbose)
+
+    if len(target) == 0:
+        click.secho("> No files provided, exiting...", fg="yellow")
+        sys.exit(2)
 
     error_counts = []
     for t in target:

--- a/commodore/inventory/lint_components.py
+++ b/commodore/inventory/lint_components.py
@@ -49,7 +49,9 @@ def _lint_file(cfg: Config, file: Path) -> int:
 
 
 def _lint_directory(cfg, path: Path) -> int:
-    assert path.is_dir()
+    if not path.is_dir():
+        raise ValueError("Unexpected path argument: expected to be a directory")
+
     errcount = 0
     for dentry in path.iterdir():
         if dentry.stem.startswith("."):

--- a/commodore/inventory/lint_components.py
+++ b/commodore/inventory/lint_components.py
@@ -1,0 +1,79 @@
+from pathlib import Path
+from typing import Dict
+
+import click
+import yaml
+
+from commodore.config import Config
+from commodore.helpers import yaml_load_all
+
+
+def _lint_component_versions(file: Path, filecontents: Dict) -> int:
+    errcount = 0
+    components = filecontents.get("parameters", {}).get("components", {})
+    for cn, cspec in components.items():
+        if "version" not in cspec:
+            click.secho(
+                f"> Component specification for {cn} is missing explict version in {file}",
+                fg="red",
+            )
+            errcount += 1
+    return errcount
+
+
+def _lint_file(cfg: Config, file: Path) -> int:
+    errcount = 0
+    try:
+        filecontents = yaml_load_all(file)
+        if len(filecontents) == 0:
+            if cfg.debug:
+                click.echo(f"> Skipping empty file {file}")
+        elif len(filecontents) > 1:
+            if cfg.debug:
+                click.echo(
+                    f"> Skipping file {file}: Linting multi-document YAML streams is not supported",
+                )
+        elif not isinstance(filecontents[0], dict):
+            if cfg.debug:
+                click.echo(
+                    f"> Skipping file {file}: Expected top-level dictionary in YAML document"
+                )
+        else:
+            errcount = _lint_component_versions(file, filecontents[0])
+
+    except (yaml.YAMLError, UnicodeDecodeError) as e:
+        if cfg.debug:
+            click.echo(f"> Skipping file {file}: Unable to load as YAML: {e}")
+
+    return errcount
+
+
+def _lint_directory(cfg, path: Path) -> int:
+    assert path.is_dir()
+    errcount = 0
+    for dentry in path.iterdir():
+        if dentry.stem.startswith("."):
+            if cfg.debug:
+                click.echo(f"> Skipping hidden directory entry {dentry}")
+            continue
+        if dentry.is_dir():
+            errcount += _lint_directory(cfg, dentry)
+        else:
+            errcount += _lint_file(cfg, dentry)
+    return errcount
+
+
+def lint_components(cfg: Config, path: Path) -> int:
+    """Lint component specifications (`parameters.components`) in `path`.
+
+    If `path` is a directory, lint `parameters.components` in all `.ya?ml` files in the
+    directory (recursively).
+    If `path` is a file, lint `parameters.components` in that file, if it's a YAML file.
+
+    Returns a value that can be used as exit code to indicate whether there were linting
+    errors.
+    """
+    if path.is_dir():
+        return _lint_directory(cfg, path)
+
+    return _lint_file(cfg, path)

--- a/docs/modules/ROOT/pages/reference/cli.adoc
+++ b/docs/modules/ROOT/pages/reference/cli.adoc
@@ -163,3 +163,7 @@ This command doesn't have any command line options.
 
 *-o, --output-format*::
   The output format for the command. Supported values are `json` and `yaml`. Defaults to `yaml`.
+
+== Inventory Lint Components
+
+No command line flags

--- a/docs/modules/ROOT/pages/reference/cli.adoc
+++ b/docs/modules/ROOT/pages/reference/cli.adoc
@@ -164,6 +164,6 @@ This command doesn't have any command line options.
 *-o, --output-format*::
   The output format for the command. Supported values are `json` and `yaml`. Defaults to `yaml`.
 
-== Inventory Lint Components
+== Inventory Lint
 
 No command line flags

--- a/docs/modules/ROOT/pages/reference/commands.adoc
+++ b/docs/modules/ROOT/pages/reference/commands.adoc
@@ -107,3 +107,19 @@ parameters:
 This must match the tenant ID associated with the provided tenant repo for accurate results.
 
 The command supports both YAML and JSON output.
+
+== Inventory Lint Components
+
+  commodore inventory lint components [PATH, [PATH, [PATH, ...]]]
+
+This command provides basic linting for Commodore component specifications.
+It treats component specifications without explicit `version` field as errors.
+
+The command takes zero or more paths to files or directories to lint as command line arguments.
+It silently skips files which aren't valid YAML, as well as empty files and files containing multi-document YAML streams.
+
+When linting directories, any hidden files (prefixed with a dot) are ignored.
+Directories are linted recursively and the same skipping logic as for individual files is applied.
+
+If no errors are found the command exits with return value 0.
+If any errors are found the command exits with return value 1.

--- a/docs/modules/ROOT/pages/reference/commands.adoc
+++ b/docs/modules/ROOT/pages/reference/commands.adoc
@@ -108,15 +108,18 @@ This must match the tenant ID associated with the provided tenant repo for accur
 
 The command supports both YAML and JSON output.
 
-== Inventory Lint Components
+== Inventory Lint
 
-  commodore inventory lint components [PATH, [PATH, [PATH, ...]]]
+  commodore inventory lint [PATH]...
 
-This command provides basic linting for Commodore component specifications.
+This command provides linting for Commodore inventory classes.
+
+Currently, the command only lints component specifications.
 It treats component specifications without explicit `version` field as errors.
 
 The command takes zero or more paths to files or directories to lint as command line arguments.
 It silently skips files which aren't valid YAML, as well as empty files and files containing multi-document YAML streams.
+All other files are assumed to be Commodore inventory classes.
 
 When linting directories, any hidden files (prefixed with a dot) are ignored.
 Directories are linted recursively and the same skipping logic as for individual files is applied.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -55,3 +55,8 @@ def test_component_compile_command():
 def test_component_inventory_components_command():
     exit_status = call("commodore inventory components --help", shell=True)
     assert exit_status == 0
+
+
+def test_component_inventory_lint_components_command():
+    exit_status = call("commodore inventory lint components --help", shell=True)
+    assert exit_status == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -57,6 +57,6 @@ def test_component_inventory_components_command():
     assert exit_status == 0
 
 
-def test_component_inventory_lint_components_command():
-    exit_status = call("commodore inventory lint components --help", shell=True)
+def test_component_inventory_lint():
+    exit_status = call("commodore inventory lint --help", shell=True)
     assert exit_status == 0

--- a/tests/test_inventory_lint_components.py
+++ b/tests/test_inventory_lint_components.py
@@ -1,0 +1,247 @@
+import os
+
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+from commodore.config import Config
+from commodore.helpers import yaml_dump, yaml_dump_all
+from commodore.inventory import lint_components
+
+
+@pytest.fixture
+def config(tmp_path: Path):
+    return Config(
+        tmp_path,
+        api_url="https://syn.example.com",
+        api_token="token",
+    )
+
+
+LINT_FILECONTENTS = [
+    ({}, 0),
+    ({"a": "b"}, 0),
+    (
+        {
+            "parameters": {
+                "components": {
+                    "c1": {
+                        "url": "https://example.com/syn/component-c1.git",
+                        "version": "v1.0.0",
+                    },
+                    "c2": {
+                        "url": "https://example.com/syn/component-c2.git",
+                        "version": "v1.0.0",
+                    },
+                    "c3": {
+                        "url": "https://example.com/syn/component-c3.git",
+                        "version": "v1.0.0",
+                    },
+                },
+            }
+        },
+        0,
+    ),
+    (
+        {
+            "parameters": {
+                "components": {
+                    "c1": {
+                        "url": "https://example.com/syn/component-c1.git",
+                    },
+                    "c2": {
+                        "url": "https://example.com/syn/component-c2.git",
+                        "version": "v1.0.0",
+                    },
+                    "c3": {
+                        "url": "https://example.com/syn/component-c3.git",
+                        "version": "v1.0.0",
+                    },
+                },
+            }
+        },
+        1,
+    ),
+    (
+        {
+            "parameters": {
+                "components": {
+                    "c1": {
+                        "url": "https://example.com/syn/component-c1.git",
+                    },
+                    "c2": {
+                        "url": "https://example.com/syn/component-c2.git",
+                    },
+                    "c3": {
+                        "version": "v1.0.0",
+                    },
+                },
+            }
+        },
+        2,
+    ),
+]
+SKIP_FILECONTENTS = [
+    ("", "> Skipping empty file"),
+    ("\tTest", "Unable to load as YAML"),
+    ([{"a": 1}, {"b": 2}], "Linting multi-document YAML streams is not supported"),
+    ([[1, 2, 3]], "Expected top-level dictionary in YAML document"),
+]
+
+
+def _check_lint_result(ec: int, expected_errcount: int, captured):
+    assert ec == expected_errcount
+    if ec == 0:
+        assert captured.out == ""
+    else:
+        assert len(captured.out.strip().split("\n")) == expected_errcount
+
+
+@pytest.mark.parametrize("filecontents,expected_errcount", LINT_FILECONTENTS)
+def test_lint_component_versions(
+    tmp_path, capsys, filecontents: Dict, expected_errcount: int
+):
+    p = tmp_path / "test.yml"
+
+    ec = lint_components._lint_component_versions(p, filecontents)
+
+    captured = capsys.readouterr()
+    _check_lint_result(ec, expected_errcount, captured)
+
+
+@pytest.mark.parametrize("filecontents,expected_errcount", LINT_FILECONTENTS)
+def test_lint_valid_file(
+    tmp_path: Path, capsys, config: Config, filecontents: Dict, expected_errcount: int
+):
+    testf = tmp_path / "test.yml"
+    yaml_dump(filecontents, testf)
+
+    ec = lint_components._lint_file(config, testf)
+
+    captured = capsys.readouterr()
+    _check_lint_result(ec, expected_errcount, captured)
+
+
+@pytest.mark.parametrize("filecontents,expected_errcount", LINT_FILECONTENTS)
+def test_lint_valid_file_stream(
+    tmp_path: Path, capsys, config: Config, filecontents: Dict, expected_errcount: int
+):
+    testf = tmp_path / "test.yml"
+    yaml_dump_all([filecontents], testf)
+
+    ec = lint_components._lint_file(config, testf)
+
+    captured = capsys.readouterr()
+    _check_lint_result(ec, expected_errcount, captured)
+
+
+def _dump_skip_file(filecontents: Any, path: Path):
+    if isinstance(filecontents, str):
+        with open(path, "w", encoding="utf-8") as t:
+            t.write(filecontents)
+    else:
+        yaml_dump_all(filecontents, path)
+
+
+@pytest.mark.parametrize("filecontents,expected_debug_msg", SKIP_FILECONTENTS)
+def test_lint_skip_file(
+    tmp_path: Path,
+    capsys,
+    config: Config,
+    filecontents: Any,
+    expected_debug_msg: str,
+):
+    # Enable debug verbosity
+    config.update_verbosity(3)
+
+    testf = tmp_path / "test.yml"
+    _dump_skip_file(filecontents, testf)
+
+    ec = lint_components._lint_file(config, testf)
+
+    captured = capsys.readouterr()
+    stdout: str = captured.out
+
+    assert ec == 0
+    assert stdout.startswith(
+        (f"> Skipping empty file {testf}", f"> Skipping file {testf}: ")
+    )
+    assert expected_debug_msg in captured.out
+
+
+def _setup_directory(tmp_path: Path):
+    lint_direntries = [
+        tmp_path / "test.yml",
+        tmp_path / "d1" / "test1.yml",
+        tmp_path / "d1" / "test2.yml",
+        tmp_path / "d2" / "test3.yml",
+        tmp_path / "d2" / "subd" / "test4.yml",
+    ]
+    assert len(lint_direntries) == len(LINT_FILECONTENTS)
+    skip_direntries = [
+        tmp_path / "empty.txt",
+        tmp_path / "d3" / "tab.txt",
+        tmp_path / "d3" / "stream.yaml",
+        tmp_path / "d3" / "top-level.yaml",
+    ]
+    assert len(skip_direntries) == len(SKIP_FILECONTENTS)
+
+    expected_errcount = 0
+    for (idx, (filecontents, eec)) in enumerate(LINT_FILECONTENTS):
+        dentry = lint_direntries[idx]
+        os.makedirs(dentry.parent, exist_ok=True)
+        yaml_dump(filecontents, dentry)
+        # these should be skipped
+        yaml_dump(filecontents, tmp_path / f".{idx}.yml")
+        expected_errcount += eec
+    for (idx, (filecontents, _)) in enumerate(SKIP_FILECONTENTS):
+        dentry = skip_direntries[idx]
+        os.makedirs(dentry.parent, exist_ok=True)
+        _dump_skip_file(filecontents, dentry)
+
+    return expected_errcount
+
+
+def test_lint_directory(tmp_path: Path, capsys, config: Config):
+    expected_errcount = _setup_directory(tmp_path)
+
+    ec = lint_components._lint_directory(config, tmp_path)
+
+    captured = capsys.readouterr()
+    _check_lint_result(ec, expected_errcount, captured)
+
+
+def test_lint_components_file(tmp_path: Path, config: Config, capsys):
+    filecontents = {
+        "parameters": {
+            "components": {
+                "c1": {
+                    "url": "https://example.com/syn/component-c1.git",
+                },
+                "c2": {
+                    "url": "https://example.com/syn/component-c2.git",
+                },
+                "c3": {
+                    "version": "v1.0.0",
+                },
+            },
+        }
+    }
+    expected_errcount = 2
+    testf = tmp_path / "test.yml"
+    yaml_dump(filecontents, testf)
+
+    ec = lint_components.lint_components(config, testf)
+
+    captured = capsys.readouterr()
+    _check_lint_result(ec, expected_errcount, captured)
+
+
+def test_lint_components_directory(tmp_path: Path, config: Config, capsys):
+    expected_errcount = _setup_directory(tmp_path)
+
+    ec = lint_components.lint_components(config, tmp_path)
+
+    captured = capsys.readouterr()
+    _check_lint_result(ec, expected_errcount, captured)


### PR DESCRIPTION
Currently the only implemented linting error is warning about component specifications without explicit version.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
