### PR TITLE
Add dependencies which shouldn't be updated to `ignoreDeps` in `renvoate.json`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,11 @@
   "lockFileMaintenance": {
     "enabled": true
   },
+  "ignoreDeps": [
+    "gitpython",
+    "requests",
+    "typing-extensions"
+  ],
   "labels": [
     "dependency"
   ]

--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,7 @@
   "poetry": {
     "enabled": true
   },
-  "lockfileMaintenance": {
+  "lockFileMaintenance": {
     "enabled": true
   },
   "labels": [


### PR DESCRIPTION
We need to keep back `gitpython`, `requests` and `typing-extensions` because Kapitan depends on specific versions of those packages.

Follow-up to #471 

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
