### PR TITLE
Add support for adding additional test cases in new config packages

### DIFF
--- a/commodore/cli.py
+++ b/commodore/cli.py
@@ -450,6 +450,16 @@ def package(config: Config, verbose: int):
     type=click.Path(file_okay=False, dir_okay=True),
     help="The directory in which to place the new package.",
 )
+@click.option(
+    "--additional-test-case",
+    "-t",
+    metavar="CASE",
+    default=[],
+    show_default=True,
+    multiple=True,
+    help="Additional test cases to generate in the new package. Can be repeated. "
+    + "Test case `defaults` will always be generated.",
+)
 @verbosity
 @pass_config
 # pylint: disable=too-many-arguments
@@ -464,6 +474,7 @@ def package_new(
     template_url: str,
     template_version: str,
     output_dir: str,
+    additional_test_case: Iterable[str],
 ):
     """Create new config package repo from template.
 
@@ -478,6 +489,7 @@ def package_new(
     t.golden_tests = golden_tests
     t.template_url = template_url
     t.template_version = template_version
+    t.test_cases = ["defaults"] + list(additional_test_case)
     t.create()
 
 

--- a/commodore/package/template.py
+++ b/commodore/package/template.py
@@ -16,6 +16,7 @@ from commodore.dependency_templater import Templater, Renderer
 class PackageTemplater(Templater):
     template_url: str
     template_version: str
+    test_cases: list[str] = ["defaults"]
 
     def _cruft_renderer(
         self,
@@ -53,6 +54,9 @@ class PackageTemplater(Templater):
             "github_owner": self.github_owner,
             "name": self.name,
             "slug": self.slug,
+            # The template expects the test cases in a single string separated by
+            # spaces.
+            "test_cases": " ".join(self.test_cases),
         }
 
     @property

--- a/docs/modules/ROOT/pages/reference/cli.adoc
+++ b/docs/modules/ROOT/pages/reference/cli.adoc
@@ -230,6 +230,11 @@ This command doesn't have any command line options.
   The directory in which to place the new package.
   If this option isn't provided, the command will place the new package under `inventory/classes/` in the Commodore working directory.
 
+*--additional-test-case, -t* CASE::
+  Additional test cases to generate in the new package.
+  Can be repeated.
+  Test case `defaults` will always be generated.
+
 == Package Compile
 
 *-f, --values* FILE::

--- a/tests/test_package_template.py
+++ b/tests/test_package_template.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
 from pathlib import Path
 from subprocess import call
 
 import click
 import pytest
+import yaml
 
 from commodore.config import Config
 from commodore.package.template import PackageTemplater
@@ -14,20 +16,34 @@ def call_package_new(
     golden="--no-golden-tests",
     output_dir: str = "",
     template_version: str = "",
+    additional_test_cases: list[str] = [],
 ):
+    atc_args = " ".join(f"-t {case}" for case in additional_test_cases)
     exit_status = call(
         f"commodore -d {tmp_path} -vvv package new {package_name}"
-        + f" {golden} {output_dir} {template_version}",
+        + f" {golden} {output_dir} {template_version} {atc_args}",
         shell=True,
     )
     assert exit_status == 0
 
 
 @pytest.mark.parametrize("output_dir", ["", "--output-dir={0}"])
-def test_run_package_new_command(tmp_path: Path, output_dir: str):
+@pytest.mark.parametrize(
+    "additional_test_cases",
+    [
+        [],
+        ["foo"],
+        ["foo", "bar"],
+    ],
+)
+def test_run_package_new_command(
+    tmp_path: Path, output_dir: str, additional_test_cases: list[str]
+):
     output_dir = output_dir.format(tmp_path)
 
-    call_package_new(tmp_path, output_dir=output_dir)
+    call_package_new(
+        tmp_path, output_dir=output_dir, additional_test_cases=additional_test_cases
+    )
 
     pkg_dir = tmp_path / "test-package"
     if output_dir == "":
@@ -50,12 +66,16 @@ def test_run_package_new_command(tmp_path: Path, output_dir: str):
         Path("docs", "modules", "ROOT", "pages", "index.adoc"),
         Path("renovate.json"),
         Path("tests", "defaults.yml"),
-    ]
+    ] + [Path("tests", f"{case}.yml") for case in additional_test_cases]
 
     assert pkg_dir.is_dir()
     for f in expected_files:
-
         assert (pkg_dir / f).is_file()
+
+    with open(pkg_dir / ".github" / "workflows" / "test.yaml") as gh_test:
+        workflows = yaml.safe_load(gh_test)
+        instances = workflows["jobs"]["test"]["strategy"]["matrix"]["instance"]
+        assert instances == list(["defaults"] + additional_test_cases)
 
 
 @pytest.mark.parametrize(
@@ -86,8 +106,16 @@ def test_package_new_invalid_slug(config: Config, slug: str, expected: str):
 
 
 @pytest.mark.parametrize("golden", ["--golden-tests", "--no-golden-tests"])
-def test_lint_package_template(tmp_path: Path, golden: str):
-    call_package_new(tmp_path, golden=golden, output_dir=f"--output-dir={tmp_path}")
+@pytest.mark.parametrize("additional_test_cases", [[], ["foo"]])
+def test_lint_package_template(
+    tmp_path: Path, golden: str, additional_test_cases: list[str]
+):
+    call_package_new(
+        tmp_path,
+        golden=golden,
+        output_dir=f"--output-dir={tmp_path}",
+        additional_test_cases=additional_test_cases,
+    )
     pkg_dir = tmp_path / "test-package"
     exit_status = call("make lint", shell=True, cwd=pkg_dir)
     assert exit_status == 0


### PR DESCRIPTION
Requires https://github.com/projectsyn/commodore-config-package-template/pull/3

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
