### PR TITLE
Fix `GitRepo.push()` when pushing to empty remote repository

### DIFF
--- a/commodore/gitrepo.py
+++ b/commodore/gitrepo.py
@@ -374,10 +374,14 @@ class GitRepo:
 
         self._repo.index.commit(commit_message, author=author, committer=author)
 
-    def push(self, remote: Optional[str] = None) -> Iterable[PushInfo]:
+    def push(
+        self, remote: Optional[str] = None, version: Optional[str] = None
+    ) -> Iterable[PushInfo]:
         if not remote:
             remote = "origin"
-        return self._repo.remote(remote).push()
+        if not version:
+            version = self._default_version()
+        return self._repo.remote(remote).push(version)
 
     def reset(self, working_tree: bool = False):
         self._repo.head.reset(working_tree=working_tree)

--- a/tests/test_gitrepo.py
+++ b/tests/test_gitrepo.py
@@ -166,3 +166,17 @@ def test_gitrepo_reset(tmp_path: Path):
     r.reset(working_tree=True)
 
     assert not r.repo.is_dirty()
+
+
+def test_gitrepo_push_empty_remote(tmp_path: Path):
+    git.Repo.init(tmp_path / "remote.git", mkdir=True, bare=True)
+    r = gitrepo.GitRepo(
+        f"file:///{tmp_path}/remote.git", tmp_path / "local", force_init=True
+    )
+
+    testf = r.working_tree_dir / "test.txt"
+    with open(testf, "w") as f:
+        f.write("Hello, world!\n")
+    r.stage_all()
+    r.commit("Initial commit")
+    r.push()


### PR DESCRIPTION
This regression got introduced by #407

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
