### PR TITLE
Convert type annotations for standard collections to PEP-585 

### DIFF
--- a/commodore/catalog.py
+++ b/commodore/catalog.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 import difflib
 import shutil
 import time
 import textwrap
 
+from collections.abc import Iterable
 from pathlib import Path as P
-from typing import Iterable, Tuple
 
 import click
 import yaml
@@ -120,7 +122,7 @@ def _push_catalog(cfg: Config, repo: GitRepo, commit_message: str):
         click.echo(" > Add flag --interactive to show the diff and decide on the push")
 
 
-def _is_semantic_diff_kapitan_029_030(win: Tuple[str, str]) -> bool:
+def _is_semantic_diff_kapitan_029_030(win: tuple[str, str]) -> bool:
     """
     Returns True if a pair of lines of a diff which is already sorted
     by K8s object indicates that this diff contains a semantic change
@@ -169,7 +171,7 @@ def _is_semantic_diff_kapitan_029_030(win: Tuple[str, str]) -> bool:
 
 def _kapitan_029_030_difffunc(
     before_text: str, after_text: str, fromfile: str = "", tofile: str = ""
-) -> Tuple[Iterable[str], bool]:
+) -> tuple[Iterable[str], bool]:
 
     before_objs = sorted(yaml.safe_load_all(before_text), key=K8sObject)
     before_sorted_lines = yaml.dump_all(before_objs).split("\n")

--- a/commodore/cli.py
+++ b/commodore/cli.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 import json
 import sys
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Iterable, Optional, Tuple
+from typing import Optional
 
 import click
 import yaml
@@ -489,7 +492,7 @@ def component_versions(
 @verbosity
 @pass_config
 def inventory_lint(
-    config: Config, verbose: int, target: Tuple[str], linter: Tuple[str]
+    config: Config, verbose: int, target: tuple[str], linter: tuple[str]
 ):
     """Lint YAML files in the provided paths.
 

--- a/commodore/cluster.py
+++ b/commodore/cluster.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import os
 
-from typing import Any, Tuple, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 import click
 
@@ -16,10 +18,10 @@ from .inventory import Inventory
 
 
 class Cluster:
-    _cluster_response: Dict
-    _tenant_response: Dict
+    _cluster_response: dict
+    _tenant_response: dict
 
-    def __init__(self, cluster_response: Dict, tenant_response: Dict):
+    def __init__(self, cluster_response: dict, tenant_response: dict):
         self._cluster = cluster_response
         self._tenant = tenant_response
         if (
@@ -87,11 +89,11 @@ class Cluster:
         return self._tenant["displayName"]
 
     @property
-    def facts(self) -> Dict[str, str]:
+    def facts(self) -> dict[str, str]:
         return self._cluster.get("facts", {})
 
     @property
-    def dynamic_facts(self) -> Dict[str, Any]:
+    def dynamic_facts(self) -> dict[str, Any]:
         return self._cluster.get("dynamicFacts", {})
 
 
@@ -107,7 +109,7 @@ def load_cluster_from_api(cfg: Config, cluster_id: str) -> Cluster:
     return Cluster(cluster_response, tenant_response)
 
 
-def read_cluster_and_tenant(inv: Inventory) -> Tuple[str, str]:
+def read_cluster_and_tenant(inv: Inventory) -> tuple[str, str]:
     """
     Reads the cluster and tenant ID from the current target.
     """
@@ -126,7 +128,7 @@ def read_cluster_and_tenant(inv: Inventory) -> Tuple[str, str]:
 def render_target(
     inv: Inventory,
     target: str,
-    components: Dict[str, Component],
+    components: dict[str, Component],
     # pylint: disable=unsubscriptable-object
     component: Optional[str] = None,
 ):
@@ -137,7 +139,7 @@ def render_target(
         raise click.ClickException(f"Target {target} is not a component")
 
     classes = [f"params.{inv.bootstrap_target}"]
-    parameters: Dict[str, Union[Dict, str]] = {
+    parameters: dict[str, Union[dict, str]] = {
         "_instance": target,
     }
     if not bootstrap:

--- a/commodore/compile.py
+++ b/commodore/compile.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Iterable
 
 import click
 

--- a/commodore/component/__init__.py
+++ b/commodore/component/__init__.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
 from pathlib import Path as P
-from typing import Iterable, Optional
+from typing import Optional
 
 import _jsonnet
 import click

--- a/commodore/component/compile.py
+++ b/commodore/component/compile.py
@@ -1,8 +1,11 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
 from pathlib import Path as P
 import shutil
 import tempfile
 from textwrap import dedent
-from typing import Iterable, Optional
+from typing import Optional
 
 import click
 from kapitan.resources import inventory_reclass

--- a/commodore/component/compile.py
+++ b/commodore/component/compile.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
-from pathlib import Path as P
 import shutil
 import tempfile
+
+from collections.abc import Iterable
+from pathlib import Path as P
 from textwrap import dedent
 from typing import Optional
 

--- a/commodore/config.py
+++ b/commodore/config.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 import time
 import textwrap
 
 from enum import Enum
 from pathlib import Path as P
-from typing import Dict, List, Optional
+from typing import Optional
 
 import jwt
 
@@ -22,10 +24,10 @@ class Migration(Enum):
 # pylint: disable=too-many-instance-attributes,too-many-public-methods
 class Config:
     _inventory: Inventory
-    _components: Dict[str, Component]
-    _config_repos: Dict[str, GitRepo]
-    _component_aliases: Dict[str, str]
-    _deprecation_notices: List[str]
+    _components: dict[str, Component]
+    _config_repos: dict[str, GitRepo]
+    _component_aliases: dict[str, str]
+    _deprecation_notices: list[str]
     _migration: Optional[Migration]
 
     oidc_client: Optional[str]
@@ -190,10 +192,10 @@ class Config:
     def get_component_aliases(self):
         return self._component_aliases
 
-    def register_component_aliases(self, aliases: Dict[str, str]):
+    def register_component_aliases(self, aliases: dict[str, str]):
         self._component_aliases = aliases
 
-    def verify_component_aliases(self, cluster_parameters: Dict):
+    def verify_component_aliases(self, cluster_parameters: dict):
         for alias, cn in self._component_aliases.items():
             if alias != cn and not _component_is_aliasable(cluster_parameters, cn):
                 raise click.ClickException(
@@ -232,7 +234,7 @@ class Config:
                 self.register_deprecation_notice(msg)
 
 
-def _component_is_aliasable(cluster_parameters: Dict, component_name: str):
+def _component_is_aliasable(cluster_parameters: dict, component_name: str):
     ckey = component_parameters_key(component_name)
     cmeta = cluster_parameters[ckey].get("_metadata", {})
     return cmeta.get("multi_instance", False)

--- a/commodore/dependency_mgmt.py
+++ b/commodore/dependency_mgmt.py
@@ -1,8 +1,11 @@
+from __future__ import annotations
+
 import os
 import json
+from collections.abc import Iterable
 from pathlib import Path as P
 from subprocess import call  # nosec
-from typing import Any, Dict, Iterable, List, Optional, Tuple, Set
+from typing import Any, Optional
 
 import click
 
@@ -21,7 +24,7 @@ def validate_component_library_name(cname: str, lib: P) -> P:
     return lib
 
 
-def _check_library_alias_prefixes(libalias: str, cn: str, component_prefixes: Set[str]):
+def _check_library_alias_prefixes(libalias: str, cn: str, component_prefixes: set[str]):
     for p in component_prefixes - {cn}:
         if libalias.startswith(p):
             raise click.ClickException(
@@ -30,9 +33,9 @@ def _check_library_alias_prefixes(libalias: str, cn: str, component_prefixes: Se
             )
 
 
-def _check_library_alias_collisions(cfg: Config, cluster_params: Dict[str, Any]):
+def _check_library_alias_collisions(cfg: Config, cluster_params: dict[str, Any]):
     # map of library alias to set(originating components)
-    collisions: Dict[str, Set[str]] = {}
+    collisions: dict[str, set[str]] = {}
 
     components = cfg.get_components()
     component_prefixes = set(cluster_params["components"].keys())
@@ -53,7 +56,7 @@ def _check_library_alias_collisions(cfg: Config, cluster_params: Dict[str, Any])
             )
 
 
-def create_component_library_aliases(cfg: Config, cluster_params: Dict[str, Any]):
+def create_component_library_aliases(cfg: Config, cluster_params: dict[str, Any]):
     _check_library_alias_collisions(cfg, cluster_params)
 
     for _, component in cfg.get_components().items():
@@ -122,7 +125,7 @@ def _format_component_list(components: Iterable[str]) -> str:
 
 def _extract_component_aliases(
     cfg: Config, kapitan_applications: Iterable[str]
-) -> Tuple[Set[str], Dict[str, Set[str]]]:
+) -> tuple[set[str], dict[str, set[str]]]:
     """
     Extract components and all aliases from Kapitan applications array.
 
@@ -131,7 +134,7 @@ def _extract_component_aliases(
     applications array.
     """
     components = set()
-    all_component_aliases: Dict[str, Set[str]] = {}
+    all_component_aliases: dict[str, set[str]] = {}
     for component in kapitan_applications:
         try:
             cn, alias = component.split(" as ")
@@ -149,7 +152,7 @@ def _extract_component_aliases(
     return components, all_component_aliases
 
 
-def _discover_components(cfg) -> Tuple[List[str], Dict[str, str]]:
+def _discover_components(cfg) -> tuple[list[str], dict[str, str]]:
     """
     Discover components used by the current cluster by extracting all entries from the
     reclass applications dictionary.
@@ -163,7 +166,7 @@ def _discover_components(cfg) -> Tuple[List[str], Dict[str, str]]:
         cfg, kapitan_applications.keys()
     )
 
-    component_aliases: Dict[str, str] = {}
+    component_aliases: dict[str, str] = {}
 
     for alias, cns in all_component_aliases.items():
         if len(cns) == 0:
@@ -209,7 +212,7 @@ def _discover_components(cfg) -> Tuple[List[str], Dict[str, str]]:
 
 def _read_components(
     cfg: Config, component_names
-) -> Tuple[Dict[str, str], Dict[str, Optional[str]]]:
+) -> tuple[dict[str, str], dict[str, Optional[str]]]:
     component_urls = {}
     component_versions = {}
 

--- a/commodore/gitrepo.py
+++ b/commodore/gitrepo.py
@@ -1,9 +1,12 @@
+from __future__ import annotations
+
 import difflib
 import hashlib
 
 from collections import namedtuple
+from collections.abc import Iterable, Sequence
 from pathlib import Path
-from typing import Iterable, List, Optional, Protocol, Sequence, Tuple
+from typing import Optional, Protocol
 
 import click
 
@@ -24,7 +27,7 @@ CommitInfo = namedtuple("CommitInfo", ["commit", "branch", "tag"])
 class DiffFunc(Protocol):
     def __call__(
         self, before_text: str, after_text: str, fromfile: str = "", tofile: str = ""
-    ) -> Tuple[Iterable[str], bool]:
+    ) -> tuple[Iterable[str], bool]:
         ...
 
 
@@ -80,7 +83,7 @@ def _compute_similarity(change):
 
 def _default_difffunc(
     before_text: str, after_text: str, fromfile: str = "", tofile: str = ""
-) -> Tuple[Iterable[str], bool]:
+) -> tuple[Iterable[str], bool]:
     before_lines = before_text.split("\n")
     after_lines = after_text.split("\n")
     diff_lines = difflib.unified_diff(
@@ -318,7 +321,7 @@ class GitRepo:
         except BadName as e:
             raise RefError(f"Revision '{version}' not found in repository") from e
 
-    def stage_all(self, diff_func: DiffFunc = _default_difffunc) -> Tuple[str, bool]:
+    def stage_all(self, diff_func: DiffFunc = _default_difffunc) -> tuple[str, bool]:
         """Stage all changes.
         This method currently doesn't handle hidden files correctly.
 
@@ -347,7 +350,7 @@ class GitRepo:
             diff = index.diff(self._null_tree)
 
         changed = False
-        difftext: List[str] = []
+        difftext: list[str] = []
         if diff:
             changed = True
             for ct in diff.change_type:

--- a/commodore/helpers.py
+++ b/commodore/helpers.py
@@ -1,10 +1,13 @@
+from __future__ import annotations
+
 import collections
 import itertools
 import json
 import shutil
 import os
+from collections.abc import Callable, Iterable
 from pathlib import Path as P
-from typing import Callable, Dict, Iterable, Optional
+from typing import Optional
 
 import click
 import requests
@@ -188,7 +191,7 @@ def kapitan_compile(
     )
 
 
-def kapitan_inventory(config: Config, key="nodes") -> Dict:
+def kapitan_inventory(config: Config, key="nodes") -> dict:
     """
     Reset reclass cache and render inventory.
     Returns the top-level key according to the kwarg.

--- a/commodore/inventory/lint.py
+++ b/commodore/inventory/lint.py
@@ -1,6 +1,10 @@
+from __future__ import annotations
+
 import abc
+
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Dict, Iterable, Protocol
+from typing import Any, Protocol
 
 import click
 import yaml
@@ -14,7 +18,7 @@ from .lint_deprecated_parameters import lint_deprecated_parameters
 
 
 class LintFunc(Protocol):
-    def __call__(self, file: Path, filecontents: Dict[str, Any]) -> int:
+    def __call__(self, file: Path, filecontents: dict[str, Any]) -> int:
         ...
 
 

--- a/commodore/inventory/lint_components.py
+++ b/commodore/inventory/lint_components.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 
 import click
 
 
-def lint_component_versions(file: Path, filecontents: Dict[str, Any]) -> int:
+def lint_component_versions(file: Path, filecontents: dict[str, Any]) -> int:
     errcount = 0
     components = filecontents.get("parameters", {}).get("components", {})
     for cn, cspec in components.items():

--- a/commodore/inventory/lint_deprecated_parameters.py
+++ b/commodore/inventory/lint_deprecated_parameters.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any
 
 import click
 
@@ -37,7 +39,7 @@ def _lint_string(file: Path, prefix: str, data: str) -> int:
     return errcount
 
 
-def _lint_list(file: Path, prefix: str, data: List) -> int:
+def _lint_list(file: Path, prefix: str, data: list) -> int:
     errcount = 0
     for i, v in enumerate(data):
         errcount += _lint_data(file, prefix + f"[{i}]", v)
@@ -45,7 +47,7 @@ def _lint_list(file: Path, prefix: str, data: List) -> int:
     return errcount
 
 
-def _lint_dict(file: Path, prefix: str, data: Dict[str, Any]) -> int:
+def _lint_dict(file: Path, prefix: str, data: dict[str, Any]) -> int:
     errcount = 0
     if prefix != "":
         prefix = f"{prefix}."
@@ -55,6 +57,6 @@ def _lint_dict(file: Path, prefix: str, data: Dict[str, Any]) -> int:
     return errcount
 
 
-def lint_deprecated_parameters(file: Path, filecontents: Dict[str, Any]) -> int:
+def lint_deprecated_parameters(file: Path, filecontents: dict[str, Any]) -> int:
     prefix = ""
     return _lint_dict(file, prefix, filecontents)

--- a/commodore/inventory/parameters.py
+++ b/commodore/inventory/parameters.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 import os
+from collections.abc import Iterable
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Optional
 
 from kapitan.reclass import reclass
 from kapitan.reclass.reclass import settings as reclass_settings
@@ -61,7 +64,7 @@ class InventoryFacts:
         return self._tenant_config
 
     @property
-    def extra_classes(self) -> List[str]:
+    def extra_classes(self) -> list[str]:
         return [cf.stem for cf in self._extra_class_files]
 
     @property
@@ -142,7 +145,7 @@ class InventoryFactory:
         self._inventory = Inventory(work_dir=work_dir)
         self._distributions = self._find_values(DefaultsFact.DISTRIBUTION)
         self._clouds = self._find_values(DefaultsFact.CLOUD)
-        self._cloud_regions: Dict[str, Iterable[str]] = {}
+        self._cloud_regions: dict[str, Iterable[str]] = {}
         for cloud in self._clouds:
             r = self._find_values(DefaultsFact.REGION, cloud=cloud)
             self._cloud_regions[cloud] = [it for it in r if it != "params"]
@@ -167,7 +170,7 @@ class InventoryFactory:
     def tenant_dir(self) -> Optional[Path]:
         return self._tenant_dir
 
-    def _reclass_config(self, allow_missing_classes: bool) -> Dict:
+    def _reclass_config(self, allow_missing_classes: bool) -> dict:
         return {
             "storage_type": "yaml_fs",
             "inventory_base_uri": str(self.directory.absolute()),
@@ -180,7 +183,7 @@ class InventoryFactory:
 
     def _render_inventory(
         self, target: Optional[str] = None, allow_missing_classes: bool = True
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         rc = self._reclass_config(allow_missing_classes)
         storage = reclass.get_storage(
             rc["storage_type"],
@@ -207,7 +210,7 @@ class InventoryFactory:
             raise
 
     def reclass(self, invfacts: InventoryFacts) -> InventoryParameters:
-        cluster_response: Dict[str, Any] = {
+        cluster_response: dict[str, Any] = {
             "id": invfacts.cluster_id,
             "tenant": invfacts.tenant_id,
             "displayName": "Foo Inc. Bar cluster",
@@ -289,7 +292,7 @@ class InventoryFactory:
         return self._clouds
 
     @property
-    def cloud_regions(self) -> Dict[str, Iterable[str]]:
+    def cloud_regions(self) -> dict[str, Iterable[str]]:
         return self._cloud_regions
 
     @classmethod

--- a/commodore/inventory/render.py
+++ b/commodore/inventory/render.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
+
 import shutil
 import tempfile
 
 from pathlib import Path
-from typing import Dict
 
 import click
 
@@ -19,7 +20,7 @@ def _cleanup_work_dir(cfg: Config, work_dir: Path):
 
 def extract_components(
     cfg: Config, invfacts: InventoryFacts
-) -> Dict[str, Dict[str, str]]:
+) -> dict[str, dict[str, str]]:
     if cfg.debug:
         click.echo(
             f"Called with: global_config={invfacts.global_config} "

--- a/commodore/login.py
+++ b/commodore/login.py
@@ -1,11 +1,11 @@
-import sys
-from typing import Optional, Any
-import threading
-from queue import Queue
-import webbrowser
 import json
-from functools import partial
+import sys
+import threading
+import webbrowser
 
+from functools import partial
+from queue import Queue
+from typing import Optional, Any
 
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from urllib.parse import urlparse, parse_qs

--- a/commodore/postprocess/__init__.py
+++ b/commodore/postprocess/__init__.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from pathlib import Path as P
-from typing import Any, Callable, ClassVar, Dict, List, Protocol, Set
+from typing import Any, Callable, ClassVar, Protocol
 
 import click
 
@@ -14,7 +16,7 @@ class FilterFunc(Protocol):
     def __call__(
         self,
         config: Config,
-        inv: Dict,
+        inv: dict,
         component: Component,
         instance: str,
         filterid: str,
@@ -24,31 +26,31 @@ class FilterFunc(Protocol):
         ...
 
 
-ValidateFunc = Callable[[Config, Component, str, Dict], Dict]
+ValidateFunc = Callable[[Config, Component, str, dict], dict]
 
 
 class Filter:
     type: str
     filter: str
     path: P
-    filterargs: Dict
+    filterargs: dict
     enabled: bool
 
     # PyLint complains about ClassVar not being subscriptable
     # pylint: disable=unsubscriptable-object
-    _run_handlers: ClassVar[Dict[str, FilterFunc]] = {
+    _run_handlers: ClassVar[dict[str, FilterFunc]] = {
         "builtin": run_builtin_filter,
         "jsonnet": run_jsonnet_filter,
     }
     # pylint: disable=unsubscriptable-object
-    _validate_handlers: ClassVar[Dict[str, ValidateFunc]] = {
+    _validate_handlers: ClassVar[dict[str, ValidateFunc]] = {
         "builtin": validate_builtin_filter,
         "jsonnet": validate_jsonnet_filter,
     }
     # pylint: disable=unsubscriptable-object
-    _required_keys: ClassVar[Set[str]] = {"type", "path", "filter"}
+    _required_keys: ClassVar[set[str]] = {"type", "path", "filter"}
 
-    def __init__(self, fd: Dict):
+    def __init__(self, fd: dict):
         """
         Assumes that `fd` has been validated with `_validate_filter`.
         """
@@ -59,7 +61,7 @@ class Filter:
         self.filterargs = fd.get("filterargs", {})
         self._runner: FilterFunc = self._run_handlers[self.type]
 
-    def run(self, config: Config, inventory: Dict, component: Component, instance: str):
+    def run(self, config: Config, inventory: dict, component: Component, instance: str):
         """
         Run the filter.
         """
@@ -80,7 +82,7 @@ class Filter:
         )
 
     @classmethod
-    def validate(cls, config: Config, c: Component, instance: str, f: Dict):
+    def validate(cls, config: Config, c: Component, instance: str, f: dict):
         """
         Validate filter definition in `f`.
         Raises exceptions as appropriate when the definition is invalid.
@@ -103,7 +105,7 @@ class Filter:
         return f
 
     @classmethod
-    def from_dict(cls, config: Config, c: Component, instance: str, f: Dict):
+    def from_dict(cls, config: Config, c: Component, instance: str, f: dict):
         """
         Create Filter object from filter definition dict `f`.
         Raises exceptions as appropriate when the definition is invalid.
@@ -112,7 +114,7 @@ class Filter:
         return Filter(Filter.validate(config, c, instance, f))
 
 
-def _get_inventory_filters(inv: Dict[str, Any]) -> List[Dict[str, Any]]:
+def _get_inventory_filters(inv: dict[str, Any]) -> list[dict[str, Any]]:
     """
     Return list of filters defined in inventory.
 
@@ -125,8 +127,8 @@ def _get_inventory_filters(inv: Dict[str, Any]) -> List[Dict[str, Any]]:
 
 def postprocess_components(
     config: Config,
-    kapitan_inventory: Dict[str, Dict[str, Any]],
-    components: Dict[str, Component],
+    kapitan_inventory: dict[str, dict[str, Any]],
+    components: dict[str, Component],
 ):
     click.secho("Postprocessing...", bold=True)
 
@@ -142,7 +144,7 @@ def postprocess_components(
         # inventory filters
         invfilters = _get_inventory_filters(inv)
 
-        filters: List[Filter] = []
+        filters: list[Filter] = []
         for fd in invfilters:
             try:
                 filters.append(Filter.from_dict(config, c, a, fd))

--- a/commodore/postprocess/builtin_filters.py
+++ b/commodore/postprocess/builtin_filters.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 import json
 
 from pathlib import Path as P
-from typing import Dict
 
 import _jsonnet
 import click
@@ -64,7 +65,7 @@ class UnknownBuiltinFilter(ValueError):
 # pylint: disable=too-many-arguments
 def run_builtin_filter(
     config: Config,
-    inv: Dict,
+    inv: dict,
     component: Component,
     instance: str,
     filterid: str,
@@ -79,7 +80,7 @@ def run_builtin_filter(
 
 
 # pylint: disable=unused-argument
-def validate_builtin_filter(config: Config, c: Component, instance: str, fd: Dict):
+def validate_builtin_filter(config: Config, c: Component, instance: str, fd: dict):
     if fd["filter"] not in _builtin_filters:
         raise UnknownBuiltinFilter(fd["filter"])
 

--- a/commodore/postprocess/jsonnet.py
+++ b/commodore/postprocess/jsonnet.py
@@ -1,9 +1,12 @@
+from __future__ import annotations
+
 import json
 import os
 import functools
 
+from collections.abc import Callable, Iterable
 from pathlib import Path as P
-from typing import Any, Callable, Dict, Iterable
+from typing import Any
 
 import _jsonnet
 
@@ -95,7 +98,7 @@ def write_jsonnet_output(output_dir: P, output: str):
 # pylint: disable=too-many-arguments
 def jsonnet_runner(
     work_dir: P,
-    inv: Dict[str, Any],
+    inv: dict[str, Any],
     component: str,
     instance: str,
     path: os.PathLike,
@@ -103,7 +106,7 @@ def jsonnet_runner(
     jsonnet_input: os.PathLike,
     **kwargs: str,
 ):
-    def _inventory() -> Dict[str, Any]:
+    def _inventory() -> dict[str, Any]:
         return inv
 
     _native_cb = _native_callbacks
@@ -127,7 +130,7 @@ def _filter_file(component: Component, filterpath: str) -> P:
 
 def run_jsonnet_filter(
     config: Config,
-    inv: Dict,
+    inv: dict,
     component: Component,
     instance: str,
     filterid: str,
@@ -153,7 +156,7 @@ def run_jsonnet_filter(
 
 
 # pylint: disable=unused-argument
-def validate_jsonnet_filter(config: Config, c: Component, instance: str, fd: Dict):
+def validate_jsonnet_filter(config: Config, c: Component, instance: str, fd: dict):
     filterfile = _filter_file(c, fd["filter"])
     if not filterfile.is_file():
         raise ValueError("Jsonnet filter definition does not exist")

--- a/commodore/refs.py
+++ b/commodore/refs.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
+
 import re
 import os
 from base64 import b64encode
 from pathlib import Path as P
-from typing import Dict
 
 import click
 
@@ -92,7 +93,7 @@ class RefBuilder:
     Helper class to wrap recursive search for Kapitan secret references
     """
 
-    _refs: Dict[str, SecretRef]
+    _refs: dict[str, SecretRef]
 
     def __init__(self, config: Config, inventory):
         self.debug = config.debug
@@ -165,7 +166,7 @@ class RefBuilder:
         return self._ref_params
 
 
-def update_refs(config: Config, aliases: Dict[str, str], inventory: Dict):
+def update_refs(config: Config, aliases: dict[str, str], inventory: dict):
     """
     Iterate over parameters for each target, and create Kapitan secret refs
     for all ?{...} found as values in the dicts

--- a/commodore/tokencache.py
+++ b/commodore/tokencache.py
@@ -1,7 +1,8 @@
-import os
-from typing import Optional
-from pathlib import Path
 import json
+import os
+
+from pathlib import Path
+from typing import Optional
 
 from xdg.BaseDirectory import xdg_cache_home
 

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,9 +1,10 @@
 """
 Tests for catalog internals
 """
+from __future__ import annotations
+
 import copy
 from pathlib import Path
-from typing import Dict, List
 from unittest.mock import patch
 
 import click
@@ -40,7 +41,7 @@ tenant_resp = {
 }
 
 
-def make_cluster_resp(id: str, displayName: str = "Test cluster") -> Dict:
+def make_cluster_resp(id: str, displayName: str = "Test cluster") -> dict:
     r = copy.deepcopy(cluster_resp)
     r["id"] = id
     r["displayName"] = displayName
@@ -469,7 +470,7 @@ def test_kapitan_029_030_difffunc_suppresses_noise():
     ],
 )
 def test_catalog_list(
-    config: Config, capsys, api_resp: List, expected: List[str], verbose: int
+    config: Config, capsys, api_resp: list, expected: list[str], verbose: int
 ):
     responses.add(
         responses.GET,

--- a/tests/test_catalog_compile.py
+++ b/tests/test_catalog_compile.py
@@ -1,13 +1,15 @@
+from __future__ import annotations
+
 import copy
 import os
 import pytest
 import re
 import yaml
 
+from collections.abc import Iterable
 from datetime import datetime, timedelta
 from pathlib import Path
 from unittest.mock import patch
-from typing import Iterable
 
 import git
 

--- a/tests/test_cli_functions.py
+++ b/tests/test_cli_functions.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import json
 
 from pathlib import Path
-from typing import Any, Dict, List, Protocol
+from typing import Any, Protocol
 from unittest import mock
 
 import pytest
@@ -16,7 +18,7 @@ from test_catalog import cluster_resp
 
 
 class RunnerFunc(Protocol):
-    def __call__(self, args: List[str]) -> Result:
+    def __call__(self, args: list[str]) -> Result:
         ...
 
 
@@ -44,7 +46,7 @@ def cli_runner() -> RunnerFunc:
 @mock.patch.object(cli, "fetch_token")
 def test_commodore_fetch_token(
     fetch_token,
-    args: List[str],
+    args: list[str],
     exitcode: int,
     output: str,
     cli_runner: RunnerFunc,
@@ -119,9 +121,9 @@ def test_commodore_fetch_token(
 )
 def test_inventory_lint_cli(
     tmp_path: Path,
-    files: Dict[str, Dict[str, Any]],
+    files: dict[str, dict[str, Any]],
     exitcode: int,
-    stdout: List[str],
+    stdout: list[str],
     cli_runner: RunnerFunc,
 ):
     for f, data in files.items():
@@ -148,8 +150,8 @@ def test_inventory_lint_cli(
 def test_component_versions_cli(
     cli_runner: RunnerFunc,
     tmp_path: Path,
-    parameters: Dict[str, Any],
-    args: List[str],
+    parameters: dict[str, Any],
+    args: list[str],
 ):
     global_config = tmp_path / "global"
     global_config.mkdir()
@@ -213,7 +215,7 @@ def verify_config(expected: Config):
     return mock
 
 
-def make_config(tmp_path: Path, expected: Dict[str, Any]):
+def make_config(tmp_path: Path, expected: dict[str, Any]):
     config = Config(tmp_path)
     config.push = expected.get("push", False)
     config.local = expected.get("local", False)
@@ -277,8 +279,8 @@ def test_catalog_compile_cli(
     mock_compile,
     mock_login,
     cli_runner: RunnerFunc,
-    args: List[str],
-    expected: Dict[str, Any],
+    args: list[str],
+    expected: dict[str, Any],
     exitcode: int,
     tmp_path: Path,
 ):

--- a/tests/test_commodore_libjsonnet.py
+++ b/tests/test_commodore_libjsonnet.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 import functools
 import json
 import os
 
 from pathlib import Path
-from typing import Dict, Any, List
+from typing import Any
 
 from commodore.postprocess.jsonnet import _import_cb, _native_callbacks
 
@@ -16,7 +18,7 @@ import yaml
 TESTS_DIR = Path(__file__).parent / "jsonnet"
 
 
-def discover_tc() -> List[str]:
+def discover_tc() -> list[str]:
     files = {
         f.stem
         for f in TESTS_DIR.iterdir()
@@ -94,7 +96,7 @@ def render_jsonnet(tmp_path: Path, inputf: Path, invf: Path, **kwargs):
         with open(invf) as invfh:
             inv = yaml.safe_load(invfh)
 
-    def _inventory() -> Dict[str, Any]:
+    def _inventory() -> dict[str, Any]:
         return inv
 
     _native_cb = _native_callbacks

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
+
 import click
 import pytest
 
 from pathlib import Path as P
-from typing import Dict
 from unittest.mock import patch
 
 from commodore import compile
@@ -150,7 +151,7 @@ def test_fetch_customer_config(tmp_path: P, config, revision, override_revision)
         ),
     ],
 )
-def test_check_parameters_component_versions(cluster_params: Dict, raises: bool):
+def test_check_parameters_component_versions(cluster_params: dict, raises: bool):
     if raises:
         with pytest.raises(click.ClickException) as e:
             compile.check_parameters_component_versions(cluster_params)

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 import json
 import pytest
 import yaml
 
+from collections.abc import Iterable
 from pathlib import Path as P
-from typing import Iterable
 from git import Repo
 from textwrap import dedent
 

--- a/tests/test_dependency_mgmt.py
+++ b/tests/test_dependency_mgmt.py
@@ -1,15 +1,18 @@
 """
 Unit-tests for dependency management
 """
+from __future__ import annotations
+
 
 import os
 import click
 import git
 import pytest
 import json
+from collections.abc import Iterable
 from unittest.mock import patch
 from pathlib import Path
-from typing import Dict, Iterable, Optional
+from typing import Optional
 
 from commodore import dependency_mgmt
 from commodore.config import Config
@@ -138,7 +141,7 @@ def test_create_component_library_aliases_single_component(
     capsys,
     tmp_path: Path,
     data: Config,
-    libaliases: Optional[Dict],
+    libaliases: Optional[dict],
     expected_paths: Iterable[str],
     stdout: str,
 ):
@@ -219,9 +222,9 @@ def test_create_component_library_aliases_single_component(
 def test_create_component_library_aliases_multiple_component(
     tmp_path: Path,
     data: Config,
-    tc1_libalias: Dict[str, str],
-    tc2_libalias: Dict[str, str],
-    tc3_libalias: Dict[str, str],
+    tc1_libalias: dict[str, str],
+    tc2_libalias: dict[str, str],
+    tc3_libalias: dict[str, str],
     err: Optional[str],
 ):
     c1 = setup_mock_component(tmp_path, name="tc1")
@@ -801,7 +804,7 @@ def test_validate_component_library_name(tmp_path: Path, libname: str, expected:
         ),
     ],
 )
-def test_verify_component_version_overrides(cluster_params: Dict, expected: str):
+def test_verify_component_version_overrides(cluster_params: dict, expected: str):
     if expected == "":
         dependency_mgmt.verify_component_version_overrides(cluster_params)
     else:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,9 +1,12 @@
 """
 Unit-tests for helpers
 """
+from __future__ import annotations
+
 import os
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable, Optional
+from typing import Optional
 import textwrap
 
 import click

--- a/tests/test_inventory_lint_components.py
+++ b/tests/test_inventory_lint_components.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import os
 
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 
 import pytest
 
@@ -101,7 +103,7 @@ def _check_lint_result(ec: int, expected_errcount: int, captured):
 
 @pytest.mark.parametrize("filecontents,expected_errcount", LINT_FILECONTENTS)
 def test_lint_component_versions(
-    tmp_path, capsys, filecontents: Dict, expected_errcount: int
+    tmp_path, capsys, filecontents: dict, expected_errcount: int
 ):
     p = tmp_path / "test.yml"
 
@@ -113,7 +115,7 @@ def test_lint_component_versions(
 
 @pytest.mark.parametrize("filecontents,expected_errcount", LINT_FILECONTENTS)
 def test_lint_valid_file(
-    tmp_path: Path, capsys, config: Config, filecontents: Dict, expected_errcount: int
+    tmp_path: Path, capsys, config: Config, filecontents: dict, expected_errcount: int
 ):
     testf = tmp_path / "test.yml"
     yaml_dump(filecontents, testf)
@@ -126,7 +128,7 @@ def test_lint_valid_file(
 
 @pytest.mark.parametrize("filecontents,expected_errcount", LINT_FILECONTENTS)
 def test_lint_valid_file_stream(
-    tmp_path: Path, capsys, config: Config, filecontents: Dict, expected_errcount: int
+    tmp_path: Path, capsys, config: Config, filecontents: dict, expected_errcount: int
 ):
     testf = tmp_path / "test.yml"
     yaml_dump_all([filecontents], testf)

--- a/tests/test_inventory_lint_deprecated_parameters.py
+++ b/tests/test_inventory_lint_deprecated_parameters.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 
 import pytest
 import yaml
@@ -76,7 +78,7 @@ def config(tmp_path: Path):
         ),
     ],
 )
-def test_lint_deprecated_parameters(capsys, data: Dict[str, Any], expected: str):
+def test_lint_deprecated_parameters(capsys, data: dict[str, Any], expected: str):
     file = Path("test.yaml")
 
     ec = lint_deprecated_parameters.lint_deprecated_parameters(file, data)

--- a/tests/test_inventory_parameters.py
+++ b/tests/test_inventory_parameters.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import os
 import pytest
 import random
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Optional
 
 from commodore.inventory import parameters
 from commodore.helpers import yaml_dump
@@ -203,7 +205,7 @@ def extract_cloud_region_params(cloud: str, region: str):
     return cparams, rparams
 
 
-def _extract_component(params: Dict, cn: str):
+def _extract_component(params: dict, cn: str):
     return params.get("components", {}).get(cn, {})
 
 
@@ -260,7 +262,7 @@ def get_component(
 
 
 def verify_components(
-    components: Dict[str, Dict[str, str]],
+    components: dict[str, dict[str, str]],
     distribution: str,
     cloud: str,
     region: str,


### PR DESCRIPTION
PEP-585 was introduced for Python 3.9. We use `from __future__ import annotations` for Python 3.8 compatibility.

See https://peps.python.org/pep-0585/ for details

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
