### PR TITLE
Change `package compile` target class to be provided as a path

### DIFF
--- a/commodore/cli.py
+++ b/commodore/cli.py
@@ -495,13 +495,15 @@ def package_new(
 
 @package.command(name="compile", short_help="Compile a config package standalone")
 @click.argument("path", type=click.Path(exists=True, file_okay=False, dir_okay=True))
-@click.argument("root_class")
+@click.argument(
+    "test_class", type=click.Path(exists=False, file_okay=True, dir_okay=False)
+)
 @click.option(
     "-f",
     "--values",
     multiple=True,
     type=click.Path(exists=True, file_okay=True, dir_okay=False),
-    help="Specify inventory class in a YAML file (can specify multiple).",
+    help="Specify additional inventory class in a YAML file (can specify multiple).",
 )
 @click.option(
     "--local",
@@ -516,7 +518,8 @@ def package_new(
     " / -F",
     "--fetch-dependencies/--no-fetch-dependencies",
     default=True,
-    help="Whether to fetch Jsonnet and Kapitan dependencies in local mode. By default dependencies are fetched.",
+    help="Whether to fetch Jsonnet and Kapitan dependencies in local mode. "
+    + "By default dependencies are fetched.",
 )
 @verbosity
 @pass_config
@@ -525,7 +528,7 @@ def package_compile(
     config: Config,
     verbose: int,
     path: str,
-    root_class: str,
+    test_class: str,
     values: Iterable[str],
     local: bool,
     fetch_dependencies: bool,
@@ -533,7 +536,7 @@ def package_compile(
     config.update_verbosity(verbose)
     config.local = local
     config.fetch_dependencies = fetch_dependencies
-    compile_package(config, path, root_class, values)
+    compile_package(config, path, test_class, values)
 
 
 @commodore.group(short_help="Interact with a Commodore inventory")

--- a/docs/modules/ROOT/pages/reference/cli.adoc
+++ b/docs/modules/ROOT/pages/reference/cli.adoc
@@ -238,11 +238,11 @@ This command doesn't have any command line options.
 == Package Compile
 
 *-f, --values* FILE::
-  Specify inventory class in a YAML file.
+  Specify an additional inventory class in a YAML file.
   This option can be repeated to provide multiple files.
   Files specified later win when resolving inventory values.
 +
-These classes are included before the package class which is getting compiled.
+These classes are included before the target class which is getting compiled.
 This allows users to customize cluster facts or similar when compiling packages standalone.
 
 *--local*::

--- a/docs/modules/ROOT/pages/reference/commands.adoc
+++ b/docs/modules/ROOT/pages/reference/commands.adoc
@@ -162,8 +162,8 @@ The template also provides many meta-files in the component repository, such as 
 
 == Package Compile
 
-  package compile PATH TARGET_CLASS
+  package compile PATH TEST_CLASS
 
 This command allows user to configure https://syn.tools/syn/SDDs/0028-reusable-config-packages.html[configuration packages] standalone.
 
-The command takes two command line arguments, the path to the package and the target class in the package to compile.
+The command takes two command line arguments, the path to the package and the test class in the package to compile.

--- a/tests/test_package_compile.py
+++ b/tests/test_package_compile.py
@@ -14,7 +14,6 @@ from commodore.dependency_mgmt import create_component_symlinks
 from commodore.helpers import yaml_dump, yaml_load
 
 from commodore.package import compile
-
 from test_component_compile import _prepare_component, _add_postprocessing_filter
 
 
@@ -72,6 +71,14 @@ def _setup_package(root: Path, package_ns: Optional[str]) -> Path:
         },
         target_cls,
     )
+    test_cls = pkg_path / "tests" / "defaults.yml"
+    test_cls.parent.mkdir(parents=True, exist_ok=True)
+    yaml_dump(
+        {
+            "classes": ["..target-class"],
+        },
+        pkg_path / "tests" / "defaults.yml",
+    )
 
     return pkg_path
 
@@ -97,7 +104,7 @@ def test_compile_package(
     if pp_filter:
         _add_postprocessing_filter(tmp_path)
 
-    compile.compile_package(config, pkg_path, "target-class", [])
+    compile.compile_package(config, pkg_path, "tests/defaults.yml", [])
 
     output = tmp_path / "compiled" / "test-component"
 
@@ -127,6 +134,6 @@ def test_compile_package_raises_exception(
     pkg_path = _setup_package(tmp_path, None)
 
     with pytest.raises(click.ClickException) as e:
-        compile.compile_package(config, pkg_path, "non-existent", [])
+        compile.compile_package(config, pkg_path, "non-existent.yml", [])
 
-    assert "Root class 'non-existent' doesn't exist" in str(e.value)
+    assert "Test class 'non-existent' doesn't exist" in str(e.value)


### PR DESCRIPTION
Some packages may require that some configuration is provided in an additional class file, for example cluster facts may be used to include additional classes by the package.

Generally, users should define test cases in `tests/` in the package directory and have each test case class include the desired target class of the package in the test class's `classes` array. Note that relative includes are always interpreted relative to the class containing the include. Reclass supports the prefix `..` to include a class from the parent directory.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
