### PR TITLE
Fix `/usr/lib/libnss_wrapper.so` not found error in Docker image

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -153,3 +153,5 @@ jobs:
         fetch-depth: "0"
     - name: Build image
       run: make docker
+    - name: Run image
+      run: docker run docker.io/projectsyn/commodore:test

--- a/tools/entrypoint.sh
+++ b/tools/entrypoint.sh
@@ -8,7 +8,7 @@ set -e
 
 # Ensure that we're using the correct libnss_wrapper.so
 # This should only ever fail in CI
-readonly libnss_wrapper_so=/usr/lib/libnss_wrapper.so
+readonly libnss_wrapper_so=/usr/lib/x86_64-linux-gnu/libnss_wrapper.so
 if [ ! -f "${libnss_wrapper_so}" ]; then
   echo "${libnss_wrapper_so} doesn't exist."
   exit 1

--- a/tools/entrypoint.sh
+++ b/tools/entrypoint.sh
@@ -6,7 +6,15 @@ set -e
 # otherwise this will cause issues with things like cloning with git+ssh
 # reference: https://access.redhat.com/documentation/en-us/openshift_container_platform/3.11/html/creating_images/creating-images-guidelines#use-uid
 
-export LD_PRELOAD=/usr/lib/libnss_wrapper.so
+# Ensure that we're using the correct libnss_wrapper.so
+# This should only ever fail in CI
+readonly libnss_wrapper_so=/usr/lib/libnss_wrapper.so
+if [ ! -f "${libnss_wrapper_so}" ]; then
+  echo "${libnss_wrapper_so} doesn't exist."
+  exit 1
+fi
+
+export LD_PRELOAD="${libnss_wrapper_so}"
 export NSS_WRAPPER_PASSWD=/tmp/passwd
 export NSS_WRAPPER_GROUP=/etc/group
 


### PR DESCRIPTION
#402 updates the Docker base image to Debian bullseye, which changes the location of `libnss_wrapper.so` from `/usr/lib/libnss_wrapper.so`to `/usr/lib/x86_64-linux-gnu/libnss_wrapper.so`. Our tests didn't catch this, because we didn't run the Docker image after building it.

This PR adds a few things:

1. A step in the docker image build Github Action which runs the freshly built image
2. A check that the configured `libnss_wrapper.so` path exists in `/usr/local/bin/entrypoint.sh` of the Docker image. This should ensure that the GitHub Action fails when the location of the library changes
3. Update the entrypoint script to use the correct path for Debian bullseye

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
