### PR TITLE
Fix edge cases in `_is_semantic_diff_kapitan_029_030()`

### DIFF
--- a/commodore/catalog.py
+++ b/commodore/catalog.py
@@ -136,8 +136,10 @@ def _is_semantic_diff_kapitan_029_030(win: Tuple[str, str]) -> bool:
 
     # Ignore context and metadata lines:
     if (
-        line_a.startswith(" ")
-        or line_b.startswith(" ")
+        # We don't use line_a/line_b here, as it's possible that the leading space of a
+        # context line gets stripped if the line is empty.
+        win[0].startswith(" ")
+        or win[1].startswith(" ")
         or line_a.startswith("@@")
         or line_b.startswith("@@")
     ):
@@ -147,7 +149,7 @@ def _is_semantic_diff_kapitan_029_030(win: Tuple[str, str]) -> bool:
     # by a stream separator anymore
     if line_a == "-null" and line_b in ("----", "---- null"):
         return False
-    if line_a == "---- null" and line_b == "----":
+    if line_a == "---- null" and line_b in ("----", "---- null"):
         return False
 
     # Ignore changes which are only about Tiller -> Helm as object manager


### PR DESCRIPTION
* Correctly ignore pair of lines if either line is an empty context line
* Correctly ignore multiple consecutive removed `null` objects in YAML stream

Follow-up to #450 

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.
- [x] Rebase after #452 is merged

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
