### PR TITLE
Add flags `--local` and `--no-fetch-dependencies` for `package compile`

### DIFF
--- a/commodore/cli.py
+++ b/commodore/cli.py
@@ -416,16 +416,36 @@ def package(config: Config, verbose: int):
     type=click.Path(exists=True, file_okay=True, dir_okay=False),
     help="Specify inventory class in a YAML file (can specify multiple).",
 )
+@click.option(
+    "--local",
+    is_flag=True,
+    default=False,
+    help=(
+        "Run in local mode, local mode reuses the contents of the working directory. "
+        + "Local mode won't fetch missing components."
+    ),
+)
+@click.option(
+    " / -F",
+    "--fetch-dependencies/--no-fetch-dependencies",
+    default=True,
+    help="Whether to fetch Jsonnet and Kapitan dependencies in local mode. By default dependencies are fetched.",
+)
 @verbosity
 @pass_config
+# pylint: disable=too-many-arguments
 def package_compile(
     config: Config,
     verbose: int,
     path: str,
     root_class: str,
     values: Iterable[str],
+    local: bool,
+    fetch_dependencies: bool,
 ):
     config.update_verbosity(verbose)
+    config.local = local
+    config.fetch_dependencies = fetch_dependencies
     compile_package(config, path, root_class, values)
 
 

--- a/commodore/cli.py
+++ b/commodore/cli.py
@@ -216,13 +216,6 @@ def compile_catalog(
             "Cannot push changes when local global or tenant repo override is specified"
         )
 
-    if not local:
-        if not fetch_dependencies:
-            click.echo(
-                "--no-fetch-dependencies doesn't take effect unless --local is specified"
-            )
-        # Ensure we always fetch dependencies in regular mode
-        fetch_dependencies = True
     config.fetch_dependencies = fetch_dependencies
 
     if config.api_token is None and not local:

--- a/commodore/config.py
+++ b/commodore/config.py
@@ -57,7 +57,7 @@ class Config:
         self._verbose = verbose
         self.username = username
         self.usermail = usermail
-        self.local = None
+        self.local = False
         self.push = None
         self.interactive = None
         self.force = False

--- a/commodore/config.py
+++ b/commodore/config.py
@@ -61,7 +61,7 @@ class Config:
         self.push = None
         self.interactive = None
         self.force = False
-        self.fetch_dependencies = True
+        self._fetch_dependencies = True
         self._inventory = Inventory(work_dir=self.work_dir)
         self._deprecation_notices = []
         self._global_repo_revision_override = None
@@ -108,6 +108,22 @@ class Config:
     @property
     def refs_dir(self) -> P:
         return self.catalog_dir / "refs"
+
+    @property
+    def fetch_dependencies(self) -> bool:
+        return self._fetch_dependencies
+
+    @fetch_dependencies.setter
+    def fetch_dependencies(self, value: bool):
+        if not self.local:
+            if not value:
+                click.secho(
+                    "[WARN] --no-fetch-dependencies doesn't take effect "
+                    + "unless --local is specified",
+                    fg="yellow",
+                )
+            value = True
+        self._fetch_dependencies = value
 
     @property
     def api_token(self):

--- a/docs/modules/ROOT/pages/reference/cli.adoc
+++ b/docs/modules/ROOT/pages/reference/cli.adoc
@@ -209,3 +209,34 @@ This command doesn't have any command line options.
 +
 These classes are included before the package class which is getting compiled.
 This allows users to customize cluster facts or similar when compiling packages standalone.
+
+*--local*::
+  Run in local mode.
+  Intended to be used to test/verify local changes (for example during component development) of a package.
++
+Local mode doesn't try to fetch components included by the package.
+In local mode, uncommitted modifications to the inventory and dependencies are never discarded.
++
+However, local mode expects that the working directory contains:
++
+* a valid inventory in `inventory/`
+* all the dependencies required by the package available locally
+* component classes symlinked to `inventory/`
+* components and Jsonnet dependencies symlinked to `vendor/`
+
++
+The quickest way to get a working directory setup for local mode is to run a "regular" `package compile` for the package you want to work on.
++
+Overall, this flag has the same semantics as `--local` of `catalog compile`.
+
+*--fetch-dependencies/--no-fetch-dependencies*::
+  Whether to fetch Jsonnet and Kapitan dependencies in local mode.
++
+This flag doesn't have an effect in regular mode, but speeds up local mode by not fetching Jsonnet dependencies, and disabling Kapitan's dependency fetching.
+By default, Jsonnet and Kapitan dependencies are fetched in local mode, to make local testing of component and configuration changes easier.
+Additionally, having Jsonnet and Kapitan dependency fetching enabled in local mode is required to test some types of changes such as upgrading versions.
++
+When you want to test adding a new component in local mode, you *must* run local mode with dependency fetching enabled at least once.
+After that, all the symlinks and dependencies which are required to compile the component will be present and you can disable dependency fetching.
++
+Overall, this flag has the same semantics as `--fetch-dependencies` of `catalog compile`.

--- a/tests/test_package_compile.py
+++ b/tests/test_package_compile.py
@@ -78,6 +78,7 @@ def _setup_package(root: Path, package_ns: Optional[str]) -> Path:
 
 @pytest.mark.parametrize("pp_filter", [True, False])
 @pytest.mark.parametrize("package_ns", [None, "myns"])
+@pytest.mark.parametrize("local", [False, True])
 @mock.patch.object(compile, "fetch_components")
 def test_compile_package(
     mock_fetch: mock.MagicMock,
@@ -85,8 +86,11 @@ def test_compile_package(
     config: Config,
     pp_filter: bool,
     package_ns: Optional[str],
+    local: bool,
 ):
     mock_fetch.side_effect = _mock_fetch_components
+
+    config.local = local
 
     pkg_path = _setup_package(tmp_path, package_ns)
     _prepare_component(tmp_path)


### PR DESCRIPTION
Add command line flags `--local` and `--no-fetch-dependencies` with the same semantics as for `catalog compile`.

Follow-up for #505 
Resolves #499

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
