### PR TITLE
Deprecate external postprocessing filter definitions

### DIFF
--- a/commodore/postprocess/__init__.py
+++ b/commodore/postprocess/__init__.py
@@ -179,6 +179,15 @@ def postprocess_components(
 
         # "old", external filters
         extfilters = _get_external_filters(inv, c)
+        if len(extfilters) > 0:
+            deprecation_notice_url = (
+                "https://syn.tools/commodore/reference/"
+                + "deprecation-notices.html#_external_pp_filters"
+            )
+            config.register_deprecation_notice(
+                f"Component '{c.name}' uses deprecated external postprocessing "
+                + f"filter definitions. See {deprecation_notice_url} for more details."
+            )
 
         filters: List[Filter] = []
         for fd in invfilters + extfilters:

--- a/docs/modules/ROOT/pages/reference/deprecation-notices.adoc
+++ b/docs/modules/ROOT/pages/reference/deprecation-notices.adoc
@@ -3,6 +3,29 @@
 This page lists deprecations of Commodore features organized by version.
 We include a link to relevant documentation, if applicable.
 
+== https://github.com/projectsyn/commodore/releases/tag/v0.16.0[v0.16.0]
+
+[#_external_pp_filters]
+=== External postprocessing filter definitions are deprecated
+
+Commodore v0.4.0 introduced support for defining postprocessing filters in the component class.
+However, defining postprocessing filters in `postprocess/filters.yml` was never formally deprecated.
+
+To migrate a component which still uses `postprocess/filters.yml`, you can simply move the contents of the file to parameter `commodore.postprocess`, remove the file and commit the changes.
+
+[source,bash]
+----
+component_name=component-name
+export filters=$(yq e '.' postprocess/filters.yml)
+yq e -i '.parameters.commodore.postprocess = env(filters)' "class/${component_name}.yml"
+rm -rf postprocess/
+git add -u
+git commit -m "Move postprocessing filter definitions to component class"
+----
+
+TIP: The provided snippet uses https://github.com/mikefarah/yq[mikefarah/yq v4].
+
+
 == https://github.com/projectsyn/commodore/releases/tag/v0.14.0[v0.14.0]
 
 [#_multi_instance_top_level]

--- a/tests/test_postprocess.py
+++ b/tests/test_postprocess.py
@@ -181,6 +181,13 @@ def test_postprocess_components(tmp_path, capsys, enabled, invfilter, jsonnet, a
         captured = capsys.readouterr()
         assert "Skipping disabled filter" in captured.out
 
+    if not invfilter:
+        assert len(config._deprecation_notices) == 1
+        assert (
+            "Component 'test-component' uses deprecated external postprocessing filter definitions"
+            in config._deprecation_notices[0]
+        )
+
 
 # We keep the enabledref tests separate as we don't actually
 # render the inventory with reclass in the test above.


### PR DESCRIPTION
Commodore v0.4.0 introduced support for defining postprocessing filters in the component class. However, defining postprocessing filters in `postprocess/filters.yml` was never formally deprecated.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
