### PR TITLE
[Backport 0.17] Fix removing dangling symlinks in `relsymlink()`

### DIFF
--- a/commodore/helpers.py
+++ b/commodore/helpers.py
@@ -225,11 +225,11 @@ def relsymlink(src: P, dest_dir: P, dest_name: Optional[str] = None):
     # https://docs.python.org/3/library/pathlib.html#pathlib.PurePath.relative_to
     link_src = os.path.relpath(src, start=dest_dir)
     link_dst = dest_dir / dest_name
-    if not P(link_src).exists():
-        click.ClickException(
+    if not P(src).exists():
+        raise click.ClickException(
             f"Can't link {link_src} to {link_dst}. Source does not exist."
         )
-    if link_dst.exists():
+    if link_dst.exists() or link_dst.is_symlink():
         os.remove(link_dst)
     os.symlink(link_src, link_dst)
 


### PR DESCRIPTION
Backport of #456 to v0.17

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
