### PR TITLE
Raise error when compiling a component which uses removed reclass variables

### DIFF
--- a/commodore/compile.py
+++ b/commodore/compile.py
@@ -28,26 +28,9 @@ from .helpers import (
     kapitan_inventory,
     rm_tree_contents,
 )
-from .inventory.lint import DeprecatedParameterLinter
+from .inventory.lint import check_removed_reclass_variables
 from .postprocess import postprocess_components
 from .refs import update_refs
-
-
-def _check_removed_reclass_variables(
-    config: Config, location: str, paths: Iterable[Path]
-):
-    lint = DeprecatedParameterLinter()
-
-    errcount = 0
-    for path in paths:
-        errcount += lint(config, path)
-
-    # Raise error if any linting errors occurred
-    if errcount > 0:
-        raise click.ClickException(
-            f"Found {errcount} usages of removed reclass variables "
-            + f"in the {location}. See individual lint errors for details."
-        )
 
 
 def check_removed_reclass_variables_inventory(config: Config, tenant: str):
@@ -58,7 +41,7 @@ def check_removed_reclass_variables_inventory(config: Config, tenant: str):
         config.inventory.tenant_config_dir(tenant),
     ]
 
-    _check_removed_reclass_variables(config, "hierarchy", paths)
+    check_removed_reclass_variables(config, "hierarchy", paths)
 
 
 def check_removed_reclass_variables_components(config: Config):
@@ -68,7 +51,7 @@ def check_removed_reclass_variables_components(config: Config):
         [],
     )
 
-    _check_removed_reclass_variables(config, "enabled components", paths)
+    check_removed_reclass_variables(config, "enabled components", paths)
 
 
 def _fetch_global_config(cfg: Config, cluster: Cluster):

--- a/commodore/component/compile.py
+++ b/commodore/component/compile.py
@@ -16,6 +16,7 @@ from commodore.dependency_mgmt import (
 )
 from commodore.helpers import kapitan_compile, relsymlink, yaml_dump
 from commodore.inventory import Inventory
+from commodore.inventory.lint import check_removed_reclass_variables
 from commodore.postprocess import postprocess_components
 
 
@@ -60,6 +61,13 @@ def compile_component(
             config, component_name, instance_name, component_path
         )
         _prepare_kapitan_inventory(inv, component, value_files, instance_name)
+
+        # Raise error if component uses removed reclass parameters
+        check_removed_reclass_variables(
+            config,
+            "component",
+            [component.defaults_file, component.class_file] + value_files,
+        )
 
         # Verify component alias
         nodes = inventory_reclass(inv.inventory_dir)["nodes"]

--- a/commodore/inventory/lint.py
+++ b/commodore/inventory/lint.py
@@ -1,6 +1,6 @@
 import abc
 from pathlib import Path
-from typing import Any, Dict, Protocol
+from typing import Any, Dict, Iterable, Protocol
 
 import click
 import yaml
@@ -98,3 +98,20 @@ def run_linter(cfg: Config, path: Path, lintfunc: LintFunc) -> int:
         return _lint_directory(cfg, path, lintfunc)
 
     return _lint_file(cfg, path, lintfunc)
+
+
+def check_removed_reclass_variables(
+    config: Config, location: str, paths: Iterable[Path]
+):
+    lint = DeprecatedParameterLinter()
+
+    errcount = 0
+    for path in paths:
+        errcount += lint(config, path)
+
+    # Raise error if any linting errors occurred
+    if errcount > 0:
+        raise click.ClickException(
+            f"Found {errcount} usages of removed reclass variables "
+            + f"in the {location}. See individual lint errors for details."
+        )

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -1,6 +1,5 @@
 import click
 import pytest
-import yaml
 
 from pathlib import Path as P
 from typing import Dict
@@ -163,14 +162,3 @@ def test_check_parameters_component_versions(cluster_params: Dict, raises: bool)
 
     else:
         compile.check_parameters_component_versions(cluster_params)
-
-
-def test_check_removed_reclass_variables_error(tmp_path, config):
-    testf = tmp_path / "test.yml"
-    with open(testf, "w") as f:
-        yaml.safe_dump({"parameters": {"test": "${customer:name}"}}, f)
-
-    with pytest.raises(click.ClickException) as e:
-        compile._check_removed_reclass_variables(config, "tests", [testf])
-
-    assert "Found 1 usages of removed reclass variables in the tests." in str(e.value)

--- a/tests/test_inventory_lint.py
+++ b/tests/test_inventory_lint.py
@@ -1,0 +1,29 @@
+import click
+import pytest
+import yaml
+
+from commodore.config import Config
+from commodore.inventory import lint
+
+
+@pytest.fixture
+def config(tmp_path):
+    """
+    Setup test config object
+    """
+    return Config(
+        tmp_path,
+        api_url="https://syn.example.com",
+        api_token="token",
+    )
+
+
+def test_check_removed_reclass_variables_error(tmp_path, config):
+    testf = tmp_path / "test.yml"
+    with open(testf, "w") as f:
+        yaml.safe_dump({"parameters": {"test": "${customer:name}"}}, f)
+
+    with pytest.raises(click.ClickException) as e:
+        lint.check_removed_reclass_variables(config, "tests", [testf])
+
+    assert "Found 1 usages of removed reclass variables in the tests." in str(e.value)


### PR DESCRIPTION
Follow-up to #460 and #482, but for `commodore component compile`.

For component compilation, the check raises an error if the component's `defaults.yml`, `<component-name>.yml` or any of the additional class files provided via command line arguments uses a removed reclass variable.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
