### PR TITLE
Remove redundant parameter `fetch_dependencies` of `kapitan_compile`

### DIFF
--- a/commodore/compile.py
+++ b/commodore/compile.py
@@ -224,12 +224,7 @@ def compile(config, cluster_id):
 
     clean_catalog(catalog_repo)
 
-    kapitan_compile(
-        config,
-        targets,
-        search_paths=[config.vendor_dir],
-        fetch_dependencies=config.fetch_dependencies,
-    )
+    kapitan_compile(config, targets, search_paths=[config.vendor_dir])
 
     postprocess_components(config, inventory, config.get_components())
 

--- a/commodore/helpers.py
+++ b/commodore/helpers.py
@@ -149,7 +149,6 @@ def kapitan_compile(
     output_dir: P = None,
     search_paths=None,
     fake_refs=False,
-    fetch_dependencies=True,
     reveal=False,
 ):
     if not output_dir:
@@ -183,7 +182,7 @@ def kapitan_compile(
         reveal=reveal,
         cache=False,
         cache_paths=None,
-        fetch_dependencies=fetch_dependencies,
+        fetch_dependencies=config.fetch_dependencies,
         force_fetch=True,
         validate=False,
         schemas_path=config.work_dir / "schemas",

--- a/commodore/package/compile.py
+++ b/commodore/package/compile.py
@@ -63,12 +63,7 @@ def compile_package(
 
     inventory, targets = setup_compile_environment(cfg)
 
-    kapitan_compile(
-        cfg,
-        targets,
-        search_paths=[cfg.vendor_dir],
-        fetch_dependencies=cfg.fetch_dependencies,
-    )
+    kapitan_compile(cfg, targets, search_paths=[cfg.vendor_dir])
     postprocess_components(cfg, inventory, cfg.get_components())
 
 


### PR DESCRIPTION
This parameter is clearly redundant, since we only ever set it to `config.fetch_dependencies`, while simultaneously passing the config object to the function.

Follow-up from #506 

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
