### PR TITLE
Skip hidden files when enumerating component library files

### DIFF
--- a/commodore/component/__init__.py
+++ b/commodore/component/__init__.py
@@ -78,7 +78,10 @@ class Component:
     def lib_files(self) -> Iterable[P]:
         lib_dir = self.target_directory / "lib"
         if lib_dir.exists():
-            return lib_dir.iterdir()
+            for e in lib_dir.iterdir():
+                # Skip hidden files in lib directory
+                if not e.name.startswith("."):
+                    yield e
 
         return []
 

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -329,13 +329,16 @@ def _setup_libfiles(c: Component, libfiles: Iterable[str]):
         [],
         ["foo.libsonnet"],
         ["foo.libsonnet", "bar.libsonnet"],
+        [".test.libsonnet", "test.libsonnet"],
     ],
 )
 def test_component_lib_files(tmp_path: P, libfiles: Iterable[str]):
     c = _setup_component(tmp_path, name="tc1")
     _setup_libfiles(c, libfiles)
 
-    assert sorted(c.lib_files) == sorted(tmp_path / "tc1" / "lib" / f for f in libfiles)
+    assert sorted(c.lib_files) == sorted(
+        tmp_path / "tc1" / "lib" / f for f in libfiles if not f.startswith(".")
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This fixes compile errors regarding invalid library names when trying to compile a component or catalog while an editor swap file (e.g. vim swap file) is present in a component library directory.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
