### PR TITLE
Fix `KeyError` in error message for invalid postprocessing filters

### DIFF
--- a/commodore/postprocess/__init__.py
+++ b/commodore/postprocess/__init__.py
@@ -148,8 +148,9 @@ def postprocess_components(
             try:
                 filters.append(Filter.from_dict(config, c, a, fd))
             except (KeyError, ValueError) as e:
+                filtername = fd.get("filter", "<unknown>")
                 click.secho(
-                    f" > Skipping filter '{fd['filter']}' with invalid definition {fd}: {e}",
+                    f" > Skipping filter '{filtername}' with invalid definition {fd}: {e}",
                     fg="yellow",
                 )
 


### PR DESCRIPTION
Previously we could cause a `KeyError` when formatting an error message for a postprocessing filter which is missing the key `filter`.

This PR ensures that we create a nice error message in that case.

Additionally, we add tests covering different invalid postprocessing filter definitions.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Rebase after #463 is merged

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
