### PR TITLE
Add OIDC integration for Lieutenant communication

### DIFF
--- a/commodore/cli.py
+++ b/commodore/cli.py
@@ -473,7 +473,7 @@ def inventory_lint(config: Config, verbose: int, target: Tuple[str]):
     "--oidc-client",
     envvar="COMMODORE_OIDC_CLIENT",
     help="The OIDC client name.",
-    metavar="URL",
+    metavar="TEXT",
 )
 @api_url_option
 @pass_config

--- a/commodore/cli.py
+++ b/commodore/cli.py
@@ -70,11 +70,14 @@ def clean(config: Config, verbose):
     clean_working_tree(config)
 
 
-@catalog.command(name="compile", short_help="Compile the catalog.")
-@click.argument("cluster")
-@click.option(
+api_url_option = click.option(
     "--api-url", envvar="COMMODORE_API_URL", help="Lieutenant API URL.", metavar="URL"
 )
+
+
+@catalog.command(name="compile", short_help="Compile the catalog.")
+@click.argument("cluster")
+@api_url_option
 @click.option(
     "--api-token",
     envvar="COMMODORE_API_TOKEN",
@@ -472,11 +475,15 @@ def inventory_lint(config: Config, verbose: int, target: Tuple[str]):
     help="The OIDC client name.",
     metavar="URL",
 )
+@api_url_option
 @pass_config
-def commodore_login(config: Config, oidc_discovery_url: str, oidc_client: str):
+def commodore_login(
+    config: Config, oidc_discovery_url: str, oidc_client: str, api_url: str
+):
     """Login to Lieutenant"""
     config.oidc_client = oidc_client
     config.oidc_discovery_url = oidc_discovery_url
+    config.api_url = api_url
 
     login(config)
 

--- a/commodore/cli.py
+++ b/commodore/cli.py
@@ -17,6 +17,7 @@ from .component.compile import compile_component
 from .inventory.render import extract_components
 from .inventory.parameters import InventoryFacts
 from .inventory.lint_components import lint_components
+from .login import login
 
 pass_config = click.make_pass_decorator(Config)
 
@@ -453,6 +454,18 @@ def inventory_lint(config: Config, verbose: int, target: Tuple[str]):
         click.secho(f"Found {errors} errors", bold=True)
 
     sys.exit(exit_status)
+
+
+@commodore.command(
+    name="login",
+    short_help="Login to Lieutenant",
+)
+@verbosity
+@pass_config
+def commodore_login(config: Config, verbose: int):
+    """Login to Lieutenant"""
+
+    login(config)
 
 
 def main():

--- a/commodore/cli.py
+++ b/commodore/cli.py
@@ -460,10 +460,26 @@ def inventory_lint(config: Config, verbose: int, target: Tuple[str]):
     name="login",
     short_help="Login to Lieutenant",
 )
+@click.option(
+    "--oidc-discovery-url",
+    envvar="COMMODORE_OIDC_DISCOVERY_URL",
+    help="The discovery URL of the IdP.",
+    metavar="URL",
+)
+@click.option(
+    "--oidc-client",
+    envvar="COMMODORE_OIDC_CLIENT",
+    help="The OIDC client name.",
+    metavar="URL",
+)
 @verbosity
 @pass_config
-def commodore_login(config: Config, verbose: int):
+def commodore_login(
+    config: Config, verbose: int, oidc_discovery_url: str, oidc_client: str
+):
     """Login to Lieutenant"""
+    config.oidc_client = oidc_client
+    config.oidc_discovery_url = oidc_discovery_url
 
     login(config)
 

--- a/commodore/cli.py
+++ b/commodore/cli.py
@@ -472,11 +472,8 @@ def inventory_lint(config: Config, verbose: int, target: Tuple[str]):
     help="The OIDC client name.",
     metavar="URL",
 )
-@verbosity
 @pass_config
-def commodore_login(
-    config: Config, verbose: int, oidc_discovery_url: str, oidc_client: str
-):
+def commodore_login(config: Config, oidc_discovery_url: str, oidc_client: str):
     """Login to Lieutenant"""
     config.oidc_client = oidc_client
     config.oidc_discovery_url = oidc_discovery_url

--- a/commodore/config.py
+++ b/commodore/config.py
@@ -9,6 +9,7 @@ import click
 from commodore.component import Component, component_parameters_key
 from .gitrepo import GitRepo
 from .inventory import Inventory
+from . import tokencache
 
 
 class Migration(Enum):
@@ -102,6 +103,8 @@ class Config:
 
     @property
     def api_token(self):
+        if self._api_token is None and self.api_url:
+            self._api_token = tokencache.get(self.api_url)
         return self._api_token
 
     @api_token.setter
@@ -119,6 +122,8 @@ class Config:
                 else:
                     raise
             self._api_token = api_token.strip()
+        else:
+            self._api_token = None
 
     @property
     def global_repo_revision_override(self):

--- a/commodore/config.py
+++ b/commodore/config.py
@@ -24,6 +24,9 @@ class Config:
     _deprecation_notices: List[str]
     _migration: Optional[Migration]
 
+    oidc_client: Optional[str]
+    oidc_discovery_url: Optional[str]
+
     # pylint: disable=too-many-arguments
     def __init__(
         self,

--- a/commodore/config.py
+++ b/commodore/config.py
@@ -37,6 +37,8 @@ class Config:
         self._work_dir = work_dir.resolve()
         self.api_url = api_url
         self.api_token = api_token
+        self.oidc_client = None
+        self.oidc_discovery_url = None
         self._components = {}
         self._config_repos = {}
         self._component_aliases = {}

--- a/commodore/login.py
+++ b/commodore/login.py
@@ -3,43 +3,49 @@ import threading
 import webbrowser
 import json
 
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import urlparse, parse_qs
+
 from oauthlib.oauth2 import WebApplicationClient
 
 import requests
 
-import uvicorn
-from fastapi import FastAPI
-from fastapi.responses import HTMLResponse
-
 from .config import Config
 
-client = WebApplicationClient("syn-lieutenant-dev")
 
-app = FastAPI()
+class OIDCServer(BaseHTTPRequestHandler):
+    client = WebApplicationClient("syn-lieutenant-dev")
+
+    def do_GET(self):
+        print(self.path)
+        query_components = parse_qs(urlparse(self.path).query)
+        code = query_components["code"]
+        token_url, headers, body = self.client.prepare_token_request(
+            "https://id.test.vshn.net/auth/realms/VSHN-main-dev-realm/protocol/openid-connect/token",
+            redirect_url="http://localhost:8000",
+            code=code[0],
+        )
+        token_response = requests.post(
+            token_url,
+            headers=headers,
+            data=body,
+        )
+
+        print(
+            self.client.parse_request_body_response(json.dumps(token_response.json()))[
+                "id_token"
+            ]
+        )
+
+        self.send_response(200)
+        self.send_header("Content-type", "text/html")
+        self.end_headers()
+        self.wfile.write(str.encode(success_page))
+
+        return
 
 
-@app.get("/")
-async def callback(code: str = ""):
-    token_url, headers, body = client.prepare_token_request(
-        "https://id.test.vshn.net/auth/realms/VSHN-main-dev-realm/protocol/openid-connect/token",
-        # authorization_response="http://localhost:8000",
-        redirect_url="http://localhost:8000",
-        code=code,
-    )
-    token_response = requests.post(
-        token_url,
-        headers=headers,
-        data=body,
-    )
-
-    print(
-        client.parse_request_body_response(json.dumps(token_response.json()))[
-            "id_token"
-        ]
-    )
-    return HTMLResponse(
-        status_code=200,
-        content="""
+success_page = """
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -70,20 +76,21 @@ async def callback(code: str = ""):
 	</div>
 </body>
 </html>
-""",
-    )
+"""
 
 
-def _start_server():
-    uvicorn.run(app, port=8000, log_level="error")
+def start_server():
+    webServer = HTTPServer(("localhost", 8000), OIDCServer)
+    webServer.serve_forever()
 
 
 def login(config: Config):
-    server_thread = threading.Thread(target=_start_server)
+    server_thread = threading.Thread(target=start_server)
     server_thread.start()
 
     # TODO(glrf) That's racy
-    request_uri = client.prepare_request_uri(
+    c = WebApplicationClient("syn-lieutenant-dev")
+    request_uri = c.prepare_request_uri(
         "https://id.test.vshn.net/auth/realms/VSHN-main-dev-realm/protocol/openid-connect/auth",
         redirect_uri="http://localhost:8000",
         scope=["openid", "email", "profile"],

--- a/commodore/login.py
+++ b/commodore/login.py
@@ -1,0 +1,93 @@
+import time
+import threading
+import webbrowser
+import json
+
+from oauthlib.oauth2 import WebApplicationClient
+
+import requests
+
+import uvicorn
+from fastapi import FastAPI
+from fastapi.responses import HTMLResponse
+
+from .config import Config
+
+client = WebApplicationClient("syn-lieutenant-dev")
+
+app = FastAPI()
+
+
+@app.get("/")
+async def callback(code: str = ""):
+    token_url, headers, body = client.prepare_token_request(
+        "https://id.test.vshn.net/auth/realms/VSHN-main-dev-realm/protocol/openid-connect/token",
+        # authorization_response="http://localhost:8000",
+        redirect_url="http://localhost:8000",
+        code=code,
+    )
+    token_response = requests.post(
+        token_url,
+        headers=headers,
+        data=body,
+    )
+
+    print(
+        client.parse_request_body_response(json.dumps(token_response.json()))[
+            "id_token"
+        ]
+    )
+    return HTMLResponse(
+        status_code=200,
+        content="""
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title>Authorized</title>
+	<script>
+		window.close()
+	</script>
+	<style>
+		body {
+			background-color: #eee;
+			margin: 0;
+			padding: 0;
+			font-family: sans-serif;
+		}
+		.placeholder {
+			margin: 2em;
+			padding: 2em;
+			background-color: #fff;
+			border-radius: 1em;
+		}
+	</style>
+</head>
+<body>
+	<div class="placeholder">
+		<h1>Authorized</h1>
+		<p>You can close this window.</p>
+	</div>
+</body>
+</html>
+""",
+    )
+
+
+def _start_server():
+    uvicorn.run(app, port=8000, log_level="error")
+
+
+def login(config: Config):
+    server_thread = threading.Thread(target=_start_server)
+    server_thread.start()
+
+    # TODO(glrf) That's racy
+    request_uri = client.prepare_request_uri(
+        "https://id.test.vshn.net/auth/realms/VSHN-main-dev-realm/protocol/openid-connect/auth",
+        redirect_uri="http://localhost:8000",
+        scope=["openid", "email", "profile"],
+    )
+    print(request_uri + "\n")
+    webbrowser.open(request_uri)
+    server_thread.join()

--- a/commodore/login.py
+++ b/commodore/login.py
@@ -150,7 +150,7 @@ success_page = """
     <meta charset="UTF-8">
     <title>Authorized</title>
     <script>
-        window.close()
+        setTimeout(window.close, 5000);
     </script>
      <style>
         body {

--- a/commodore/login.py
+++ b/commodore/login.py
@@ -117,18 +117,18 @@ def login(config: Config):
     OIDCHandler.done = done_queue
 
     OIDCHandler.token_url = idp_cfg["token_endpoint"]
-    OIDCHandler.redirect_url = "http://localhost:8000"
+    OIDCHandler.redirect_url = "http://localhost:18000"
     OIDCHandler.lieutenant_url = config.api_url
 
-    server = HTTPServer(("localhost", 8000), OIDCHandler)
+    server = HTTPServer(("localhost", 18000), OIDCHandler)
     server_thread = threading.Thread(target=server.serve_forever)
     server_thread.daemon = True
     server_thread.start()
 
-    # TODO(glrf) That's racy
+    # That's racy, but it should work most of the time and if not the browser shoudld retry
     request_uri = client.prepare_request_uri(
         idp_cfg["authorization_endpoint"],
-        redirect_uri="http://localhost:8000",
+        redirect_uri="http://localhost:18000",
         scope=["openid", "email", "profile"],
     )
 

--- a/commodore/login.py
+++ b/commodore/login.py
@@ -1,8 +1,10 @@
-from typing import Optional
+from typing import Optional, Any
 import threading
 from queue import Queue
 import webbrowser
 import json
+from functools import partial
+
 
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from urllib.parse import urlparse, parse_qs
@@ -10,13 +12,52 @@ from urllib.parse import urlparse, parse_qs
 import click
 import requests
 
+# pylint: disable=redefined-builtin
+from requests.exceptions import ConnectionError, HTTPError
+
 from oauthlib.oauth2 import WebApplicationClient
 
 from .config import Config
 from . import tokencache
 
 
-class OIDCHandler(BaseHTTPRequestHandler):
+class OIDCError(Exception):
+    pass
+
+
+class OIDCCallbackServer:
+    done_queue: Queue = Queue()
+    thread: threading.Thread
+    server: HTTPServer
+
+    def __init__(
+        self,
+        client: WebApplicationClient,
+        token_url: str,
+        lieutenant_url: Optional[str],
+    ):
+        self.client = client
+        self.token_endpoint = token_url
+        self.lieutenant_url = lieutenant_url
+
+        handler = partial(
+            OIDCCallbackHandler, client, token_url, lieutenant_url, self.done_queue
+        )
+
+        self.server = HTTPServer(("localhost", 18000), handler)
+        self.thread = threading.Thread(target=self.server.serve_forever)
+        self.thread.daemon = True
+
+    def start(self):
+        self.thread.start()
+
+    def join(self):
+        self.done_queue.get()
+        self.server.shutdown()
+        self.thread.join()
+
+
+class OIDCCallbackHandler(BaseHTTPRequestHandler):
     client: WebApplicationClient
     done: Queue
 
@@ -24,6 +65,22 @@ class OIDCHandler(BaseHTTPRequestHandler):
     redirect_url: str
 
     lieutenant_url: Optional[str]
+
+    def __init__(
+        self,
+        client: WebApplicationClient,
+        token_url: str,
+        lieutenant_url: Optional[str],
+        done_queue: Queue,
+        *args,
+        **kwargs,
+    ):
+        self.client = client
+        self.done = done_queue
+        self.lieutenant_url = lieutenant_url
+        self.token_url = token_url
+        self.redirect_url = "http://localhost:18000"
+        super().__init__(*args, **kwargs)
 
     # pylint: disable=unused-argument
     # pylint: disable=redefined-builtin
@@ -102,39 +159,42 @@ success_page = """
 """
 
 
+def get_idp_cfg(discovery_url: str) -> Any:
+    try:
+        r = requests.get(discovery_url)
+    except ConnectionError as e:
+        raise OIDCError(f"Unable to connect to IDP at {discovery_url}") from e
+    try:
+        resp = json.loads(r.text)
+    except json.JSONDecodeError as e:
+        raise OIDCError("Client error: Unable to parse JSON") from e
+    try:
+        r.raise_for_status()
+    except HTTPError as e:
+        raise OIDCError(f"IDP returned {r.status_code} {e}") from e
+    else:
+        return resp
+
+
 def login(config: Config):
     if config.oidc_client is None:
         raise click.ClickException("Required OIDC client not set")
-    client = WebApplicationClient(config.oidc_client)
-
     if config.oidc_discovery_url is None:
         raise click.ClickException("Required OIDC discovery URL not set")
-    idp_cfg = requests.get(config.oidc_discovery_url).json()
 
-    done_queue: Queue = Queue()
+    client = WebApplicationClient(config.oidc_client)
+    idp_cfg = get_idp_cfg(config.oidc_discovery_url)
 
-    OIDCHandler.client = client
-    OIDCHandler.done = done_queue
+    server = OIDCCallbackServer(client, idp_cfg["token_endpoint"], config.api_url)
+    server.start()
 
-    OIDCHandler.token_url = idp_cfg["token_endpoint"]
-    OIDCHandler.redirect_url = "http://localhost:18000"
-    OIDCHandler.lieutenant_url = config.api_url
-
-    server = HTTPServer(("localhost", 18000), OIDCHandler)
-    server_thread = threading.Thread(target=server.serve_forever)
-    server_thread.daemon = True
-    server_thread.start()
-
-    # That's racy, but it should work most of the time and if not the browser shoudld retry
+    # That's racy, but it should work most of the time and if not the browser should retry
     request_uri = client.prepare_request_uri(
         idp_cfg["authorization_endpoint"],
         redirect_uri="http://localhost:18000",
         scope=["openid", "email", "profile"],
     )
-
     print(f"Follow this link if it doesn't open automatically \n\n{request_uri}\n")
     webbrowser.open(request_uri)
 
-    done_queue.get()
-    server.shutdown()
-    server_thread.join()
+    server.join()

--- a/commodore/login.py
+++ b/commodore/login.py
@@ -1,17 +1,15 @@
-import time
 import threading
 from queue import Queue
 import webbrowser
 import json
 
-import click
-
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from urllib.parse import urlparse, parse_qs
 
-from oauthlib.oauth2 import WebApplicationClient
-
+import click
 import requests
+
+from oauthlib.oauth2 import WebApplicationClient
 
 from .config import Config
 
@@ -23,6 +21,8 @@ class OIDCHandler(BaseHTTPRequestHandler):
     token_url: str
     redirect_url: str
 
+    # pylint: disable=unused-argument
+    # pylint: disable=redefined-builtin
     def log_message(self, format, *args):
         return
 
@@ -66,46 +66,46 @@ success_page = """
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta charset="UTF-8">
-	<title>Authorized</title>
-	<script>
-		window.close()
-	</script>
-	<style>
-		body {
-			background-color: #eee;
-			margin: 0;
-			padding: 0;
-			font-family: sans-serif;
-		}
-		.placeholder {
-			margin: 2em;
-			padding: 2em;
-			background-color: #fff;
-			border-radius: 1em;
-		}
-	</style>
+    <meta charset="UTF-8">
+    <title>Authorized</title>
+    <script>
+        window.close()
+    </script>
+     <style>
+        body {
+            background-color: #eee;
+            margin: 0;
+            padding: 0;
+            font-family: sans-serif;
+        }
+        .placeholder {
+            margin: 2em;
+            padding: 2em;
+            background-color: #fff;
+            border-radius: 1em;
+        }
+    </style>
 </head>
 <body>
-	<div class="placeholder">
-		<h1>Authorized</h1>
-		<p>You can close this window.</p>
-	</div>
+    <div class="placeholder">
+        <h1>Authorized</h1>
+        <p>You can close this window.</p>
+    </div>
 </body>
 </html>
 """
 
 
 def login(config: Config):
-    if config.oidc_client == None:
-        raise click.ClickException(f"Required OIDC client not set")
+    if config.oidc_client is None:
+        raise click.ClickException("Required OIDC client not set")
     client = WebApplicationClient(config.oidc_client)
 
-    if config.oidc_discovery_url == None:
-        raise click.ClickException(f"Required OIDC discovery URL not set")
+    if config.oidc_discovery_url is None:
+        raise click.ClickException("Required OIDC discovery URL not set")
     idp_cfg = requests.get(config.oidc_discovery_url).json()
 
-    done_queue = Queue()
+    done_queue: Queue = Queue()
 
     OIDCHandler.client = client
     OIDCHandler.done = done_queue

--- a/commodore/tokencache.py
+++ b/commodore/tokencache.py
@@ -3,12 +3,12 @@ from typing import Optional
 from pathlib import Path
 import json
 
-cache_name = "{home}/.cache/commodore/token".format(home=Path.home())
+cache_name = f"{Path.home()}/.cache/commodore/token"
 
 
 def save(lieutenant: str, token: str):
     try:
-        with open(cache_name, "r") as f:
+        with open(cache_name, "r", encoding="utf-8") as f:
             cache = json.load(f)
     except (IOError, FileNotFoundError):
         cache = {}
@@ -16,14 +16,14 @@ def save(lieutenant: str, token: str):
     cache[lieutenant] = token
 
     os.makedirs(os.path.dirname(cache_name), exist_ok=True)
-    with open(cache_name, "w") as f:
+    with open(cache_name, "w", encoding="utf-8") as f:
         f.write(json.dumps(cache, indent=1))
 
 
 def get(lieutenant: str) -> Optional[str]:
     try:
-        with open(cache_name, "r") as f:
+        with open(cache_name, "r", encoding="utf-8") as f:
             cache = json.load(f)
     except (IOError, FileNotFoundError):
-        return
+        return None
     return cache[lieutenant]

--- a/commodore/tokencache.py
+++ b/commodore/tokencache.py
@@ -1,0 +1,29 @@
+import os
+from typing import Optional
+from pathlib import Path
+import json
+
+cache_name = "{home}/.cache/commodore/token".format(home=Path.home())
+
+
+def save(lieutenant: str, token: str):
+    try:
+        with open(cache_name, "r") as f:
+            cache = json.load(f)
+    except (IOError, FileNotFoundError):
+        cache = {}
+
+    cache[lieutenant] = token
+
+    os.makedirs(os.path.dirname(cache_name), exist_ok=True)
+    with open(cache_name, "w") as f:
+        f.write(json.dumps(cache, indent=1))
+
+
+def get(lieutenant: str) -> Optional[str]:
+    try:
+        with open(cache_name, "r") as f:
+            cache = json.load(f)
+    except (IOError, FileNotFoundError):
+        return
+    return cache[lieutenant]

--- a/commodore/tokencache.py
+++ b/commodore/tokencache.py
@@ -3,7 +3,9 @@ from typing import Optional
 from pathlib import Path
 import json
 
-cache_name = f"{Path.home()}/.cache/commodore/token"
+from xdg.BaseDirectory import xdg_cache_home
+
+cache_name = Path(xdg_cache_home) / "commodore" / "token"
 
 
 def save(lieutenant: str, token: str):

--- a/docs/modules/ROOT/pages/reference/cli.adoc
+++ b/docs/modules/ROOT/pages/reference/cli.adoc
@@ -167,3 +167,16 @@ This command doesn't have any command line options.
 == Inventory Lint
 
 No command line flags
+
+== Login
+
+*--oidc-discovery-url* URL::
+  The discovery URL of the IdP.
+  OpenID Connect defines a discovery mechanism, called OpenID Connect Discovery, where an OpenID server publishes its metadata at a well-known URL.
+  Typically this is at `https://auth.example.com/.well-known/openid-configuration`.
+
+*--oidc-client* TEXT::
+  The OIDC client-id.
+
+*--api-url* URL::
+  Lieutenant API URL.

--- a/docs/modules/ROOT/pages/reference/commands.adoc
+++ b/docs/modules/ROOT/pages/reference/commands.adoc
@@ -126,3 +126,13 @@ Directories are linted recursively and the same skipping logic as for individual
 
 If no errors are found the command exits with return value 0.
 If any errors are found the command exits with return value 1.
+
+
+== Login
+
+  commodore login
+
+This command allows you to authenticate yourself to Lieutenant using OIDC, if OIDC integrations is enabled for your Lieutenant instance.
+
+The command will open a web-browser where you can authenticate yourself to the configured IdP.
+Commodore will use the returned token for future commands if no other token is explicitly provided.

--- a/poetry.lock
+++ b/poetry.lock
@@ -7,24 +7,6 @@ optional = false
 python-versions = "*"
 
 [[package]]
-name = "anyio"
-version = "3.5.0"
-description = "High level compatibility layer for multiple asynchronous event loop implementations"
-category = "main"
-optional = false
-python-versions = ">=3.6.2"
-
-[package.dependencies]
-idna = ">=2.8"
-sniffio = ">=1.1"
-typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
-
-[package.extras]
-doc = ["packaging", "sphinx-rtd-theme", "sphinx-autodoc-typehints (>=1.2.0)"]
-test = ["coverage[toml] (>=4.5)", "hypothesis (>=4.0)", "pytest (>=6.0)", "pytest-mock (>=3.6.1)", "trustme", "contextlib2", "uvloop (<0.15)", "mock (>=4)", "uvloop (>=0.15)"]
-trio = ["trio (>=0.16)"]
-
-[[package]]
 name = "arrow"
 version = "1.2.2"
 description = "Better dates & times for Python"
@@ -35,20 +17,6 @@ python-versions = ">=3.6"
 [package.dependencies]
 python-dateutil = ">=2.7.0"
 typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
-
-[[package]]
-name = "asgiref"
-version = "3.5.0"
-description = "ASGI specs, helper code, and adapters"
-category = "main"
-optional = false
-python-versions = ">=3.7"
-
-[package.dependencies]
-typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
-
-[package.extras]
-tests = ["pytest", "pytest-asyncio", "mypy (>=0.800)"]
 
 [[package]]
 name = "atomicwrites"
@@ -340,24 +308,6 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 testing = ["pre-commit"]
 
 [[package]]
-name = "fastapi"
-version = "0.75.0"
-description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
-category = "main"
-optional = false
-python-versions = ">=3.6.1"
-
-[package.dependencies]
-pydantic = ">=1.6.2,<1.7 || >1.7,<1.7.1 || >1.7.1,<1.7.2 || >1.7.2,<1.7.3 || >1.7.3,<1.8 || >1.8,<1.8.1 || >1.8.1,<2.0.0"
-starlette = "0.17.1"
-
-[package.extras]
-all = ["requests (>=2.24.0,<3.0.0)", "jinja2 (>=2.11.2,<4.0.0)", "python-multipart (>=0.0.5,<0.0.6)", "itsdangerous (>=1.1.0,<3.0.0)", "pyyaml (>=5.3.1,<6.0.0)", "ujson (>=4.0.1,<5.0.0)", "orjson (>=3.2.1,<4.0.0)", "email_validator (>=1.1.1,<2.0.0)", "uvicorn[standard] (>=0.12.0,<0.16.0)"]
-dev = ["python-jose[cryptography] (>=3.3.0,<4.0.0)", "passlib[bcrypt] (>=1.7.2,<2.0.0)", "autoflake (>=1.4.0,<2.0.0)", "flake8 (>=3.8.3,<4.0.0)", "uvicorn[standard] (>=0.12.0,<0.16.0)"]
-doc = ["mkdocs (>=1.1.2,<2.0.0)", "mkdocs-material (>=8.1.4,<9.0.0)", "mdx-include (>=1.4.1,<2.0.0)", "mkdocs-markdownextradata-plugin (>=0.1.7,<0.3.0)", "typer-cli (>=0.0.12,<0.0.13)", "pyyaml (>=5.3.1,<6.0.0)"]
-test = ["pytest (>=6.2.4,<7.0.0)", "pytest-cov (>=2.12.0,<4.0.0)", "mypy (==0.910)", "flake8 (>=3.8.3,<4.0.0)", "black (==21.9b0)", "isort (>=5.0.6,<6.0.0)", "requests (>=2.24.0,<3.0.0)", "httpx (>=0.14.0,<0.19.0)", "email_validator (>=1.1.1,<2.0.0)", "sqlalchemy (>=1.3.18,<1.5.0)", "peewee (>=3.13.3,<4.0.0)", "databases[sqlite] (>=0.3.2,<0.6.0)", "orjson (>=3.2.1,<4.0.0)", "ujson (>=4.0.1,<5.0.0)", "python-multipart (>=0.0.5,<0.0.6)", "flask (>=1.1.2,<3.0.0)", "anyio[trio] (>=3.2.1,<4.0.0)", "types-ujson (==0.1.1)", "types-orjson (==3.6.0)", "types-dataclasses (==0.1.7)"]
-
-[[package]]
 name = "filelock"
 version = "3.6.0"
 description = "A platform independent file lock."
@@ -474,17 +424,6 @@ protobuf = ">=3.12.0"
 
 [package.extras]
 grpc = ["grpcio (>=1.0.0)"]
-
-[[package]]
-name = "h11"
-version = "0.13.0"
-description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
-category = "main"
-optional = false
-python-versions = ">=3.6"
-
-[package.dependencies]
-typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "httplib2"
@@ -895,21 +834,6 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
-name = "pydantic"
-version = "1.9.0"
-description = "Data validation and settings management using python 3.6 type hinting"
-category = "main"
-optional = false
-python-versions = ">=3.6.1"
-
-[package.dependencies]
-typing-extensions = ">=3.7.4.3"
-
-[package.extras]
-dotenv = ["python-dotenv (>=0.10.4)"]
-email = ["email-validator (>=1.0.3)"]
-
-[[package]]
 name = "pyjwt"
 version = "2.1.0"
 description = "JSON Web Token implementation in Python"
@@ -1178,29 +1102,6 @@ optional = false
 python-versions = ">=3.5"
 
 [[package]]
-name = "sniffio"
-version = "1.2.0"
-description = "Sniff out which async library your code is running under"
-category = "main"
-optional = false
-python-versions = ">=3.5"
-
-[[package]]
-name = "starlette"
-version = "0.17.1"
-description = "The little ASGI library that shines."
-category = "main"
-optional = false
-python-versions = ">=3.6"
-
-[package.dependencies]
-anyio = ">=3.0.0,<4"
-typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
-
-[package.extras]
-full = ["itsdangerous", "jinja2", "python-multipart", "pyyaml", "requests"]
-
-[[package]]
 name = "text-unidecode"
 version = "1.3"
 description = "The most basic Text::Unidecode port"
@@ -1296,23 +1197,6 @@ secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "cer
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
-name = "uvicorn"
-version = "0.17.6"
-description = "The lightning-fast ASGI server."
-category = "main"
-optional = false
-python-versions = ">=3.7"
-
-[package.dependencies]
-asgiref = ">=3.4.0"
-click = ">=7.0"
-h11 = ">=0.8"
-typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
-
-[package.extras]
-standard = ["websockets (>=10.0)", "httptools (>=0.4.0)", "watchgod (>=0.6)", "python-dotenv (>=0.13)", "PyYAML (>=5.1)", "uvloop (>=0.14.0,!=0.15.0,!=0.15.1)", "colorama (>=0.4)"]
-
-[[package]]
 name = "virtualenv"
 version = "20.13.4"
 description = "Virtual Python Environment builder"
@@ -1374,24 +1258,16 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7, <3.11"
-content-hash = "0ee8885318e5a1b4653941d7429f45825cfbb12ef169843cc61c9fcf8fb8de22"
+content-hash = "a72817fc6124d1dba9b1a142523a6ffd482448ecd6b8b4b7af79e1bf43e6a151"
 
 [metadata.files]
 addict = [
     {file = "addict-2.4.0-py3-none-any.whl", hash = "sha256:249bb56bbfd3cdc2a004ea0ff4c2b6ddc84d53bc2194761636eb314d5cfa5dfc"},
     {file = "addict-2.4.0.tar.gz", hash = "sha256:b3b2210e0e067a281f5646c8c5db92e99b7231ea8b0eb5f74dbdf9e259d4e494"},
 ]
-anyio = [
-    {file = "anyio-3.5.0-py3-none-any.whl", hash = "sha256:b5fa16c5ff93fa1046f2eeb5bbff2dad4d3514d6cda61d02816dba34fa8c3c2e"},
-    {file = "anyio-3.5.0.tar.gz", hash = "sha256:a0aeffe2fb1fdf374a8e4b471444f0f3ac4fb9f5a5b542b48824475e0042a5a6"},
-]
 arrow = [
     {file = "arrow-1.2.2-py3-none-any.whl", hash = "sha256:d622c46ca681b5b3e3574fcb60a04e5cc81b9625112d5fb2b44220c36c892177"},
     {file = "arrow-1.2.2.tar.gz", hash = "sha256:05caf1fd3d9a11a1135b2b6f09887421153b94558e5ef4d090b567b47173ac2b"},
-]
-asgiref = [
-    {file = "asgiref-3.5.0-py3-none-any.whl", hash = "sha256:88d59c13d634dcffe0510be048210188edd79aeccb6a6c9028cdad6f31d730a9"},
-    {file = "asgiref-3.5.0.tar.gz", hash = "sha256:2f8abc20f7248433085eda803936d98992f1343ddb022065779f37c5da0181d0"},
 ]
 atomicwrites = [
     {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
@@ -1561,10 +1437,6 @@ execnet = [
     {file = "execnet-1.9.0-py2.py3-none-any.whl", hash = "sha256:a295f7cc774947aac58dde7fdc85f4aa00c42adf5d8f5468fc630c1acf30a142"},
     {file = "execnet-1.9.0.tar.gz", hash = "sha256:8f694f3ba9cc92cab508b152dcfe322153975c29bda272e2fd7f3f00f36e47c5"},
 ]
-fastapi = [
-    {file = "fastapi-0.75.0-py3-none-any.whl", hash = "sha256:43d12891b78fc497a50623e9c7c24640c569489f060acd9ce2c4902080487a93"},
-    {file = "fastapi-0.75.0.tar.gz", hash = "sha256:124774ce4cb3322841965f559669b233a0b8d343ea24fdd8b293253c077220d7"},
-]
 filelock = [
     {file = "filelock-3.6.0-py3-none-any.whl", hash = "sha256:f8314284bfffbdcfa0ff3d7992b023d4c628ced6feb957351d4c48d059f56bc0"},
     {file = "filelock-3.6.0.tar.gz", hash = "sha256:9cd540a9352e432c7246a48fe4e8712b10acb1df2ad1f30e8c070b82ae1fed85"},
@@ -1596,10 +1468,6 @@ google-auth-httplib2 = [
 googleapis-common-protos = [
     {file = "googleapis-common-protos-1.53.0.tar.gz", hash = "sha256:a88ee8903aa0a81f6c3cec2d5cf62d3c8aa67c06439b0496b49048fb1854ebf4"},
     {file = "googleapis_common_protos-1.53.0-py2.py3-none-any.whl", hash = "sha256:f6d561ab8fb16b30020b940e2dd01cd80082f4762fa9f3ee670f4419b4b8dbd0"},
-]
-h11 = [
-    {file = "h11-0.13.0-py3-none-any.whl", hash = "sha256:8ddd78563b633ca55346c8cd41ec0af27d3c79931828beffb46ce70a379e7442"},
-    {file = "h11-0.13.0.tar.gz", hash = "sha256:70813c1135087a248a4d38cc0e1a0181ffab2188141a93eaf567940c3957ff06"},
 ]
 httplib2 = [
     {file = "httplib2-0.19.1-py3-none-any.whl", hash = "sha256:2ad195faf9faf079723f6714926e9a9061f694d07724b846658ce08d40f522b4"},
@@ -1837,43 +1705,6 @@ pycparser = [
     {file = "pycparser-2.20-py2.py3-none-any.whl", hash = "sha256:7582ad22678f0fcd81102833f60ef8d0e57288b6b5fb00323d101be910e35705"},
     {file = "pycparser-2.20.tar.gz", hash = "sha256:2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0"},
 ]
-pydantic = [
-    {file = "pydantic-1.9.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:cb23bcc093697cdea2708baae4f9ba0e972960a835af22560f6ae4e7e47d33f5"},
-    {file = "pydantic-1.9.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1d5278bd9f0eee04a44c712982343103bba63507480bfd2fc2790fa70cd64cf4"},
-    {file = "pydantic-1.9.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ab624700dc145aa809e6f3ec93fb8e7d0f99d9023b713f6a953637429b437d37"},
-    {file = "pydantic-1.9.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c8d7da6f1c1049eefb718d43d99ad73100c958a5367d30b9321b092771e96c25"},
-    {file = "pydantic-1.9.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:3c3b035103bd4e2e4a28da9da7ef2fa47b00ee4a9cf4f1a735214c1bcd05e0f6"},
-    {file = "pydantic-1.9.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:3011b975c973819883842c5ab925a4e4298dffccf7782c55ec3580ed17dc464c"},
-    {file = "pydantic-1.9.0-cp310-cp310-win_amd64.whl", hash = "sha256:086254884d10d3ba16da0588604ffdc5aab3f7f09557b998373e885c690dd398"},
-    {file = "pydantic-1.9.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:0fe476769acaa7fcddd17cadd172b156b53546ec3614a4d880e5d29ea5fbce65"},
-    {file = "pydantic-1.9.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c8e9dcf1ac499679aceedac7e7ca6d8641f0193c591a2d090282aaf8e9445a46"},
-    {file = "pydantic-1.9.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d1e4c28f30e767fd07f2ddc6f74f41f034d1dd6bc526cd59e63a82fe8bb9ef4c"},
-    {file = "pydantic-1.9.0-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:c86229333cabaaa8c51cf971496f10318c4734cf7b641f08af0a6fbf17ca3054"},
-    {file = "pydantic-1.9.0-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:c0727bda6e38144d464daec31dff936a82917f431d9c39c39c60a26567eae3ed"},
-    {file = "pydantic-1.9.0-cp36-cp36m-win_amd64.whl", hash = "sha256:dee5ef83a76ac31ab0c78c10bd7d5437bfdb6358c95b91f1ba7ff7b76f9996a1"},
-    {file = "pydantic-1.9.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:d9c9bdb3af48e242838f9f6e6127de9be7063aad17b32215ccc36a09c5cf1070"},
-    {file = "pydantic-1.9.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ee7e3209db1e468341ef41fe263eb655f67f5c5a76c924044314e139a1103a2"},
-    {file = "pydantic-1.9.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0b6037175234850ffd094ca77bf60fb54b08b5b22bc85865331dd3bda7a02fa1"},
-    {file = "pydantic-1.9.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:b2571db88c636d862b35090ccf92bf24004393f85c8870a37f42d9f23d13e032"},
-    {file = "pydantic-1.9.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:8b5ac0f1c83d31b324e57a273da59197c83d1bb18171e512908fe5dc7278a1d6"},
-    {file = "pydantic-1.9.0-cp37-cp37m-win_amd64.whl", hash = "sha256:bbbc94d0c94dd80b3340fc4f04fd4d701f4b038ebad72c39693c794fd3bc2d9d"},
-    {file = "pydantic-1.9.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:e0896200b6a40197405af18828da49f067c2fa1f821491bc8f5bde241ef3f7d7"},
-    {file = "pydantic-1.9.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:7bdfdadb5994b44bd5579cfa7c9b0e1b0e540c952d56f627eb227851cda9db77"},
-    {file = "pydantic-1.9.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:574936363cd4b9eed8acdd6b80d0143162f2eb654d96cb3a8ee91d3e64bf4cf9"},
-    {file = "pydantic-1.9.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c556695b699f648c58373b542534308922c46a1cda06ea47bc9ca45ef5b39ae6"},
-    {file = "pydantic-1.9.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:f947352c3434e8b937e3aa8f96f47bdfe6d92779e44bb3f41e4c213ba6a32145"},
-    {file = "pydantic-1.9.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:5e48ef4a8b8c066c4a31409d91d7ca372a774d0212da2787c0d32f8045b1e034"},
-    {file = "pydantic-1.9.0-cp38-cp38-win_amd64.whl", hash = "sha256:96f240bce182ca7fe045c76bcebfa0b0534a1bf402ed05914a6f1dadff91877f"},
-    {file = "pydantic-1.9.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:815ddebb2792efd4bba5488bc8fde09c29e8ca3227d27cf1c6990fc830fd292b"},
-    {file = "pydantic-1.9.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:6c5b77947b9e85a54848343928b597b4f74fc364b70926b3c4441ff52620640c"},
-    {file = "pydantic-1.9.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4c68c3bc88dbda2a6805e9a142ce84782d3930f8fdd9655430d8576315ad97ce"},
-    {file = "pydantic-1.9.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5a79330f8571faf71bf93667d3ee054609816f10a259a109a0738dac983b23c3"},
-    {file = "pydantic-1.9.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:f5a64b64ddf4c99fe201ac2724daada8595ada0d102ab96d019c1555c2d6441d"},
-    {file = "pydantic-1.9.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a733965f1a2b4090a5238d40d983dcd78f3ecea221c7af1497b845a9709c1721"},
-    {file = "pydantic-1.9.0-cp39-cp39-win_amd64.whl", hash = "sha256:2cc6a4cb8a118ffec2ca5fcb47afbacb4f16d0ab8b7350ddea5e8ef7bcc53a16"},
-    {file = "pydantic-1.9.0-py3-none-any.whl", hash = "sha256:085ca1de245782e9b46cefcf99deecc67d418737a1fd3f6a4f511344b613a5b3"},
-    {file = "pydantic-1.9.0.tar.gz", hash = "sha256:742645059757a56ecd886faf4ed2441b9c0cd406079c2b4bee51bcc3fbcd510a"},
-]
 pyjwt = [
     {file = "PyJWT-2.1.0-py3-none-any.whl", hash = "sha256:934d73fbba91b0483d3857d1aff50e96b2a892384ee2c17417ed3203f173fca1"},
     {file = "PyJWT-2.1.0.tar.gz", hash = "sha256:fba44e7898bbca160a2b2b501f492824fc8382485d3a6f11ba5d0c1937ce6130"},
@@ -2019,14 +1850,6 @@ smmap = [
     {file = "smmap-4.0.0-py2.py3-none-any.whl", hash = "sha256:a9a7479e4c572e2e775c404dcd3080c8dc49f39918c2cf74913d30c4c478e3c2"},
     {file = "smmap-4.0.0.tar.gz", hash = "sha256:7e65386bd122d45405ddf795637b7f7d2b532e7e401d46bbe3fb49b9986d5182"},
 ]
-sniffio = [
-    {file = "sniffio-1.2.0-py3-none-any.whl", hash = "sha256:471b71698eac1c2112a40ce2752bb2f4a4814c22a54a3eed3676bc0f5ca9f663"},
-    {file = "sniffio-1.2.0.tar.gz", hash = "sha256:c4666eecec1d3f50960c6bdf61ab7bc350648da6c126e3cf6898d8cd4ddcd3de"},
-]
-starlette = [
-    {file = "starlette-0.17.1-py3-none-any.whl", hash = "sha256:26a18cbda5e6b651c964c12c88b36d9898481cd428ed6e063f5f29c418f73050"},
-    {file = "starlette-0.17.1.tar.gz", hash = "sha256:57eab3cc975a28af62f6faec94d355a410634940f10b30d68d31cb5ec1b44ae8"},
-]
 text-unidecode = [
     {file = "text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93"},
     {file = "text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8"},
@@ -2085,10 +1908,6 @@ url-normalize = [
 urllib3 = [
     {file = "urllib3-1.26.6-py2.py3-none-any.whl", hash = "sha256:39fb8672126159acb139a7718dd10806104dec1e2f0f6c88aab05d17df10c8d4"},
     {file = "urllib3-1.26.6.tar.gz", hash = "sha256:f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f"},
-]
-uvicorn = [
-    {file = "uvicorn-0.17.6-py3-none-any.whl", hash = "sha256:19e2a0e96c9ac5581c01eb1a79a7d2f72bb479691acd2b8921fce48ed5b961a6"},
-    {file = "uvicorn-0.17.6.tar.gz", hash = "sha256:5180f9d059611747d841a4a4c4ab675edf54c8489e97f96d0583ee90ac3bfc23"},
 ]
 virtualenv = [
     {file = "virtualenv-20.13.4-py2.py3-none-any.whl", hash = "sha256:c3e01300fb8495bc00ed70741f5271fc95fed067eb7106297be73d30879af60c"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -1004,6 +1004,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "pyxdg"
+version = "0.27"
+description = "PyXDG contains implementations of freedesktop.org standards in python."
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "pyyaml"
 version = "5.4.1"
 description = "YAML parser and emitter for Python"
@@ -1266,7 +1274,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7, <3.11"
-content-hash = "872cf9e4bbb88334ff36e9c274e8ec56922402b7c7e9b35767e8e0274b056b67"
+content-hash = "68344a5d491b9cd9681b2c093337d7466f454f3b38ae216c8407257301773c2d"
 
 [metadata.files]
 addict = [
@@ -1797,6 +1805,10 @@ pywin32 = [
     {file = "pywin32-227-cp38-cp38-win_amd64.whl", hash = "sha256:7c1ae32c489dc012930787f06244426f8356e129184a02c25aef163917ce158e"},
     {file = "pywin32-227-cp39-cp39-win32.whl", hash = "sha256:c054c52ba46e7eb6b7d7dfae4dbd987a1bb48ee86debe3f245a2884ece46e295"},
     {file = "pywin32-227-cp39-cp39-win_amd64.whl", hash = "sha256:f27cec5e7f588c3d1051651830ecc00294f90728d19c3bf6916e6dba93ea357c"},
+]
+pyxdg = [
+    {file = "pyxdg-0.27-py2.py3-none-any.whl", hash = "sha256:2d6701ab7c74bbab8caa6a95e0a0a129b1643cf6c298bf7c569adec06d0709a0"},
+    {file = "pyxdg-0.27.tar.gz", hash = "sha256:80bd93aae5ed82435f20462ea0208fb198d8eec262e831ee06ce9ddb6b91c5a5"},
 ]
 pyyaml = [
     {file = "PyYAML-5.4.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:3b2b1824fe7112845700f815ff6a489360226a5609b96ec2190a45e62a9fc922"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -7,6 +7,24 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "anyio"
+version = "3.5.0"
+description = "High level compatibility layer for multiple asynchronous event loop implementations"
+category = "main"
+optional = false
+python-versions = ">=3.6.2"
+
+[package.dependencies]
+idna = ">=2.8"
+sniffio = ">=1.1"
+typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
+
+[package.extras]
+doc = ["packaging", "sphinx-rtd-theme", "sphinx-autodoc-typehints (>=1.2.0)"]
+test = ["coverage[toml] (>=4.5)", "hypothesis (>=4.0)", "pytest (>=6.0)", "pytest-mock (>=3.6.1)", "trustme", "contextlib2", "uvloop (<0.15)", "mock (>=4)", "uvloop (>=0.15)"]
+trio = ["trio (>=0.16)"]
+
+[[package]]
 name = "arrow"
 version = "1.2.2"
 description = "Better dates & times for Python"
@@ -17,6 +35,20 @@ python-versions = ">=3.6"
 [package.dependencies]
 python-dateutil = ">=2.7.0"
 typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
+
+[[package]]
+name = "asgiref"
+version = "3.5.0"
+description = "ASGI specs, helper code, and adapters"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
+
+[package.extras]
+tests = ["pytest", "pytest-asyncio", "mypy (>=0.800)"]
 
 [[package]]
 name = "atomicwrites"
@@ -308,6 +340,24 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 testing = ["pre-commit"]
 
 [[package]]
+name = "fastapi"
+version = "0.75.0"
+description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
+category = "main"
+optional = false
+python-versions = ">=3.6.1"
+
+[package.dependencies]
+pydantic = ">=1.6.2,<1.7 || >1.7,<1.7.1 || >1.7.1,<1.7.2 || >1.7.2,<1.7.3 || >1.7.3,<1.8 || >1.8,<1.8.1 || >1.8.1,<2.0.0"
+starlette = "0.17.1"
+
+[package.extras]
+all = ["requests (>=2.24.0,<3.0.0)", "jinja2 (>=2.11.2,<4.0.0)", "python-multipart (>=0.0.5,<0.0.6)", "itsdangerous (>=1.1.0,<3.0.0)", "pyyaml (>=5.3.1,<6.0.0)", "ujson (>=4.0.1,<5.0.0)", "orjson (>=3.2.1,<4.0.0)", "email_validator (>=1.1.1,<2.0.0)", "uvicorn[standard] (>=0.12.0,<0.16.0)"]
+dev = ["python-jose[cryptography] (>=3.3.0,<4.0.0)", "passlib[bcrypt] (>=1.7.2,<2.0.0)", "autoflake (>=1.4.0,<2.0.0)", "flake8 (>=3.8.3,<4.0.0)", "uvicorn[standard] (>=0.12.0,<0.16.0)"]
+doc = ["mkdocs (>=1.1.2,<2.0.0)", "mkdocs-material (>=8.1.4,<9.0.0)", "mdx-include (>=1.4.1,<2.0.0)", "mkdocs-markdownextradata-plugin (>=0.1.7,<0.3.0)", "typer-cli (>=0.0.12,<0.0.13)", "pyyaml (>=5.3.1,<6.0.0)"]
+test = ["pytest (>=6.2.4,<7.0.0)", "pytest-cov (>=2.12.0,<4.0.0)", "mypy (==0.910)", "flake8 (>=3.8.3,<4.0.0)", "black (==21.9b0)", "isort (>=5.0.6,<6.0.0)", "requests (>=2.24.0,<3.0.0)", "httpx (>=0.14.0,<0.19.0)", "email_validator (>=1.1.1,<2.0.0)", "sqlalchemy (>=1.3.18,<1.5.0)", "peewee (>=3.13.3,<4.0.0)", "databases[sqlite] (>=0.3.2,<0.6.0)", "orjson (>=3.2.1,<4.0.0)", "ujson (>=4.0.1,<5.0.0)", "python-multipart (>=0.0.5,<0.0.6)", "flask (>=1.1.2,<3.0.0)", "anyio[trio] (>=3.2.1,<4.0.0)", "types-ujson (==0.1.1)", "types-orjson (==3.6.0)", "types-dataclasses (==0.1.7)"]
+
+[[package]]
 name = "filelock"
 version = "3.6.0"
 description = "A platform independent file lock."
@@ -424,6 +474,17 @@ protobuf = ">=3.12.0"
 
 [package.extras]
 grpc = ["grpcio (>=1.0.0)"]
+
+[[package]]
+name = "h11"
+version = "0.13.0"
+description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "httplib2"
@@ -834,6 +895,21 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
+name = "pydantic"
+version = "1.9.0"
+description = "Data validation and settings management using python 3.6 type hinting"
+category = "main"
+optional = false
+python-versions = ">=3.6.1"
+
+[package.dependencies]
+typing-extensions = ">=3.7.4.3"
+
+[package.extras]
+dotenv = ["python-dotenv (>=0.10.4)"]
+email = ["email-validator (>=1.0.3)"]
+
+[[package]]
 name = "pyjwt"
 version = "2.1.0"
 description = "JSON Web Token implementation in Python"
@@ -1102,6 +1178,29 @@ optional = false
 python-versions = ">=3.5"
 
 [[package]]
+name = "sniffio"
+version = "1.2.0"
+description = "Sniff out which async library your code is running under"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
+name = "starlette"
+version = "0.17.1"
+description = "The little ASGI library that shines."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+anyio = ">=3.0.0,<4"
+typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
+
+[package.extras]
+full = ["itsdangerous", "jinja2", "python-multipart", "pyyaml", "requests"]
+
+[[package]]
 name = "text-unidecode"
 version = "1.3"
 description = "The most basic Text::Unidecode port"
@@ -1197,6 +1296,23 @@ secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "cer
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
+name = "uvicorn"
+version = "0.17.6"
+description = "The lightning-fast ASGI server."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+asgiref = ">=3.4.0"
+click = ">=7.0"
+h11 = ">=0.8"
+typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
+
+[package.extras]
+standard = ["websockets (>=10.0)", "httptools (>=0.4.0)", "watchgod (>=0.6)", "python-dotenv (>=0.13)", "PyYAML (>=5.1)", "uvloop (>=0.14.0,!=0.15.0,!=0.15.1)", "colorama (>=0.4)"]
+
+[[package]]
 name = "virtualenv"
 version = "20.13.4"
 description = "Virtual Python Environment builder"
@@ -1258,16 +1374,24 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7, <3.11"
-content-hash = "a72817fc6124d1dba9b1a142523a6ffd482448ecd6b8b4b7af79e1bf43e6a151"
+content-hash = "0ee8885318e5a1b4653941d7429f45825cfbb12ef169843cc61c9fcf8fb8de22"
 
 [metadata.files]
 addict = [
     {file = "addict-2.4.0-py3-none-any.whl", hash = "sha256:249bb56bbfd3cdc2a004ea0ff4c2b6ddc84d53bc2194761636eb314d5cfa5dfc"},
     {file = "addict-2.4.0.tar.gz", hash = "sha256:b3b2210e0e067a281f5646c8c5db92e99b7231ea8b0eb5f74dbdf9e259d4e494"},
 ]
+anyio = [
+    {file = "anyio-3.5.0-py3-none-any.whl", hash = "sha256:b5fa16c5ff93fa1046f2eeb5bbff2dad4d3514d6cda61d02816dba34fa8c3c2e"},
+    {file = "anyio-3.5.0.tar.gz", hash = "sha256:a0aeffe2fb1fdf374a8e4b471444f0f3ac4fb9f5a5b542b48824475e0042a5a6"},
+]
 arrow = [
     {file = "arrow-1.2.2-py3-none-any.whl", hash = "sha256:d622c46ca681b5b3e3574fcb60a04e5cc81b9625112d5fb2b44220c36c892177"},
     {file = "arrow-1.2.2.tar.gz", hash = "sha256:05caf1fd3d9a11a1135b2b6f09887421153b94558e5ef4d090b567b47173ac2b"},
+]
+asgiref = [
+    {file = "asgiref-3.5.0-py3-none-any.whl", hash = "sha256:88d59c13d634dcffe0510be048210188edd79aeccb6a6c9028cdad6f31d730a9"},
+    {file = "asgiref-3.5.0.tar.gz", hash = "sha256:2f8abc20f7248433085eda803936d98992f1343ddb022065779f37c5da0181d0"},
 ]
 atomicwrites = [
     {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
@@ -1419,8 +1543,10 @@ cryptography = [
     {file = "cryptography-3.4.7-cp36-abi3-win_amd64.whl", hash = "sha256:de4e5f7f68220d92b7637fc99847475b59154b7a1b3868fb7385337af54ac9ca"},
     {file = "cryptography-3.4.7-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:26965837447f9c82f1855e0bc8bc4fb910240b6e0d16a664bb722df3b5b06873"},
     {file = "cryptography-3.4.7-pp36-pypy36_pp73-manylinux2014_x86_64.whl", hash = "sha256:eb8cc2afe8b05acbd84a43905832ec78e7b3873fb124ca190f574dca7389a87d"},
+    {file = "cryptography-3.4.7-pp37-pypy37_pp73-macosx_10_10_x86_64.whl", hash = "sha256:b01fd6f2737816cb1e08ed4807ae194404790eac7ad030b34f2ce72b332f5586"},
     {file = "cryptography-3.4.7-pp37-pypy37_pp73-manylinux2010_x86_64.whl", hash = "sha256:7ec5d3b029f5fa2b179325908b9cd93db28ab7b85bb6c1db56b10e0b54235177"},
     {file = "cryptography-3.4.7-pp37-pypy37_pp73-manylinux2014_x86_64.whl", hash = "sha256:ee77aa129f481be46f8d92a1a7db57269a2f23052d5f2433b4621bb457081cc9"},
+    {file = "cryptography-3.4.7-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:bf40af59ca2465b24e54f671b2de2c59257ddc4f7e5706dbd6930e26823668d3"},
     {file = "cryptography-3.4.7.tar.gz", hash = "sha256:3d10de8116d25649631977cb37da6cbdd2d6fa0e0281d014a5b7d337255ca713"},
 ]
 distlib = [
@@ -1434,6 +1560,10 @@ docker = [
 execnet = [
     {file = "execnet-1.9.0-py2.py3-none-any.whl", hash = "sha256:a295f7cc774947aac58dde7fdc85f4aa00c42adf5d8f5468fc630c1acf30a142"},
     {file = "execnet-1.9.0.tar.gz", hash = "sha256:8f694f3ba9cc92cab508b152dcfe322153975c29bda272e2fd7f3f00f36e47c5"},
+]
+fastapi = [
+    {file = "fastapi-0.75.0-py3-none-any.whl", hash = "sha256:43d12891b78fc497a50623e9c7c24640c569489f060acd9ce2c4902080487a93"},
+    {file = "fastapi-0.75.0.tar.gz", hash = "sha256:124774ce4cb3322841965f559669b233a0b8d343ea24fdd8b293253c077220d7"},
 ]
 filelock = [
     {file = "filelock-3.6.0-py3-none-any.whl", hash = "sha256:f8314284bfffbdcfa0ff3d7992b023d4c628ced6feb957351d4c48d059f56bc0"},
@@ -1466,6 +1596,10 @@ google-auth-httplib2 = [
 googleapis-common-protos = [
     {file = "googleapis-common-protos-1.53.0.tar.gz", hash = "sha256:a88ee8903aa0a81f6c3cec2d5cf62d3c8aa67c06439b0496b49048fb1854ebf4"},
     {file = "googleapis_common_protos-1.53.0-py2.py3-none-any.whl", hash = "sha256:f6d561ab8fb16b30020b940e2dd01cd80082f4762fa9f3ee670f4419b4b8dbd0"},
+]
+h11 = [
+    {file = "h11-0.13.0-py3-none-any.whl", hash = "sha256:8ddd78563b633ca55346c8cd41ec0af27d3c79931828beffb46ce70a379e7442"},
+    {file = "h11-0.13.0.tar.gz", hash = "sha256:70813c1135087a248a4d38cc0e1a0181ffab2188141a93eaf567940c3957ff06"},
 ]
 httplib2 = [
     {file = "httplib2-0.19.1-py3-none-any.whl", hash = "sha256:2ad195faf9faf079723f6714926e9a9061f694d07724b846658ce08d40f522b4"},
@@ -1511,12 +1645,28 @@ kapitan = [
     {file = "kapitan-0.30.0.tar.gz", hash = "sha256:30fe09703d676bad89c82dbf5336881a3d3df4d46c182cdfa4ec2d6c326e5326"},
 ]
 markupsafe = [
+    {file = "MarkupSafe-2.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d8446c54dc28c01e5a2dbac5a25f071f6653e6e40f3a8818e8b45d790fe6ef53"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:36bc903cbb393720fad60fc28c10de6acf10dc6cc883f3e24ee4012371399a38"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2d7d807855b419fc2ed3e631034685db6079889a1f01d5d9dac950f764da3dad"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:add36cb2dbb8b736611303cd3bfcee00afd96471b09cda130da3581cbdc56a6d"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:168cd0a3642de83558a5153c8bd34f175a9a6e7f6dc6384b9655d2697312a646"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:4dc8f9fb58f7364b63fd9f85013b780ef83c11857ae79f2feda41e270468dd9b"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:20dca64a3ef2d6e4d5d615a3fd418ad3bde77a47ec8a23d984a12b5b4c74491a"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:cdfba22ea2f0029c9261a4bd07e830a8da012291fbe44dc794e488b6c9bb353a"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-win32.whl", hash = "sha256:99df47edb6bda1249d3e80fdabb1dab8c08ef3975f69aed437cb69d0a5de1e28"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:e0f138900af21926a02425cf736db95be9f4af72ba1bb21453432a07f6082134"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:0955295dd5eec6cb6cc2fe1698f4c6d84af2e92de33fbcac4111913cd100a6ff"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:0446679737af14f45767963a1a9ef7620189912317d095f2d9ffa183a4d25d2b"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:f826e31d18b516f653fe296d967d700fddad5901ae07c622bb3705955e1faa94"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:fa130dd50c57d53368c9d59395cb5526eda596d3ffe36666cd81a44d56e48872"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:905fec760bd2fa1388bb5b489ee8ee5f7291d692638ea5f67982d968366bef9f"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bf5d821ffabf0ef3533c39c518f3357b171a1651c1ff6827325e4489b0e46c3c"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:0d4b31cc67ab36e3392bbf3862cfbadac3db12bdd8b02a2731f509ed5b829724"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:baa1a4e8f868845af802979fcdbf0bb11f94f1cb7ced4c4b8a351bb60d108145"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:deb993cacb280823246a026e3b2d81c493c53de6acfd5e6bfe31ab3402bb37dd"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:63f3268ba69ace99cab4e3e3b5840b03340efed0948ab8f78d2fd87ee5442a4f"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:8d206346619592c6200148b01a2142798c989edcb9c896f9ac9722a99d4e77e6"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-win32.whl", hash = "sha256:6c4ca60fa24e85fe25b912b01e62cb969d69a23a5d5867682dd3e80b5b02581d"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b2f4bf27480f5e5e8ce285a8c8fd176c0b03e93dcc6646477d4630e83440c6a9"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0717a7390a68be14b8c793ba258e075c6f4ca819f15edfc2a3a027c823718567"},
@@ -1525,14 +1675,27 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:d7f9850398e85aba693bb640262d3611788b1f29a79f0c93c565694658f4071f"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:6a7fae0dd14cf60ad5ff42baa2e95727c3d81ded453457771d02b7d2b3f9c0c2"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:b7f2d075102dc8c794cbde1947378051c4e5180d52d276987b8d28a3bd58c17d"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e9936f0b261d4df76ad22f8fee3ae83b60d7c3e871292cd42f40b81b70afae85"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:2a7d351cbd8cfeb19ca00de495e224dea7e7d919659c2841bbb7f420ad03e2d6"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:60bf42e36abfaf9aff1f50f52644b336d4f0a3fd6d8a60ca0d054ac9f713a864"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:d6c7ebd4e944c85e2c3421e612a7057a2f48d478d79e61800d81468a8d842207"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:f0567c4dc99f264f49fe27da5f735f414c4e7e7dd850cfd8e69f0862d7c74ea9"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:89c687013cb1cd489a0f0ac24febe8c7a666e6e221b783e53ac50ebf68e45d86"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-win32.whl", hash = "sha256:a30e67a65b53ea0a5e62fe23682cfe22712e01f453b95233b25502f7c61cb415"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:611d1ad9a4288cf3e3c16014564df047fe08410e628f89805e475368bd304914"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:5bb28c636d87e840583ee3adeb78172efc47c8b26127267f54a9c0ec251d41a9"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:be98f628055368795d818ebf93da628541e10b75b41c559fdf36d104c5787066"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:1d609f577dc6e1aa17d746f8bd3c31aa4d258f4070d61b2aa5c4166c1539de35"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7d91275b0245b1da4d4cfa07e0faedd5b0812efc15b702576d103293e252af1b"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:01a9b8ea66f1658938f65b93a85ebe8bc016e6769611be228d797c9d998dd298"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:47ab1e7b91c098ab893b828deafa1203de86d0bc6ab587b160f78fe6c4011f75"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:97383d78eb34da7e1fa37dd273c20ad4320929af65d156e35a5e2d89566d9dfb"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6fcf051089389abe060c9cd7caa212c707e58153afa2c649f00346ce6d260f1b"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:5855f8438a7d1d458206a2466bf82b0f104a3724bf96a1c781ab731e4201731a"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3dd007d54ee88b46be476e293f48c85048603f5f516008bee124ddd891398ed6"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:aca6377c0cb8a8253e493c6b451565ac77e98c2951c45f913e0b52facdcff83f"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:04635854b943835a6ea959e948d19dcd311762c5c0c6e1f0e16ee57022669194"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:6300b8454aa6930a24b9618fbb54b5a68135092bc666f7b06901f897fa5c2fee"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-win32.whl", hash = "sha256:023cb26ec21ece8dc3907c0e8320058b2e0cb3c55cf9564da612bc325bed5e64"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:984d76483eb32f1bcb536dc27e4ad56bba4baa70be32fa87152832cdd9db0833"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:2ef54abee730b502252bcdf31b10dacb0a416229b72c18b19e24a4509f273d26"},
@@ -1542,6 +1705,12 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:4efca8f86c54b22348a5467704e3fec767b2db12fc39c6d963168ab1d3fc9135"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:ab3ef638ace319fa26553db0624c4699e31a28bb2a835c5faca8f8acf6a5a902"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:f8ba0e8349a38d3001fae7eadded3f6606f0da5d748ee53cc1dab1d6527b9509"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c47adbc92fc1bb2b3274c4b3a43ae0e4573d9fbff4f54cd484555edbf030baf1"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:37205cac2a79194e3750b0af2a5720d95f786a55ce7df90c3af697bfa100eaac"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:1f2ade76b9903f39aa442b4aadd2177decb66525062db244b35d71d0ee8599b6"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:4296f2b1ce8c86a6aea78613c34bb1a672ea0e3de9c6ba08a960efe0b0a09047"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:9f02365d4e99430a12647f09b6cc8bab61a6564363f313126f775eb4f6ef798e"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5b6d930f030f8ed98e3e6c98ffa0652bdb82601e7a016ec2ab5d7ff23baa78d1"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-win32.whl", hash = "sha256:10f82115e21dc0dfec9ab5c0223652f7197feb168c940f3ef61563fc2d6beb74"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8"},
     {file = "MarkupSafe-2.0.1.tar.gz", hash = "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a"},
@@ -1668,6 +1837,43 @@ pycparser = [
     {file = "pycparser-2.20-py2.py3-none-any.whl", hash = "sha256:7582ad22678f0fcd81102833f60ef8d0e57288b6b5fb00323d101be910e35705"},
     {file = "pycparser-2.20.tar.gz", hash = "sha256:2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0"},
 ]
+pydantic = [
+    {file = "pydantic-1.9.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:cb23bcc093697cdea2708baae4f9ba0e972960a835af22560f6ae4e7e47d33f5"},
+    {file = "pydantic-1.9.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1d5278bd9f0eee04a44c712982343103bba63507480bfd2fc2790fa70cd64cf4"},
+    {file = "pydantic-1.9.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ab624700dc145aa809e6f3ec93fb8e7d0f99d9023b713f6a953637429b437d37"},
+    {file = "pydantic-1.9.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c8d7da6f1c1049eefb718d43d99ad73100c958a5367d30b9321b092771e96c25"},
+    {file = "pydantic-1.9.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:3c3b035103bd4e2e4a28da9da7ef2fa47b00ee4a9cf4f1a735214c1bcd05e0f6"},
+    {file = "pydantic-1.9.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:3011b975c973819883842c5ab925a4e4298dffccf7782c55ec3580ed17dc464c"},
+    {file = "pydantic-1.9.0-cp310-cp310-win_amd64.whl", hash = "sha256:086254884d10d3ba16da0588604ffdc5aab3f7f09557b998373e885c690dd398"},
+    {file = "pydantic-1.9.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:0fe476769acaa7fcddd17cadd172b156b53546ec3614a4d880e5d29ea5fbce65"},
+    {file = "pydantic-1.9.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c8e9dcf1ac499679aceedac7e7ca6d8641f0193c591a2d090282aaf8e9445a46"},
+    {file = "pydantic-1.9.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d1e4c28f30e767fd07f2ddc6f74f41f034d1dd6bc526cd59e63a82fe8bb9ef4c"},
+    {file = "pydantic-1.9.0-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:c86229333cabaaa8c51cf971496f10318c4734cf7b641f08af0a6fbf17ca3054"},
+    {file = "pydantic-1.9.0-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:c0727bda6e38144d464daec31dff936a82917f431d9c39c39c60a26567eae3ed"},
+    {file = "pydantic-1.9.0-cp36-cp36m-win_amd64.whl", hash = "sha256:dee5ef83a76ac31ab0c78c10bd7d5437bfdb6358c95b91f1ba7ff7b76f9996a1"},
+    {file = "pydantic-1.9.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:d9c9bdb3af48e242838f9f6e6127de9be7063aad17b32215ccc36a09c5cf1070"},
+    {file = "pydantic-1.9.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ee7e3209db1e468341ef41fe263eb655f67f5c5a76c924044314e139a1103a2"},
+    {file = "pydantic-1.9.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0b6037175234850ffd094ca77bf60fb54b08b5b22bc85865331dd3bda7a02fa1"},
+    {file = "pydantic-1.9.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:b2571db88c636d862b35090ccf92bf24004393f85c8870a37f42d9f23d13e032"},
+    {file = "pydantic-1.9.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:8b5ac0f1c83d31b324e57a273da59197c83d1bb18171e512908fe5dc7278a1d6"},
+    {file = "pydantic-1.9.0-cp37-cp37m-win_amd64.whl", hash = "sha256:bbbc94d0c94dd80b3340fc4f04fd4d701f4b038ebad72c39693c794fd3bc2d9d"},
+    {file = "pydantic-1.9.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:e0896200b6a40197405af18828da49f067c2fa1f821491bc8f5bde241ef3f7d7"},
+    {file = "pydantic-1.9.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:7bdfdadb5994b44bd5579cfa7c9b0e1b0e540c952d56f627eb227851cda9db77"},
+    {file = "pydantic-1.9.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:574936363cd4b9eed8acdd6b80d0143162f2eb654d96cb3a8ee91d3e64bf4cf9"},
+    {file = "pydantic-1.9.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c556695b699f648c58373b542534308922c46a1cda06ea47bc9ca45ef5b39ae6"},
+    {file = "pydantic-1.9.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:f947352c3434e8b937e3aa8f96f47bdfe6d92779e44bb3f41e4c213ba6a32145"},
+    {file = "pydantic-1.9.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:5e48ef4a8b8c066c4a31409d91d7ca372a774d0212da2787c0d32f8045b1e034"},
+    {file = "pydantic-1.9.0-cp38-cp38-win_amd64.whl", hash = "sha256:96f240bce182ca7fe045c76bcebfa0b0534a1bf402ed05914a6f1dadff91877f"},
+    {file = "pydantic-1.9.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:815ddebb2792efd4bba5488bc8fde09c29e8ca3227d27cf1c6990fc830fd292b"},
+    {file = "pydantic-1.9.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:6c5b77947b9e85a54848343928b597b4f74fc364b70926b3c4441ff52620640c"},
+    {file = "pydantic-1.9.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4c68c3bc88dbda2a6805e9a142ce84782d3930f8fdd9655430d8576315ad97ce"},
+    {file = "pydantic-1.9.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5a79330f8571faf71bf93667d3ee054609816f10a259a109a0738dac983b23c3"},
+    {file = "pydantic-1.9.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:f5a64b64ddf4c99fe201ac2724daada8595ada0d102ab96d019c1555c2d6441d"},
+    {file = "pydantic-1.9.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a733965f1a2b4090a5238d40d983dcd78f3ecea221c7af1497b845a9709c1721"},
+    {file = "pydantic-1.9.0-cp39-cp39-win_amd64.whl", hash = "sha256:2cc6a4cb8a118ffec2ca5fcb47afbacb4f16d0ab8b7350ddea5e8ef7bcc53a16"},
+    {file = "pydantic-1.9.0-py3-none-any.whl", hash = "sha256:085ca1de245782e9b46cefcf99deecc67d418737a1fd3f6a4f511344b613a5b3"},
+    {file = "pydantic-1.9.0.tar.gz", hash = "sha256:742645059757a56ecd886faf4ed2441b9c0cd406079c2b4bee51bcc3fbcd510a"},
+]
 pyjwt = [
     {file = "PyJWT-2.1.0-py3-none-any.whl", hash = "sha256:934d73fbba91b0483d3857d1aff50e96b2a892384ee2c17417ed3203f173fca1"},
     {file = "PyJWT-2.1.0.tar.gz", hash = "sha256:fba44e7898bbca160a2b2b501f492824fc8382485d3a6f11ba5d0c1937ce6130"},
@@ -1756,18 +1962,26 @@ pyyaml = [
     {file = "PyYAML-5.4.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:bb4191dfc9306777bc594117aee052446b3fa88737cd13b7188d0e7aa8162185"},
     {file = "PyYAML-5.4.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:6c78645d400265a062508ae399b60b8c167bf003db364ecb26dcab2bda048253"},
     {file = "PyYAML-5.4.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:4e0583d24c881e14342eaf4ec5fbc97f934b999a6828693a99157fde912540cc"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:72a01f726a9c7851ca9bfad6fd09ca4e090a023c00945ea05ba1638c09dc3347"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-manylinux2014_s390x.whl", hash = "sha256:895f61ef02e8fed38159bb70f7e100e00f471eae2bc838cd0f4ebb21e28f8541"},
     {file = "PyYAML-5.4.1-cp36-cp36m-win32.whl", hash = "sha256:3bd0e463264cf257d1ffd2e40223b197271046d09dadf73a0fe82b9c1fc385a5"},
     {file = "PyYAML-5.4.1-cp36-cp36m-win_amd64.whl", hash = "sha256:e4fac90784481d221a8e4b1162afa7c47ed953be40d31ab4629ae917510051df"},
     {file = "PyYAML-5.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:5accb17103e43963b80e6f837831f38d314a0495500067cb25afab2e8d7a4018"},
     {file = "PyYAML-5.4.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:e1d4970ea66be07ae37a3c2e48b5ec63f7ba6804bdddfdbd3cfd954d25a82e63"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:cb333c16912324fd5f769fff6bc5de372e9e7a202247b48870bc251ed40239aa"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-manylinux2014_s390x.whl", hash = "sha256:fe69978f3f768926cfa37b867e3843918e012cf83f680806599ddce33c2c68b0"},
     {file = "PyYAML-5.4.1-cp37-cp37m-win32.whl", hash = "sha256:dd5de0646207f053eb0d6c74ae45ba98c3395a571a2891858e87df7c9b9bd51b"},
     {file = "PyYAML-5.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf"},
     {file = "PyYAML-5.4.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d2d9808ea7b4af864f35ea216be506ecec180628aced0704e34aca0b040ffe46"},
     {file = "PyYAML-5.4.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:8c1be557ee92a20f184922c7b6424e8ab6691788e6d86137c5d93c1a6ec1b8fb"},
+    {file = "PyYAML-5.4.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:fd7f6999a8070df521b6384004ef42833b9bd62cfee11a09bda1079b4b704247"},
+    {file = "PyYAML-5.4.1-cp38-cp38-manylinux2014_s390x.whl", hash = "sha256:bfb51918d4ff3d77c1c856a9699f8492c612cde32fd3bcd344af9be34999bfdc"},
     {file = "PyYAML-5.4.1-cp38-cp38-win32.whl", hash = "sha256:fa5ae20527d8e831e8230cbffd9f8fe952815b2b7dae6ffec25318803a7528fc"},
     {file = "PyYAML-5.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:0f5f5786c0e09baddcd8b4b45f20a7b5d61a7e7e99846e3c799b05c7c53fa696"},
     {file = "PyYAML-5.4.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:294db365efa064d00b8d1ef65d8ea2c3426ac366c0c4368d930bf1c5fb497f77"},
     {file = "PyYAML-5.4.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:74c1485f7707cf707a7aef42ef6322b8f97921bd89be2ab6317fd782c2d53183"},
+    {file = "PyYAML-5.4.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:d483ad4e639292c90170eb6f7783ad19490e7a8defb3e46f97dfe4bacae89122"},
+    {file = "PyYAML-5.4.1-cp39-cp39-manylinux2014_s390x.whl", hash = "sha256:fdc842473cd33f45ff6bce46aea678a54e3d21f1b61a7750ce3c498eedfe25d6"},
     {file = "PyYAML-5.4.1-cp39-cp39-win32.whl", hash = "sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10"},
     {file = "PyYAML-5.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db"},
     {file = "PyYAML-5.4.1.tar.gz", hash = "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e"},
@@ -1804,6 +2018,14 @@ six = [
 smmap = [
     {file = "smmap-4.0.0-py2.py3-none-any.whl", hash = "sha256:a9a7479e4c572e2e775c404dcd3080c8dc49f39918c2cf74913d30c4c478e3c2"},
     {file = "smmap-4.0.0.tar.gz", hash = "sha256:7e65386bd122d45405ddf795637b7f7d2b532e7e401d46bbe3fb49b9986d5182"},
+]
+sniffio = [
+    {file = "sniffio-1.2.0-py3-none-any.whl", hash = "sha256:471b71698eac1c2112a40ce2752bb2f4a4814c22a54a3eed3676bc0f5ca9f663"},
+    {file = "sniffio-1.2.0.tar.gz", hash = "sha256:c4666eecec1d3f50960c6bdf61ab7bc350648da6c126e3cf6898d8cd4ddcd3de"},
+]
+starlette = [
+    {file = "starlette-0.17.1-py3-none-any.whl", hash = "sha256:26a18cbda5e6b651c964c12c88b36d9898481cd428ed6e063f5f29c418f73050"},
+    {file = "starlette-0.17.1.tar.gz", hash = "sha256:57eab3cc975a28af62f6faec94d355a410634940f10b30d68d31cb5ec1b44ae8"},
 ]
 text-unidecode = [
     {file = "text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93"},
@@ -1863,6 +2085,10 @@ url-normalize = [
 urllib3 = [
     {file = "urllib3-1.26.6-py2.py3-none-any.whl", hash = "sha256:39fb8672126159acb139a7718dd10806104dec1e2f0f6c88aab05d17df10c8d4"},
     {file = "urllib3-1.26.6.tar.gz", hash = "sha256:f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f"},
+]
+uvicorn = [
+    {file = "uvicorn-0.17.6-py3-none-any.whl", hash = "sha256:19e2a0e96c9ac5581c01eb1a79a7d2f72bb479691acd2b8921fce48ed5b961a6"},
+    {file = "uvicorn-0.17.6.tar.gz", hash = "sha256:5180f9d059611747d841a4a4c4ab675edf54c8489e97f96d0583ee90ac3bfc23"},
 ]
 virtualenv = [
     {file = "virtualenv-20.13.4-py2.py3-none-any.whl", hash = "sha256:c3e01300fb8495bc00ed70741f5271fc95fed067eb7106297be73d30879af60c"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -837,7 +837,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 name = "pyfakefs"
 version = "4.5.6"
 description = "pyfakefs implements a fake file system that mocks the Python file system modules."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
 
@@ -1274,7 +1274,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7, <3.11"
-content-hash = "68344a5d491b9cd9681b2c093337d7466f454f3b38ae216c8407257301773c2d"
+content-hash = "cc4868c7e741b62a88103b0b811a466eb065bbfe567e7c18ad55cf625a46e0f6"
 
 [metadata.files]
 addict = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -834,6 +834,14 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
+name = "pyfakefs"
+version = "4.5.6"
+description = "pyfakefs implements a fake file system that mocks the Python file system modules."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "pyjwt"
 version = "2.1.0"
 description = "JSON Web Token implementation in Python"
@@ -1258,7 +1266,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7, <3.11"
-content-hash = "a72817fc6124d1dba9b1a142523a6ffd482448ecd6b8b4b7af79e1bf43e6a151"
+content-hash = "872cf9e4bbb88334ff36e9c274e8ec56922402b7c7e9b35767e8e0274b056b67"
 
 [metadata.files]
 addict = [
@@ -1704,6 +1712,10 @@ pycodestyle = [
 pycparser = [
     {file = "pycparser-2.20-py2.py3-none-any.whl", hash = "sha256:7582ad22678f0fcd81102833f60ef8d0e57288b6b5fb00323d101be910e35705"},
     {file = "pycparser-2.20.tar.gz", hash = "sha256:2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0"},
+]
+pyfakefs = [
+    {file = "pyfakefs-4.5.6-py3-none-any.whl", hash = "sha256:6bb4e27457b0bc90e3ebfe5aed4f1b8c32a18713ba44e925f304bb9b9816a03c"},
+    {file = "pyfakefs-4.5.6.tar.gz", hash = "sha256:914d7bf994406cfbefee0b4d45918f60c15b406afe93f8194a804da5a450a822"},
 ]
 pyjwt = [
     {file = "PyJWT-2.1.0-py3-none-any.whl", hash = "sha256:934d73fbba91b0483d3857d1aff50e96b2a892384ee2c17417ed3203f173fca1"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ python-dotenv = "*"
 importlib_metadata = "*"
 typing-extensions = "^3.7.4"
 pyfakefs = "^4.5.6"
+pyxdg = "^0.27"
 
 [tool.poetry.dev-dependencies]
 tox = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,8 @@ url-normalize = "*"
 python-dotenv = "*"
 importlib_metadata = "*"
 typing-extensions = "^3.7.4"
+uvicorn = "^0.17.6"
+fastapi = "^0.75.0"
 
 [tool.poetry.dev-dependencies]
 tox = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,6 @@ url-normalize = "*"
 python-dotenv = "*"
 importlib_metadata = "*"
 typing-extensions = "^3.7.4"
-uvicorn = "^0.17.6"
-fastapi = "^0.75.0"
 
 [tool.poetry.dev-dependencies]
 tox = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ url-normalize = "*"
 python-dotenv = "*"
 importlib_metadata = "*"
 typing-extensions = "^3.7.4"
-pyfakefs = "^4.5.6"
 pyxdg = "^0.27"
 
 [tool.poetry.dev-dependencies]
@@ -38,6 +37,7 @@ pytest-xdist = "^1.32.0"
 pytest-benchmark = "^3.2.3"
 responses = "^0.16.0"
 black = "^22.1.0"
+pyfakefs = "^4.5.6"
 
 [tool.poetry.scripts]
 commodore = 'commodore.cli:main'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ url-normalize = "*"
 python-dotenv = "*"
 importlib_metadata = "*"
 typing-extensions = "^3.7.4"
+pyfakefs = "^4.5.6"
 
 [tool.poetry.dev-dependencies]
 tox = "*"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -60,3 +60,8 @@ def test_component_inventory_components_command():
 def test_component_inventory_lint():
     exit_status = call("commodore inventory lint --help", shell=True)
     assert exit_status == 0
+
+
+def test_login():
+    exit_status = call("commodore login --help", shell=True)
+    assert exit_status == 0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,9 +2,12 @@ import pytest
 import textwrap
 from pathlib import Path as P
 
+from typing import Optional
+
 import click
 
 from commodore.config import Config
+from commodore import tokencache
 
 
 @pytest.fixture
@@ -195,3 +198,19 @@ def test_print_deprecation_notices(config, capsys):
         )
         == captured.out
     )
+
+
+def test_use_token_cache(monkeypatch):
+    def mock_get_token(url: str)  -> Optional[str]:
+        if url != "https://syn.example.com":
+            return None
+        return "from_token_cache"
+
+    monkeypatch.setattr(tokencache, "get", mock_get_token)
+
+    conf = Config(
+        P("."),
+        api_url="https://syn.example.com"
+    )
+    tokencache.save("https://syn.example.com", "from_token_cache")
+    assert conf.api_token == "from_token_cache"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,6 +2,7 @@ import pytest
 import textwrap
 from pathlib import Path as P
 
+from unittest.mock import patch
 from typing import Optional
 
 import click
@@ -200,14 +201,14 @@ def test_print_deprecation_notices(config, capsys):
     )
 
 
-def test_use_token_cache(monkeypatch):
-    def mock_get_token(url: str) -> Optional[str]:
+def mock_get_token(url: str) -> Optional[str]:
         if url != "https://syn.example.com":
             return None
         return "from_token_cache"
 
-    monkeypatch.setattr(tokencache, "get", mock_get_token)
-
-    conf = Config(P("."), api_url="https://syn.example.com")
+@patch("commodore.tokencache.get")
+def test_use_token_cache(test_patch):
+    test_patch.side_effect = mock_get_token
     tokencache.save("https://syn.example.com", "from_token_cache")
+    conf = Config(P("."), api_url="https://syn.example.com")
     assert conf.api_token == "from_token_cache"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -201,16 +201,13 @@ def test_print_deprecation_notices(config, capsys):
 
 
 def test_use_token_cache(monkeypatch):
-    def mock_get_token(url: str)  -> Optional[str]:
+    def mock_get_token(url: str) -> Optional[str]:
         if url != "https://syn.example.com":
             return None
         return "from_token_cache"
 
     monkeypatch.setattr(tokencache, "get", mock_get_token)
 
-    conf = Config(
-        P("."),
-        api_url="https://syn.example.com"
-    )
+    conf = Config(P("."), api_url="https://syn.example.com")
     tokencache.save("https://syn.example.com", "from_token_cache")
     assert conf.api_token == "from_token_cache"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -202,9 +202,10 @@ def test_print_deprecation_notices(config, capsys):
 
 
 def mock_get_token(url: str) -> Optional[str]:
-        if url != "https://syn.example.com":
-            return None
-        return "from_token_cache"
+    if url != "https://syn.example.com":
+        return None
+    return "from_token_cache"
+
 
 @patch("commodore.tokencache.get")
 def test_use_token_cache(test_patch):

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -1,0 +1,67 @@
+"""
+Unit-tests for login
+"""
+
+from unittest.mock import patch, Mock
+
+import requests
+
+
+from commodore.config import Config
+from commodore import login
+
+
+def mock_open_browser(authorization_endpoint: str):
+    def mock(request_uri: str):
+        assert request_uri.startswith(authorization_endpoint)
+
+        r = requests.get("http://localhost:18000/?code=foobar")
+
+        print(r.text)
+        r.raise_for_status()
+
+    return mock
+
+
+def mock_tokencache_save(url: str, token: str):
+    def mock(key: str, val: str):
+        if key != url:
+            raise IOError(f"wrong url, expected https://syn.example.com, got {key}")
+        if val != token:
+            raise IOError(f"wrong token, expected blub, got {val}")
+
+    return mock
+
+
+@patch("commodore.login.get_idp_cfg")
+@patch("webbrowser.open")
+@patch("requests.post")
+@patch("commodore.tokencache.save")
+def test_login(mock_tokencache, mock_token_post, mock_browser, mock_idp, tmp_path):
+    discovery_url = "https://idp.example.com/discovery"
+    token_url = "https://idp.example.com/token"
+    auth_url = "https://idp.example.com/auth"
+    client = "syn-test"
+    api_url = "https://syn.example.com"
+    access_token = "access-123"
+    id_token = "id-123"
+
+    config = Config(
+        tmp_path,
+        api_url=api_url,
+    )
+    config.oidc_client = client
+    config.oidc_discovery_url = discovery_url
+
+    mock_idp.return_value = {
+        "authorization_endpoint": auth_url,
+        "token_endpoint": token_url,
+    }
+    mock_token_post.return_value = Mock(
+        status_code=200,
+        text=f'{{"id_token":"{id_token}", "access_token": "{access_token}"}}',
+    )
+
+    mock_tokencache.side_effect = mock_tokencache_save(api_url, id_token)
+    mock_browser.side_effect = mock_open_browser(auth_url)
+    login.login(config)

--- a/tests/test_tokencache.py
+++ b/tests/test_tokencache.py
@@ -2,7 +2,6 @@
 Unit-tests for tokencache
 """
 import json
-from pathlib import Path
 
 from xdg.BaseDirectory import xdg_cache_home
 from commodore import tokencache

--- a/tests/test_tokencache.py
+++ b/tests/test_tokencache.py
@@ -1,0 +1,41 @@
+"""
+Unit-tests for tokencache
+"""
+import json
+from pathlib import Path
+
+import commodore.tokencache as tokencache
+
+
+def test_get_token(fs):
+    home = Path.home()
+    fs.create_file(
+        f"{home}/.cache/commodore/token",
+        contents='{"https://syn.example.com":"token","https://syn2.example.com":"token2"}',
+    )
+    assert tokencache.get("https://syn.example.com") == "token"
+    assert tokencache.get("https://syn2.example.com") == "token2"
+
+
+def test_save_token(fs):
+    tokencache.save("https://syn.example.com", "save")
+    tokencache.save("https://syn2.example.com", "save2")
+
+    home = Path.home()
+    with open(f"{home}/.cache/commodore/token") as f:
+        cache = json.load(f)
+        assert cache == {
+            "https://syn.example.com": "save",
+            "https://syn2.example.com": "save2",
+        }
+
+
+def test_save_and_get_token(fs):
+    tokencache.save("https://syn.example.com", "token")
+    tokencache.save("https://syn2.example.com", "token2")
+    tokencache.save("https://syn3.example.com", "token3")
+    tokencache.save("https://syn2.example.com", "Foo")
+
+    assert tokencache.get("https://syn.example.com") == "token"
+    assert tokencache.get("https://syn2.example.com") == "Foo"
+    assert tokencache.get("https://syn3.example.com") == "token3"

--- a/tests/test_tokencache.py
+++ b/tests/test_tokencache.py
@@ -4,13 +4,13 @@ Unit-tests for tokencache
 import json
 from pathlib import Path
 
-import commodore.tokencache as tokencache
+from xdg.BaseDirectory import xdg_cache_home
+from commodore import tokencache
 
 
 def test_get_token(fs):
-    home = Path.home()
     fs.create_file(
-        f"{home}/.cache/commodore/token",
+        f"{xdg_cache_home}/commodore/token",
         contents='{"https://syn.example.com":"token","https://syn2.example.com":"token2"}',
     )
     assert tokencache.get("https://syn.example.com") == "token"
@@ -21,8 +21,7 @@ def test_save_token(fs):
     tokencache.save("https://syn.example.com", "save")
     tokencache.save("https://syn2.example.com", "save2")
 
-    home = Path.home()
-    with open(f"{home}/.cache/commodore/token") as f:
+    with open(f"{xdg_cache_home}/commodore/token") as f:
         cache = json.load(f)
         assert cache == {
             "https://syn.example.com": "save",

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ deps =
     cli-test-helpers
     pytest
     responses
+    pyfakefs
     !bench: pytest-xdist
     bench: pytest-benchmark
 commands = \


### PR DESCRIPTION
This PR introduces a `commodore login` command that fetches an `id_token` from the configured IDP and stores it in a cache at `~/.cache/commodore/token`. This cache is used to lookup API tokens if no token is explicitly set.

You can test the login with `lieutenant-dev` using 

```
export COMMODORE_API_URL="https://api-dev.syn.vshn.net"
export COMMODORE_OIDC_CLIENT=syn-lieutenant-dev 
export COMMODORE_OIDC_DISCOVERY_URL=https://id.test.vshn.net/auth/realms/VSHN-main-dev-realm/.well-known/openid-configuration

commodore login
commodore catalog compile c-glrf-test
```

I'm still  not very happy with the tests..

Things I still want to do, but not in this PR:
* Automatically call `commodore login` if there is no token in the cache / token is expired
* Return the client-id and discovery URL from lieutenant. Which would mean we would be able to just call
`COMMODORE_API_URL="https://api-dev.syn.vshn.net" commodore login`

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
