### PR TITLE
Make usage of parameter `component_versions` an error

### DIFF
--- a/commodore/compile.py
+++ b/commodore/compile.py
@@ -124,17 +124,18 @@ def _local_setup(config: Config, cluster_id):
     return GitRepo(None, config.catalog_dir)
 
 
-def check_parameters_component_versions(config: Config, cluster_parameters):
+def check_parameters_component_versions(cluster_parameters):
     """
-    Deprecation handler for `parameters.component_versions`.
+    Check inventory for `parameters.component_versions`.
 
-    Registers a deprecation notice if uses of `parameters.component_versions`
-    are found in the rendered inventory.
+    Raise an error if the parameter has any contents.
     """
     cvers = cluster_parameters.get("component_versions", {})
     if len(cvers.keys()) > 0:
-        config.register_deprecation_notice(
-            "`parameters.component_versions` is deprecated, please migrate to `parameters.components`"
+        raise click.ClickException(
+            "Specifying component versions in parameter `component_versions` "
+            + "is no longer suppported. Please migrate your configuration to "
+            + "parameter `components`."
         )
 
 
@@ -148,7 +149,7 @@ def compile(config, cluster_id):
 
     inventory = kapitan_inventory(config)
     cluster_parameters = inventory[config.inventory.bootstrap_target]["parameters"]
-    check_parameters_component_versions(config, cluster_parameters)
+    check_parameters_component_versions(cluster_parameters)
     create_component_library_aliases(config, cluster_parameters)
 
     # Verify that all aliased components support instantiation


### PR DESCRIPTION
Relates #375

Removal of support for `parameters.component_versions` is already added as a breaking change in #454

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
