### PR TITLE
Update component template to support Podman out of the box

### DIFF
--- a/commodore/component-template/{{ cookiecutter.slug }}/Makefile.vars.mk
+++ b/commodore/component-template/{{ cookiecutter.slug }}/Makefile.vars.mk
@@ -6,8 +6,14 @@ root_volume     ?= -v "$${PWD}:/$(COMPONENT_NAME)"
 compiled_volume ?= -v "$${PWD}/$(compiled_path):/$(COMPONENT_NAME)"
 commodore_args  ?= --search-paths ./dependencies --search-paths .
 
-DOCKER_CMD   ?= docker
-DOCKER_ARGS  ?= run --rm -u "$$(id -u):$$(id -g)" -w /$(COMPONENT_NAME) -e HOME="/$(COMPONENT_NAME)"
+ifneq "$(shell which docker 2>/dev/null)" ""
+	DOCKER_CMD    ?= $(shell which docker)
+	DOCKER_USERNS ?= ""
+else
+	DOCKER_CMD    ?= podman
+	DOCKER_USERNS ?= keep-id
+endif
+DOCKER_ARGS ?= run --rm -u "$$(id -u):$$(id -g)" --userns=$(DOCKER_USERNS) -w /$(COMPONENT_NAME) -e HOME="/$(COMPONENT_NAME)"
 
 JSONNET_FILES   ?= $(shell find . -type f -not -path './vendor/*' \( -name '*.*jsonnet' -or -name '*.libsonnet' \))
 JSONNETFMT_ARGS ?= --in-place --pad-arrays


### PR DESCRIPTION
While it was already possible to use podman by setting the DOCKER_CMD
env var, this was not enough for most commands.

This commit adds support for Podman out of the box. If Docker is
installed, it will be preferred over Podman to stay
backwards-compatible.

The `--userns=keep-id` flag is required on Podman to ensure that 1.) the
process in the container can write to the mounted workdirs, and 2.)
ensure files created by processes in the container have the correct owner
and group IDs: The ones from the user running the Make tasks.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.