### PR TITLE
component-template: Split `COMMODORE_CMD` and `COMPILE_CMD` in Makefile 

### DIFF
--- a/commodore/component-template/{{ cookiecutter.slug }}/Makefile
+++ b/commodore/component-template/{{ cookiecutter.slug }}/Makefile
@@ -43,7 +43,7 @@ docs-serve: ## Preview the documentation
 .PHONY: compile
 .compile:
 	mkdir -p dependencies
-	$(COMMODORE_CMD)
+	$(COMPILE_CMD)
 
 .PHONY: test
 test: commodore_args += -f tests/$(instance).yml

--- a/commodore/component-template/{{ cookiecutter.slug }}/Makefile.vars.mk
+++ b/commodore/component-template/{{ cookiecutter.slug }}/Makefile.vars.mk
@@ -31,7 +31,8 @@ VALE_ARGS ?= --minAlertLevel=error --config=/pages/ROOT/pages/.vale.ini /pages
 ANTORA_PREVIEW_CMD ?= $(DOCKER_CMD) run --rm --publish 35729:35729 --publish 2020:2020 --volume "${PWD}/.git":/preview/antora/.git --volume "${PWD}/docs":/preview/antora/docs docker.io/vshn/antora-preview:3.0.1.1 --style=syn --antora=docs
 
 
-COMMODORE_CMD  ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) docker.io/projectsyn/commodore:latest component compile . $(commodore_args)
+COMMODORE_CMD  ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) docker.io/projectsyn/commodore:latest
+COMPILE_CMD    ?= $(COMMODORE_CMD) component compile . $(commodore_args)
 JB_CMD         ?= $(DOCKER_CMD) $(DOCKER_ARGS) --entrypoint /usr/local/bin/jb docker.io/projectsyn/commodore:latest install
 
 instance ?= defaults

--- a/tests/test_component_template.py
+++ b/tests/test_component_template.py
@@ -320,9 +320,14 @@ def test_check_golden_diff(tmp_path: P):
     )
     assert exit_status == 0
 
-    # Call `make lint` in component directory
+    # Override component Makefile COMMODORE_CMD to use the local Commodore binary
+    env = os.environ
+    env["COMMODORE_CMD"] = "commodore"
+
+    # Call `make golden-diff` in component directory
     exit_status = call(
         "make golden-diff",
+        env=env,
         shell=True,
         cwd=tmp_path / "dependencies" / component_name,
     )


### PR DESCRIPTION
We want to be able to adjust which `commodore` to use without having to reproduce the full compile command when compiling individual components with `make test`, `make golden-diff` or `make gen-golden`.

This commit reduces `COMMODORE_CMD` to be the equivalent of a bare invocation of `commodore` and introduces a new variable `COMPILE_COMMAND` which corresponds to the previous value of `COMMODORE_CMD`.

The PR also updates the `golden-diff` test to run the Commodore binary under test instead of whichever container image is available locally as `projectsyn/commodore:latest`.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
