### PR TITLE
Fix potential KeyError in `tokencache.get()`

### DIFF
--- a/commodore/tokencache.py
+++ b/commodore/tokencache.py
@@ -28,4 +28,4 @@ def get(lieutenant: str) -> Optional[str]:
             cache = json.load(f)
     except (IOError, FileNotFoundError):
         return None
-    return cache[lieutenant]
+    return cache.get(lieutenant)

--- a/tests/test_tokencache.py
+++ b/tests/test_tokencache.py
@@ -16,6 +16,14 @@ def test_get_token(fs):
     assert tokencache.get("https://syn2.example.com") == "token2"
 
 
+def test_get_nonexistent_token(fs):
+    fs.create_file(
+        f"{xdg_cache_home}/commodore/token",
+        contents='{"https://syn.example.com":"token","https://syn2.example.com":"token2"}',
+    )
+    assert tokencache.get("https://syn3.example.com") is None
+
+
 def test_save_token(fs):
     tokencache.save("https://syn.example.com", "save")
     tokencache.save("https://syn2.example.com", "save2")


### PR DESCRIPTION
We need to use `Dict.get()` to read a key which might not exist from the dictionary.

Will be backported to v0.17

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
