### PR TITLE
Move component instantiation advertisement to `_metadata.multi_instance`

### DIFF
--- a/docs/modules/ROOT/pages/reference/architecture.adoc
+++ b/docs/modules/ROOT/pages/reference/architecture.adoc
@@ -90,8 +90,16 @@ Since Commodore won't re-read `parameters.components` after including the discov
 
 With https://syn.tools/syn/SDDs/0025-commodore-component-instantiation.html[SDD0025], we've introduced support for instantiating components multiple times.
 As discussed in the design document, component authors must explicitly declare that their component supports instantiation.
-Components declare that they support instantiation by setting the field `multi_instance` in `parameters.<component_name>` to `true`.
-Commodore will exit with an error if a hierarchy tries to instantiate a component which hasn't declared that it supports instantiation.
+Components advertise that they support instantiation by setting the field `multi_instance` in `parameters.<component_name>._metadata` to `true`.
+Commodore will exit with an error if a hierarchy tries to instantiate a component which doesn't explicitly advertise multi-instance support.
+
+[TIP]
+====
+Components which are generated with `commodore component new` by Commodore v0.7.0 or newer already have field `_metadata` in their component parameters.
+The component template prefixes the field with an equals sign, which makes the field constant.
+This ensures that the hierarchy can't change the contents of the field.
+See the https://github.com/kapicorp/reclass/blob/develop/README-extensions.rst#constant-parameters[Kapitan reclass documentation] for more details on constant parameters.
+====
 
 Component instance names aren't namespaced per component, but must be globally unique.
 Commodore will exit with an error if the hierarchy uses the same instance name twice.

--- a/docs/modules/ROOT/pages/reference/deprecation-notices.adoc
+++ b/docs/modules/ROOT/pages/reference/deprecation-notices.adoc
@@ -3,7 +3,30 @@
 This page lists deprecations of Commodore features organized by version.
 We include a link to relevant documentation, if applicable.
 
-== Unreleased
+== https://github.com/projectsyn/commodore/releases/tag/v0.14.0[v0.14.0]
+
+[#_multi_instance_top_level]
+=== Advertising multi-instance support in component parameter `multi_instance` is deprecated
+
+Commodore v0.14.0 adds support for advertising multi-instance support in components to field `multi_instance` in the component metadata parameter `_metadata`.
+In turn the old location for advertising multi-instance support in component parameter `multi_instance` is deprecated.
+
+To update existing components, you can simply adjust the component's `class/defaults.yml` to match the sample shown below.
+
+[source,yaml]
+----
+parameters:
+  <component_name>: <1>
+    =_metadata: <2>
+      multi_instance: true
+----
+<1> `<component_name>` is a placeholder for the component's parameters key
+<2> By prefixing the `_metadata` key with an equals sign, we make the component metadata constant.
+This ensures that values in `_metadata` can't be changed in the hierarchy.
+See also the https://github.com/kapicorp/reclass/blob/develop/README-extensions.rst#constant-parameters[Kapitan reclass documentation].
+
+TIP: Depending on the age of the component, the `metadata` key may already exist with empty content.
+
 
 == https://github.com/projectsyn/commodore/releases/tag/v0.13.0[v0.13.0]
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -24,6 +24,14 @@ def test_verify_component_aliases_no_instance(config):
     config.verify_component_aliases(params)
 
 
+def test_verify_component_aliases_explicit_no_instance(config):
+    alias_data = {"bar": "bar"}
+    config.register_component_aliases(alias_data)
+    params = {"bar": {"_metadata": {"multi_instance": False}, "namespace": "syn-bar"}}
+
+    config.verify_component_aliases(params)
+
+
 def test_verify_component_aliases_metadata(config):
     alias_data = {"baz": "bar"}
     config.register_component_aliases(alias_data)
@@ -54,6 +62,15 @@ def test_verify_component_aliases_error(config):
     alias_data = {"baz": "bar"}
     config.register_component_aliases(alias_data)
     params = {"bar": {"namespace": "syn-bar"}}
+
+    with pytest.raises(click.ClickException):
+        config.verify_component_aliases(params)
+
+
+def test_verify_component_aliases_explicit_no_instance_error(config):
+    alias_data = {"baz": "bar"}
+    config.register_component_aliases(alias_data)
+    params = {"bar": {"_metadata": {"multi_instance": False}, "namespace": "syn-bar"}}
 
     with pytest.raises(click.ClickException):
         config.verify_component_aliases(params)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -16,12 +16,38 @@ def config(tmp_path: P):
     )
 
 
-def test_verify_component_aliases(config):
+def test_verify_component_aliases_no_instance(config):
+    alias_data = {"bar": "bar"}
+    config.register_component_aliases(alias_data)
+    params = {"bar": {"namespace": "syn-bar"}}
+
+    config.verify_component_aliases(params)
+
+
+def test_verify_component_aliases_metadata(config):
+    alias_data = {"baz": "bar"}
+    config.register_component_aliases(alias_data)
+    params = {"bar": {"_metadata": {"multi_instance": True}, "namespace": "syn-bar"}}
+
+    config.verify_component_aliases(params)
+
+    assert len(config._deprecation_notices) == 0
+
+
+def test_verify_component_aliases_deprecated(config):
     alias_data = {"baz": "bar"}
     config.register_component_aliases(alias_data)
     params = {"bar": {"multi_instance": True, "namespace": "syn-bar"}}
 
     config.verify_component_aliases(params)
+
+    assert len(config._deprecation_notices) == 1
+    depnotice = config._deprecation_notices[0]
+    assert (
+        "Component `bar` advertises multi-instance support in component parameter "
+        + "`multi_instance`. This has been deprecated in favor of using "
+        + "`_metadata.multi_instance`."
+    ) in depnotice
 
 
 def test_verify_component_aliases_error(config):


### PR DESCRIPTION
This PR moves the preferred location for components to advertise multi-instance support to `parameters.<component_name>._metadata.multi_instance`.

The old parameter `parameters.<component_name>.multi_instance` is still supported, but Commodore emits a deprecation notice for each component which still uses the old parameter.

Fixes #317

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
