### PR TITLE
Fix docker image if running on non-`x86` architectures

### DIFF
--- a/tools/entrypoint.sh
+++ b/tools/entrypoint.sh
@@ -8,7 +8,7 @@ set -e
 
 # Ensure that we're using the correct libnss_wrapper.so
 # This should only ever fail in CI
-readonly libnss_wrapper_so=/usr/lib/x86_64-linux-gnu/libnss_wrapper.so
+readonly libnss_wrapper_so="/usr/lib/$(uname -m)-linux-gnu/libnss_wrapper.so"
 if [ ! -f "${libnss_wrapper_so}" ]; then
   echo "${libnss_wrapper_so} doesn't exist."
   exit 1


### PR DESCRIPTION
Tested on `aarch64`.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
