### PR TITLE
Fix Commodore OIDC login when running in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,4 +71,7 @@ RUN chgrp 0 /app/ \
 
 USER 1001
 
+# OIDC token callback
+EXPOSE 18000
+
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh", "commodore"]

--- a/commodore/login.py
+++ b/commodore/login.py
@@ -45,7 +45,7 @@ class OIDCCallbackServer:
             OIDCCallbackHandler, client, token_url, lieutenant_url, self.done_queue
         )
 
-        self.server = HTTPServer(("localhost", 18000), handler)
+        self.server = HTTPServer(("", 18000), handler)
         self.thread = threading.Thread(target=self.server.serve_forever)
         self.thread.daemon = True
 

--- a/docs/modules/ROOT/pages/explanation/running-commodore.adoc
+++ b/docs/modules/ROOT/pages/explanation/running-commodore.adoc
@@ -115,10 +115,12 @@ commodore() {
     --env COMMODORE_API_URL=$COMMODORE_API_URL \
     --env COMMODORE_API_TOKEN=$COMMODORE_API_TOKEN \
     --env SSH_AUTH_SOCK=/tmp/ssh_agent.sock \
+    --publish 18000:18000 \
     --volume "${SSH_AUTH_SOCK}:/tmp/ssh_agent.sock" \
     --volume "${HOME}/.ssh/config:/app/.ssh/config:ro" \
     --volume "${HOME}/.ssh/known_hosts:/app/.ssh/known_hosts:ro" \
     --volume "${HOME}/.gitconfig:/app/.gitconfig:ro" \
+    --volume "${HOME}/.cache:/app/.cache" \
     --volume "${PWD}:/app/data" \
     --workdir /app/data \
     projectsyn/commodore:${COMMODORE_VERSION:=latest} \
@@ -156,10 +158,12 @@ commodore() {
     --env COMMODORE_API_URL=$COMMODORE_API_URL \
     --env COMMODORE_API_TOKEN=$COMMODORE_API_TOKEN \
     --env SSH_AUTH_SOCK=/tmp/ssh_agent.sock \
+    --publish 18000:18000 \
     --volume "/run/host-services/ssh-auth.sock:/tmp/ssh_agent.sock" \
     --volume "${HOME}/.ssh/config:/app/.ssh/config:ro" \
     --volume "${HOME}/.ssh/known_hosts:/app/.ssh/known_hosts:ro" \
     --volume "${HOME}/.gitconfig:/app/.gitconfig:ro" \
+    --volume "${HOME}/.cache:/app/.cache" \
     --volume "${PWD}:/app/data" \
     --workdir /app/data \
     projectsyn/commodore:latest \
@@ -181,8 +185,10 @@ commodore() {
     --user="$(id -u)" \
     --env COMMODORE_API_URL=$COMMODORE_API_URL \
     --env COMMODORE_API_TOKEN=$COMMODORE_API_TOKEN \
+    --publish 18000:18000 \
     --volume "${HOME}/.ssh:/app/.ssh:ro" \
     --volume "${HOME}/.gitconfig:/app/.gitconfig:ro" \
+    --volume "${HOME}/.cache:/app/.cache" \
     --volume "${PWD}:/app/data" \
     --workdir /app/data \
     projectsyn/commodore:latest \


### PR DESCRIPTION
This PR makes the changes which are necessary to allow users which run Commodore in Docker to use Commodore's OIDC login feature. The documentation is also updated with the newly required command line arguments for Docker.

Fixes #491 

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
