### PR TITLE
Raise error when compiling a cluster which uses removed reclass variables

### DIFF
--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -1,5 +1,6 @@
 import click
 import pytest
+import yaml
 
 from pathlib import Path as P
 from typing import Dict
@@ -162,3 +163,14 @@ def test_check_parameters_component_versions(cluster_params: Dict, raises: bool)
 
     else:
         compile.check_parameters_component_versions(cluster_params)
+
+
+def test_check_removed_reclass_variables_error(tmp_path, config):
+    testf = tmp_path / "test.yml"
+    with open(testf, "w") as f:
+        yaml.safe_dump({"parameters": {"test": "${customer:name}"}}, f)
+
+    with pytest.raises(click.ClickException) as e:
+        compile._check_removed_reclass_variables(config, "tests", [testf])
+
+    assert "Found 1 usages of removed reclass variables in the tests." in str(e.value)


### PR DESCRIPTION
We raise an error if we find any occurrences of removed reclass variables (cf. #460) in the cluster's global defaults, tenant repo, or
any enabled components. 

The global and tenant repo are linted before we try to fetch or register components, so that we always are able to produce nice errors instead of a reclass stack trace if the inventory contains usages of removed parameters.

For the components, we check the `defaults.yml` and `<component-name>.yml` of each included component after fetching or registering the cluster's components.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
