### PR TITLE
Update link to Commodore site

### DIFF
--- a/commodore/component-template/{{ cookiecutter.slug }}/README.md
+++ b/commodore/component-template/{{ cookiecutter.slug }}/README.md
@@ -20,6 +20,6 @@ After writing the documentation, please use the `make docs-vale` command and cor
 This library is licensed under [BSD-3-Clause](LICENSE).
 For information about how to contribute see [CONTRIBUTING](CONTRIBUTING.md).
 
-[commodore]: https://docs.syn.tools/commodore/index.html
+[commodore]: https://syn.tools/commodore/
 [asciidoc]: https://asciidoctor.org/
 [antora]: https://antora.org/


### PR DESCRIPTION
The previous link presents a cert for *.apps.cloudscale-lpg-2.appuio.cloud which results in SSL_ERROR_BAD_CERT_DOMAIN.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog