### PR TITLE
Auto discover OIDC configuration if not set

### DIFF
--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -49,10 +49,14 @@ def test_login(mock_tokencache, mock_browser, tmp_path):
         tmp_path,
         api_url=api_url,
     )
-    config.oidc_client = client
-    config.oidc_discovery_url = discovery_url
 
     responses.add_passthru("http://localhost:18000/")
+    responses.add(
+        responses.GET,
+        api_url,
+        json={"oidc": {"discoveryUrl": discovery_url, "clientId": client}},
+        status=200,
+    )
     responses.add(
         responses.GET,
         discovery_url,


### PR DESCRIPTION
With this we are able to auto discover all configuration through lieutenant.

You should be able to do: 
```
COMMODORE_API_URL="https://api-dev.syn.vshn.net"  commodore catalog compile c-glrf-test
```
And commdore will find out where to authenticate and open a browser.



## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [ ] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
