### PR TITLE
Correctly remove dangling link destinations in `relsymlink()` 

### DIFF
--- a/commodore/helpers.py
+++ b/commodore/helpers.py
@@ -225,8 +225,8 @@ def relsymlink(src: P, dest_dir: P, dest_name: Optional[str] = None):
     # https://docs.python.org/3/library/pathlib.html#pathlib.PurePath.relative_to
     link_src = os.path.relpath(src, start=dest_dir)
     link_dst = dest_dir / dest_name
-    if not P(link_src).exists():
-        click.ClickException(
+    if not P(src).exists():
+        raise click.ClickException(
             f"Can't link {link_src} to {link_dst}. Source does not exist."
         )
     if link_dst.exists() or link_dst.is_symlink():

--- a/commodore/helpers.py
+++ b/commodore/helpers.py
@@ -229,7 +229,7 @@ def relsymlink(src: P, dest_dir: P, dest_name: Optional[str] = None):
         click.ClickException(
             f"Can't link {link_src} to {link_dst}. Source does not exist."
         )
-    if link_dst.exists():
+    if link_dst.exists() or link_dst.is_symlink():
         os.remove(link_dst)
     os.symlink(link_src, link_dst)
 

--- a/tests/test_dependency_mgmt.py
+++ b/tests/test_dependency_mgmt.py
@@ -32,8 +32,9 @@ def setup_components_upstream(tmp_path: Path, components: Iterable[str]):
         class_dir = repo_path / "class"
         class_dir.mkdir(parents=True, exist_ok=True)
         (class_dir / "defaults.yml").touch(exist_ok=True)
+        (class_dir / f"{component}.yml").touch(exist_ok=True)
 
-        repo.index.add(["class/defaults.yml"])
+        repo.index.add(["class/defaults.yml", f"class/{component}.yml"])
         repo.index.commit("component defaults")
 
     return component_urls, component_versions
@@ -53,23 +54,32 @@ def data(tmp_path):
 
 
 def test_symlink(tmp_path: Path):
-    test_file = tmp_path / "test1"
+    test_file = tmp_path / "src" / "test"
+    test_file.parent.mkdir(parents=True, exist_ok=True)
+    with open(test_file, "w") as f:
+        f.write("test")
+
     relsymlink(test_file, tmp_path)
-    assert test_file.is_symlink()
+    assert (tmp_path / "test").is_symlink()
+    assert (tmp_path / "test").exists()
+    with open(tmp_path / "test") as f:
+        assert f.read() == "test"
 
 
 def test_override_symlink(tmp_path: Path):
-    test_file = tmp_path / "test2"
+    test_file = tmp_path / "src" / "test2"
+    test_file.parent.mkdir()
     test_file.touch()
-    assert not test_file.is_symlink()
     relsymlink(test_file, tmp_path)
-    assert test_file.is_symlink()
+    assert (tmp_path / "test2").is_symlink()
 
 
 def test_create_component_symlinks_fails(data: Config, tmp_path: Path):
     component = Component("my-component", work_dir=tmp_path)
-    with pytest.raises(FileNotFoundError):
+    with pytest.raises(click.ClickException) as e:
         dependency_mgmt.create_component_symlinks(data, component)
+
+    assert "Source does not exist" in str(e.value)
 
 
 def setup_mock_component(tmp_path: Path, name="my-component") -> Component:
@@ -639,6 +649,8 @@ def _setup_register_components(tmp_path: Path):
         r.create_remote("origin", f"ssh://git@example.com/git/{directory}")
         os.makedirs(cpath / "class", exist_ok=True)
         with open(cpath / "class" / "defaults.yml", "w") as f:
+            f.write("")
+        with open(cpath / "class" / f"{directory}.yml", "w") as f:
             f.write("")
 
     return component_dirs, other_dirs

--- a/tests/test_dependency_mgmt.py
+++ b/tests/test_dependency_mgmt.py
@@ -14,7 +14,6 @@ from typing import Dict, Iterable, List, Optional
 from commodore import dependency_mgmt
 from commodore.config import Config
 from commodore.component import Component
-from commodore.helpers import relsymlink
 from commodore.inventory import Inventory
 
 
@@ -51,27 +50,6 @@ def data(tmp_path):
         api_url="https://syn.example.com",
         api_token="token",
     )
-
-
-def test_symlink(tmp_path: Path):
-    test_file = tmp_path / "src" / "test"
-    test_file.parent.mkdir(parents=True, exist_ok=True)
-    with open(test_file, "w") as f:
-        f.write("test")
-
-    relsymlink(test_file, tmp_path)
-    assert (tmp_path / "test").is_symlink()
-    assert (tmp_path / "test").exists()
-    with open(tmp_path / "test") as f:
-        assert f.read() == "test"
-
-
-def test_override_symlink(tmp_path: Path):
-    test_file = tmp_path / "src" / "test2"
-    test_file.parent.mkdir()
-    test_file.touch()
-    relsymlink(test_file, tmp_path)
-    assert (tmp_path / "test2").is_symlink()
 
 
 def test_create_component_symlinks_fails(data: Config, tmp_path: Path):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,9 +1,12 @@
 """
 Unit-tests for helpers
 """
+import os
 from pathlib import Path
-from typing import Callable
+from typing import Callable, Optional
 import textwrap
+
+import click
 import pytest
 import responses
 from url_normalize import url_normalize
@@ -252,3 +255,33 @@ def test_lieutenant_query_response_errors(response, expected):
         helpers.lieutenant_query(base_url, "token", "clusters", "")
 
     _verify_call_status(query_url)
+
+
+@pytest.mark.parametrize("dst_is_dangling", [None, True, False])
+def test_relsymlink_dest_name(tmp_path: Path, dst_is_dangling: Optional[bool]):
+    src = tmp_path / "src.txt"
+    dst = tmp_path / "dst.txt"
+
+    with open(src, "w") as f:
+        f.write("Test")
+
+    if dst_is_dangling is not None:
+        if dst_is_dangling:
+            os.symlink(tmp_path / "err.txt", dst)
+        else:
+            os.symlink(tmp_path / "src.txt", dst)
+
+    helpers.relsymlink(src, tmp_path, dest_name="dst.txt")
+
+
+def test_relsymlink_invalid_src_exception(tmp_path: Path):
+    src = tmp_path / "src.txt"
+
+    with pytest.raises(click.ClickException) as e:
+        helpers.relsymlink(src, tmp_path, dest_name="dst.txt")
+
+    print(str(e.value))
+    assert (
+        f"Can't link {src.name} to {tmp_path / 'dst.txt'}. Source does not exist."
+        in str(e.value)
+    )

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -257,6 +257,27 @@ def test_lieutenant_query_response_errors(response, expected):
     _verify_call_status(query_url)
 
 
+def test_relsymlink(tmp_path: Path):
+    test_file = tmp_path / "src" / "test"
+    test_file.parent.mkdir(parents=True, exist_ok=True)
+    with open(test_file, "w") as f:
+        f.write("test")
+
+    helpers.relsymlink(test_file, tmp_path)
+    assert (tmp_path / "test").is_symlink()
+    assert (tmp_path / "test").exists()
+    with open(tmp_path / "test") as f:
+        assert f.read() == "test"
+
+
+def test_override_relsymlink(tmp_path: Path):
+    test_file = tmp_path / "src" / "test2"
+    test_file.parent.mkdir()
+    test_file.touch()
+    helpers.relsymlink(test_file, tmp_path)
+    assert (tmp_path / "test2").is_symlink()
+
+
 @pytest.mark.parametrize("dst_is_dangling", [None, True, False])
 def test_relsymlink_dest_name(tmp_path: Path, dst_is_dangling: Optional[bool]):
     src = tmp_path / "src.txt"


### PR DESCRIPTION
`Path.exists()` returns False for dangling symlinks. Until now, we used only `Path.exists()` to determine whether we need to remove the link target before creating a new symlink.

This PR checks both `Path.exists()` and `Path.is_symlink()` to determine whether we need to remove a link target before creating a new symlink.

This fixes an issue where Commodore can fail to replace dangling symlinks for components which have been changed to export component library aliases.

The PR also correctly raises the exception when source doesn't exist.

Will be backported to a v0.17.1 since the bug may break catalog compilations in existing Commodore working directories.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
