### PR TITLE
Remove unused property `Component.filters_file`

### DIFF
--- a/commodore/component/__init__.py
+++ b/commodore/component/__init__.py
@@ -91,10 +91,6 @@ class Component:
         return None
 
     @property
-    def filters_file(self) -> P:
-        return self.target_directory / "postprocess" / "filters.yml"
-
-    @property
     def parameters_key(self):
         return component_parameters_key(self.name)
 


### PR DESCRIPTION
We don't support external postprocessing filter definitions anymore, so we don't need a property telling us where components used to define external postprocessing filters.

Follow-up for #453 

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
