### PR TITLE
Use `url_normalize()` when auto-discovering OIDC config

### DIFF
--- a/commodore/login.py
+++ b/commodore/login.py
@@ -9,6 +9,7 @@ from typing import Optional, Any
 
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from urllib.parse import urlparse, parse_qs
+from url_normalize import url_normalize
 
 import click
 import requests
@@ -209,7 +210,7 @@ def login(config: Config):
     ):
         api_cfg: Any = {}
         try:
-            r = requests.get(config.api_url)
+            r = requests.get(url_normalize(config.api_url))
             api_cfg = json.loads(r.text)
         except (RequestException, json.JSONDecodeError) as e:
             # We do this on a best effort basis

--- a/commodore/login.py
+++ b/commodore/login.py
@@ -211,9 +211,9 @@ def login(config: Config):
         try:
             r = requests.get(config.api_url)
             api_cfg = json.loads(r.text)
-        except (RequestException, json.JSONDecodeError):
+        except (RequestException, json.JSONDecodeError) as e:
             # We do this on a best effort basis
-            pass
+            click.echo(f" > Unable to auto-discover OIDC config: {e}")
         if "oidc" in api_cfg:
             config.oidc_client = api_cfg["oidc"]["clientId"]
             config.oidc_discovery_url = api_cfg["oidc"]["discoveryUrl"]


### PR DESCRIPTION
Without `url_normalize()`, auto-discovery doesn't work for users which set `COMMODORE_API_URL` to a hostname without a scheme because the `requests` library raises an Exception for URLs without a scheme.

Additionally, the PR adds an informational message containing the exception summary when OIDC auto-discovery fails with an Exception in the `requests.get()` call.


## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
