### PR TITLE
Refactor `_push_catalog()` to return early in local mode

### DIFF
--- a/commodore/catalog.py
+++ b/commodore/catalog.py
@@ -105,7 +105,8 @@ def _push_catalog(cfg: Config, repo: GitRepo, commit_message: str):
             ) from e
         for pi in pushinfos:
             # Any error has pi.ERROR set in the `flags` bitmask
-            # We just forward the summary from the pushinfo
+            # We just forward the summary from the first pushinfo which has the error
+            # flag set.
             summary = pi.summary.strip()
             if (pi.flags & pi.ERROR) != 0:
                 raise click.ClickException(

--- a/commodore/catalog.py
+++ b/commodore/catalog.py
@@ -84,38 +84,37 @@ def _push_catalog(cfg: Config, repo: GitRepo, commit_message: str):
 
     Ask user to confirm push if `--interactive` is specified
     """
-    if not cfg.local:
-        if cfg.interactive and cfg.push:
-            cfg.push = click.confirm(" > Should the push be done?")
-
-        if cfg.push:
-            click.echo(" > Commiting changes...")
-            repo.commit(commit_message)
-            click.echo(" > Pushing catalog to remote...")
-            try:
-                pushinfos = repo.push()
-            except GitCommandError as e:
-                raise click.ClickException(
-                    "Failed to push to the catalog repository: "
-                    + f"Git exited with status code {e.status}"
-                ) from e
-            for pi in pushinfos:
-                # Any error has pi.ERROR set in the `flags` bitmask
-                # We just forward the summary from the pushinfo
-                summary = pi.summary.strip()
-                if (pi.flags & pi.ERROR) != 0:
-                    raise click.ClickException(
-                        f"Failed to push to the catalog repository: {summary}"
-                    )
-        else:
-            click.echo(" > Skipping commit+push to catalog...")
-            click.echo(" > Use flag --push to commit and push the catalog repo")
-            click.echo(
-                " > Add flag --interactive to show the diff and decide on the push"
-            )
-    else:
+    if cfg.local:
         repo.reset(working_tree=False)
         click.echo(" > Skipping commit+push to catalog in local mode...")
+        return
+
+    if cfg.interactive and cfg.push:
+        cfg.push = click.confirm(" > Should the push be done?")
+
+    if cfg.push:
+        click.echo(" > Commiting changes...")
+        repo.commit(commit_message)
+        click.echo(" > Pushing catalog to remote...")
+        try:
+            pushinfos = repo.push()
+        except GitCommandError as e:
+            raise click.ClickException(
+                "Failed to push to the catalog repository: "
+                + f"Git exited with status code {e.status}"
+            ) from e
+        for pi in pushinfos:
+            # Any error has pi.ERROR set in the `flags` bitmask
+            # We just forward the summary from the pushinfo
+            summary = pi.summary.strip()
+            if (pi.flags & pi.ERROR) != 0:
+                raise click.ClickException(
+                    f"Failed to push to the catalog repository: {summary}"
+                )
+    else:
+        click.echo(" > Skipping commit+push to catalog...")
+        click.echo(" > Use flag --push to commit and push the catalog repo")
+        click.echo(" > Add flag --interactive to show the diff and decide on the push")
 
 
 def _is_semantic_diff_kapitan_029_030(win: Tuple[str, str]) -> bool:

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -3,7 +3,9 @@ Tests for catalog internals
 """
 import copy
 from pathlib import Path
+from unittest.mock import patch
 
+import click
 import git
 import pytest
 
@@ -68,7 +70,7 @@ def inexistent_cluster() -> Cluster:
 def fresh_cluster(tmp_path: Path) -> Cluster:
     cr = copy.deepcopy(cluster_resp)
 
-    git.Repo.init(tmp_path / "repo.git")
+    git.Repo.init(tmp_path / "repo.git", bare=True)
 
     cr["gitRepo"]["url"] = f"file:///{tmp_path}/repo.git"
     return Cluster(
@@ -106,3 +108,121 @@ def test_fetch_catalog_initial_commit_for_empty_repo(
     assert r.repo.head
     assert r.working_tree_dir
     assert r.repo.head.commit.message == "Initial commit"
+
+
+def setup_catalog_for_push(config: Config, cluster: Cluster):
+    repo = catalog.fetch_catalog(config, cluster)
+    with open(repo.working_tree_dir / "test.txt", "w") as f:
+        f.writelines(["foo"])
+
+    repo.stage_files(["test.txt"])
+
+    return repo
+
+
+@pytest.mark.parametrize("push", [True, False])
+@pytest.mark.parametrize("local", [True, False])
+def test_push_catalog(
+    capsys,
+    tmp_path: Path,
+    config: Config,
+    fresh_cluster: Cluster,
+    push: bool,
+    local: bool,
+):
+    repo = setup_catalog_for_push(config, fresh_cluster)
+
+    config.push = push
+    config.local = local
+
+    catalog._push_catalog(config, repo, "Add test.txt")
+
+    upstream = git.Repo(tmp_path / "repo.git")
+    captured = capsys.readouterr()
+
+    if local:
+        assert len(upstream.branches) == 0
+        assert repo.repo.untracked_files == ["test.txt"]
+        assert not repo.repo.is_dirty()
+        assert "Skipping commit+push to catalog in local mode..." in captured.out
+    elif push:
+        assert upstream.active_branch.commit.message == "Add test.txt"
+        assert repo.repo.untracked_files == []
+        assert not repo.repo.is_dirty()
+        assert "Commiting changes..." in captured.out
+        assert "Pushing catalog to remote..." in captured.out
+    else:
+        assert len(upstream.branches) == 0
+        assert repo.repo.untracked_files == []
+        assert repo.repo.is_dirty()
+        assert ("test.txt", 0) in repo.repo.index.entries
+        assert "Skipping commit+push to catalog..." in captured.out
+
+
+@pytest.mark.parametrize("interactive", ["y", "n"])
+@patch("click.confirm")
+def test_push_catalog_interactive(
+    mock_confirm,
+    capsys,
+    tmp_path: Path,
+    config: Config,
+    fresh_cluster: Cluster,
+    interactive: str,
+):
+    repo = setup_catalog_for_push(config, fresh_cluster)
+
+    config.push = True
+    config.interactive = True
+    mock_confirm.return_value = interactive == "y"
+
+    catalog._push_catalog(config, repo, "Add test.txt")
+
+    upstream = git.Repo(tmp_path / "repo.git")
+    captured = capsys.readouterr()
+
+    if interactive == "y":
+        assert upstream.active_branch.commit.message == "Add test.txt"
+        assert repo.repo.untracked_files == []
+        assert not repo.repo.is_dirty()
+        assert "Commiting changes..." in captured.out
+        assert "Pushing catalog to remote..." in captured.out
+    else:
+        assert len(upstream.branches) == 0
+        assert repo.repo.untracked_files == []
+        assert repo.repo.is_dirty()
+        assert ("test.txt", 0) in repo.repo.index.entries
+        assert "Skipping commit+push to catalog..." in captured.out
+
+
+def test_push_catalog_giterror(config: Config, fresh_cluster: Cluster):
+    repo = setup_catalog_for_push(config, fresh_cluster)
+
+    config.push = True
+    repo.remote = "file:///path/to/repo.git"
+
+    with pytest.raises(click.ClickException) as e:
+        catalog._push_catalog(config, repo, "Add test.txt")
+        assert (
+            "Failed to push to the catalog repository: Git exited with status code"
+            in str(e)
+        )
+
+
+def test_push_catalog_remoteerror(
+    tmp_path: Path, config: Config, fresh_cluster: Cluster
+):
+    repo = setup_catalog_for_push(config, fresh_cluster)
+
+    config.push = True
+    hook_path = tmp_path / "repo.git" / "hooks" / "pre-receive"
+    with open(hook_path, "w") as hookf:
+        hookf.write("#!/bin/sh\necho 'Push denied'\nexit 1")
+
+    hook_path.chmod(0o755)
+
+    with pytest.raises(click.ClickException) as e:
+        catalog._push_catalog(config, repo, "Add test.txt")
+        assert (
+            "Failed to push to the catalog repository: [remote rejected] (pre-receive hook declined)"
+            in str(e)
+        )


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
