### PR TITLE
Update default `kube-libsonnet` version to v1.19.0

### DIFF
--- a/commodore/dependency_mgmt.py
+++ b/commodore/dependency_mgmt.py
@@ -295,7 +295,7 @@ def inject_essential_libraries(file: P):
                 "source": {
                     "git": {"remote": "https://github.com/bitnami-labs/kube-libsonnet"}
                 },
-                "version": "v1.14.6",
+                "version": "v1.19.0",
             },
         )
 

--- a/tests/test_dependency_mgmt.py
+++ b/tests/test_dependency_mgmt.py
@@ -408,7 +408,7 @@ def test_inject_essential_libraries(tmp_path: Path):
             deps[0]["source"]["git"]["remote"]
             == "https://github.com/bitnami-labs/kube-libsonnet"
         )
-        assert deps[0]["version"] == "v1.14.6"
+        assert deps[0]["version"] == "v1.19.0"
 
 
 def test_clear_jsonnet_lock_file(tmp_path: Path):


### PR DESCRIPTION
Commodore injects `kube-libsonnet` as a dependency when compiling a cluster catalog. This commit updates the code to use the latest available tagged kube-libsonnet version as of 2022-02-23.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
