### PR TITLE
Remove deprecated parameter `component_versions`

### DIFF
--- a/commodore/cluster.py
+++ b/commodore/cluster.py
@@ -221,14 +221,6 @@ def render_params(inv: Inventory, cluster: Cluster):
             "customer": {
                 "name": cluster.tenant_id,
             },
-            # Merge component_versions into components in params.cluster for
-            # backwards-compatibility.
-            # We do this here instead of the target to ensure values in
-            # `components` have precedence over values in
-            # `component_versions`.
-            # TODO Remove once the deprecated `component_versions` field is removed
-            "component_versions": {},
-            "components": "${component_versions}",
         },
     }
 

--- a/commodore/inventory/parameters.py
+++ b/commodore/inventory/parameters.py
@@ -233,11 +233,6 @@ class InventoryFactory:
         )
         params = render_params(self._inventory, cluster)
 
-        # Don't support legacy component_versions key
-        # TODO: remove this when implementing issue #375
-        del params["parameters"]["components"]
-        del params["parameters"]["component_versions"]
-
         yaml_dump(params, self.classes_dir / "base.yml")
 
         # Create the following fake hierarchy for the render target:

--- a/docs/modules/ROOT/pages/reference/deprecation-notices.adoc
+++ b/docs/modules/ROOT/pages/reference/deprecation-notices.adoc
@@ -6,6 +6,7 @@ We include a link to relevant documentation, if applicable.
 == https://github.com/projectsyn/commodore/releases/tag/v1.0.0[v1.0.0]
 
 * Support for external postprocessing filter definitions is removed [<<_external_pp_filters,deprecated in v0.16.0>>].
+* Support for `parameters.component_versions` is removed [<<_parameters_component_versions_is_deprecated,deprecated in v0.5.0>>].
 
 == https://github.com/projectsyn/commodore/releases/tag/v0.16.0[v0.16.0]
 


### PR DESCRIPTION
We've moved to `parameters.components` to specify component URLs and versions in Commodore v0.5.0. This commit removes support for the deprecated parameter `component_versions` which we used before v0.5.0 to specify component version overrides.

Relates #375

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
