### PR TITLE
Update the component template docs preview command

### DIFF
--- a/commodore/component-template/{{ cookiecutter.slug }}/Makefile.vars.mk
+++ b/commodore/component-template/{{ cookiecutter.slug }}/Makefile.vars.mk
@@ -22,7 +22,8 @@ YAMLLINT_DOCKER ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) $(YAMLLINT_IMAGE)
 VALE_CMD  ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) --volume "$${PWD}"/docs/modules:/pages docker.io/vshn/vale:2.1.1
 VALE_ARGS ?= --minAlertLevel=error --config=/pages/ROOT/pages/.vale.ini /pages
 
-ANTORA_PREVIEW_CMD ?= $(DOCKER_CMD) run --rm --publish 2020:2020 --volume "${PWD}":/antora docker.io/vshn/antora-preview:2.3.3 --style=syn --antora=docs
+ANTORA_PREVIEW_CMD ?= $(DOCKER_CMD) run --rm --publish 35729:35729 --publish 2020:2020 --volume "${PWD}/.git":/preview/antora/.git --volume "${PWD}/docs":/preview/antora/docs docker.io/vshn/antora-preview:3.0.0.1 --style=syn --antora=docs
+
 
 COMMODORE_CMD  ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) docker.io/projectsyn/commodore:latest component compile . $(commodore_args)
 JB_CMD         ?= $(DOCKER_CMD) $(DOCKER_ARGS) --entrypoint /usr/local/bin/jb docker.io/projectsyn/commodore:latest install


### PR DESCRIPTION
This PR:
* Bumps Antora preview command docker image to vshn/antora-preview:3.0.0.1. This gives us a Antora preview which auto-refreshes the docs while the command is running and updates the image to one which contains the current VSHN Kroki instance URL.
* Only mounts `<component-dir>/docs` and `<component-dir>/.git` into the Docker container. This should avoid issues with Antora getting confused about paths in `vendor` not being readable in the container.
* Exposes port 35729 of the Docker container for the auto-reload browser plugin.

See also https://github.com/projectsyn/modulesync-control/pull/59

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
