### PR TITLE
Add support for Python 3.10

### DIFF
--- a/.github/workflows/build-virtualenv-caches.yml
+++ b/.github/workflows/build-virtualenv-caches.yml
@@ -46,6 +46,7 @@ jobs:
           - '3.8'
           - '3.9.7'
           - '3.9'
+          - '3.10'
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v3
@@ -74,6 +75,7 @@ jobs:
           - '3.7'
           - '3.8'
           - '3.9'
+          - '3.10'
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,7 @@ jobs:
           - '3.8'
           - '3.9.7'
           - '3.9'
+          - '3.10'
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v3
@@ -82,6 +83,7 @@ jobs:
           - '3.7'
           - '3.8'
           - '3.9'
+          - '3.10'
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v3

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ using `helm template`.
 
 ## System Requirements
 
-* Python 3.7, 3.8 or 3.9, with `python3-dev` and `python3-venv` updated
+* Python 3.7 - 3.10 with `python3-dev` and `python3-venv` updated
 * [jsonnet-bundler](https://github.com/jsonnet-bundler/jsonnet-bundler)
 
 ## Getting started

--- a/docs/modules/ROOT/pages/explanation/running-commodore.adoc
+++ b/docs/modules/ROOT/pages/explanation/running-commodore.adoc
@@ -17,7 +17,7 @@ We recommend that you use the Commodore Python package provided on PyPI to make 
 
 === Prerequisites
 
-* Python 3.7, 3.8 or 3.9 as `python3` and the Python `venv` module.
+* Python 3.7, 3.8, 3.9, or 3.10 as `python3` and the Python `venv` module.
 We recommend that you install Python and the `venv` module with your preferred package manager.
 * `jsonnet-bundler`, https://github.com/jsonnet-bundler/jsonnet-bundler#install[installation instructions]
 * Helm 3, https://helm.sh/docs/intro/install/[installation instructions]
@@ -28,14 +28,9 @@ Other documentation assumes that Helm 3 is available as `helm` and `helm3`, and 
 Please make sure you setup the Helm binaries accordingly on your local system.
 ====
 
-[WARNING]
-====
-As of 2021–11–03, Commodore doesn't yet support Python 3.10+.
-====
-
 === Installation
 
-Generally, it's best to create a separate https://docs.python.org/3.9/tutorial/venv.html[virtualenv] for Python utilities.
+Generally, it's best to create a separate https://docs.python.org/3.10/tutorial/venv.html[virtualenv] for Python utilities.
 Having separate virtualenvs avoids running into dependency conflicts when installing multiple Python utilities from PyPI.
 
 . Check your Python version

--- a/poetry.lock
+++ b/poetry.lock
@@ -1257,8 +1257,8 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 
 [metadata]
 lock-version = "1.1"
-python-versions = ">=3.7, <3.10"
-content-hash = "1dc9cfb774607add287e6cbb388d9195cb3a0e1b7ad59fb4004e5991edd95d31"
+python-versions = ">=3.7, <3.11"
+content-hash = "a72817fc6124d1dba9b1a142523a6ffd482448ecd6b8b4b7af79e1bf43e6a151"
 
 [metadata.files]
 addict = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ include = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.7, <3.10"
+python = ">=3.7, <3.11"
 kapitan = "0.30.0"
 click = "*"
 cookiecutter = "*"

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist =
     bandit
     mypy
     black
-    py3{7,8,9}{,-bench}
+    py3{7,8,9,10}{,-bench}
 
 [testenv]
 description = Unit tests and doctests

--- a/tox.mk
+++ b/tox.mk
@@ -39,7 +39,7 @@ lintenv_mypy:
 lintenv_black:
 	$(TOX_COMMAND) -e black --notest
 
-.PHONY: test_py3.7 test_py3.8 test_py3.9
+.PHONY: test_py3.7 test_py3.8 test_py3.9 test_py3.10
 
 test_py3.7:
 	$(TOX_COMMAND) -e py37
@@ -50,7 +50,10 @@ test_py3.8:
 test_py3.9:
 	$(TOX_COMMAND) -e py39
 
-.PHONY: testenv_py3.7 testenv_py3.8 testenv_py3.9
+test_py3.10:
+	$(TOX_COMMAND) -e py310
+
+.PHONY: testenv_py3.7 testenv_py3.8 testenv_py3.9 testenv_py3.10
 
 testenv_py3.7:
 	$(TOX_COMMAND) -e py37 --notest
@@ -61,7 +64,10 @@ testenv_py3.8:
 testenv_py3.9:
 	$(TOX_COMMAND) -e py39 --notest
 
-.PHONY: bench_py3.7 bench_py3.8 bench_py3.9
+testenv_py3.10:
+	$(TOX_COMMAND) -e py3.10 --notest
+
+.PHONY: bench_py3.7 bench_py3.8 bench_py3.9 bench_py3.10
 
 bench_py3.7:
 	$(TOX_COMMAND) -e py37-bench
@@ -72,7 +78,10 @@ bench_py3.8:
 bench_py3.9:
 	$(TOX_COMMAND) -e py39-bench
 
-.PHONY: benchenv_py3.7 benchenv_py3.8 benchenv_py3.9
+bench_py3.10:
+	$(TOX_COMMAND) -e py310-bench
+
+.PHONY: benchenv_py3.7 benchenv_py3.8 benchenv_py3.9 benchenv_py3.10
 
 benchenv_py3.7:
 	$(TOX_COMMAND) -e py37-bench --notest
@@ -82,3 +91,6 @@ benchenv_py3.8:
 
 benchenv_py3.9:
 	$(TOX_COMMAND) -e py39-bench --notest
+
+benchenv_py3.10:
+	$(TOX_COMMAND) -e py310-bench --notest


### PR DESCRIPTION
The reclass version bundled with Kapitan 0.30 supports Python 3.10, so we can finally also support Python 3.10 in Commodore.

This commit also adds Python 3.10 to the Python versions which we run tests on in GitHub actions.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
