### PR TITLE
Change `package compile` to always use a temporary directory

### DIFF
--- a/commodore/cli.py
+++ b/commodore/cli.py
@@ -521,6 +521,20 @@ def package_new(
     help="Whether to fetch Jsonnet and Kapitan dependencies in local mode. "
     + "By default dependencies are fetched.",
 )
+@click.option(
+    "-k / ",
+    "--keep-dir/--no-keep-dir",
+    default=False,
+    show_default=True,
+    help="Whether to keep the compilation temp directory after the compilation is done.",
+)
+@click.option(
+    "--tmp-dir",
+    default="",
+    metavar="PATH",
+    type=click.Path(exists=False, file_okay=False, dir_okay=True),
+    help="Temp directory to use for compilation. Implies `--keep-dir`",
+)
 @verbosity
 @pass_config
 # pylint: disable=too-many-arguments
@@ -532,11 +546,13 @@ def package_compile(
     values: Iterable[str],
     local: bool,
     fetch_dependencies: bool,
+    keep_dir: bool,
+    tmp_dir: str,
 ):
     config.update_verbosity(verbose)
     config.local = local
     config.fetch_dependencies = fetch_dependencies
-    compile_package(config, path, test_class, values)
+    compile_package(config, path, test_class, values, tmp_dir, keep_dir)
 
 
 @commodore.group(short_help="Interact with a Commodore inventory")

--- a/commodore/package/compile.py
+++ b/commodore/package/compile.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import shutil
+import tempfile
+
 from collections.abc import Iterable
 from pathlib import Path
 from textwrap import dedent
+from typing import Optional
 
 import click
 
@@ -16,12 +20,26 @@ from commodore.inventory import Inventory
 from commodore.postprocess import postprocess_components
 
 
+# pylint: disable=too-many-arguments disable=too-many-locals
 def compile_package(
     cfg: Config,
     pkg_path_: str,
     root_class: str,
     value_files_: Iterable[str],
+    tmp_dir: Optional[str] = "",
+    keep_dir: bool = False,
 ):
+    if tmp_dir:
+        temp_dir = Path(tmp_dir).resolve()
+        if cfg.debug:
+            click.echo(
+                " > Always setting `--keep-dir` when temp dir provided explicitly"
+            )
+        keep_dir = True
+    else:
+        temp_dir = Path(tempfile.mkdtemp(prefix="package-")).resolve()
+    cfg.work_dir = temp_dir
+
     # Clean working tree before compiling package, some of our symlinking logic expects
     # that `inventory/` is cleaned before symlinks are created.
     if not cfg.local:
@@ -64,6 +82,18 @@ def compile_package(
 
     kapitan_compile(cfg, targets, search_paths=[cfg.vendor_dir])
     postprocess_components(cfg, inventory, cfg.get_components())
+
+    shutil.copytree(
+        cfg.work_dir / "compiled", pkg_path / "compiled", dirs_exist_ok=True
+    )
+
+    if not keep_dir:
+        shutil.rmtree(temp_dir)
+    elif not tmp_dir:
+        click.echo(
+            f"Compilation working directory: {temp_dir}. Specify `--tmp-dir={temp_dir}`"
+            + ", if you want to use local mode for subsequent compilations."
+        )
 
 
 def _setup_inventory(

--- a/commodore/package/compile.py
+++ b/commodore/package/compile.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import shutil
-import tempfile
 
 from collections.abc import Iterable
 from pathlib import Path
+from tempfile import mkdtemp
 from textwrap import dedent
 from typing import Optional
 
@@ -30,14 +30,17 @@ def compile_package(
     keep_dir: bool = False,
 ):
     if tmp_dir:
-        temp_dir = Path(tmp_dir).resolve()
+        if not tmp_dir.startswith("/"):
+            temp_dir = Path(cfg.work_dir, tmp_dir).resolve()
+        else:
+            temp_dir = Path(tmp_dir).resolve()
         if cfg.debug:
             click.echo(
                 " > Always setting `--keep-dir` when temp dir provided explicitly"
             )
         keep_dir = True
     else:
-        temp_dir = Path(tempfile.mkdtemp(prefix="package-")).resolve()
+        temp_dir = Path(mkdtemp(prefix="package-")).resolve()
     cfg.work_dir = temp_dir
 
     # Clean working tree before compiling package, some of our symlinking logic expects

--- a/docs/modules/ROOT/pages/reference/cli.adoc
+++ b/docs/modules/ROOT/pages/reference/cli.adoc
@@ -275,3 +275,18 @@ When you want to test adding a new component in local mode, you *must* run local
 After that, all the symlinks and dependencies which are required to compile the component will be present and you can disable dependency fetching.
 +
 Overall, this flag has the same semantics as `--fetch-dependencies` of `catalog compile`.
+
+*--keep-dir / --no-keep-dir*::
+  Whether to keep the compilation temp directory after the compilation is done.
++
+This flag allows users to keep the package compilation temp directory created by Commodore for subsequent package compilations in local mode.
+If this flag isn't provided, Commodore will delete the temp directory after compilation is done.
+
+*--tmp-dir* PATH::
+  Temp directory to use for compilation.
+  Implies `--keep-dir`.
++
+When this flag is provided, Commodore will use the provided path as the directory for the compilation.
+It's the users responsibility to clean up the temp directory when this flag is provided.
++
+If the specified path doesn't exist, Commodore will create it as a directory.

--- a/docs/modules/ROOT/pages/reference/commands.adoc
+++ b/docs/modules/ROOT/pages/reference/commands.adoc
@@ -167,3 +167,8 @@ The template also provides many meta-files in the component repository, such as 
 This command allows user to configure https://syn.tools/syn/SDDs/0028-reusable-config-packages.html[configuration packages] standalone.
 
 The command takes two command line arguments, the path to the package and the test class in the package to compile.
+
+By default, the command creates a temp directory in `/tmp` which is used as the working directory for compiling the package.
+To keep an automatically created temp directory for subsequent compilations, users can specify `--keep-dir` to skip deleting the temp directory created by the command.
+Users can specify a custom temp directory location with flag `--tmp-dir`.
+If the path provided with `--tmp-dir` doesn't exist, Commodore will create it as a directory.

--- a/tests/test_package_compile.py
+++ b/tests/test_package_compile.py
@@ -87,27 +87,50 @@ def _setup_package(root: Path, package_ns: Optional[str]) -> Path:
 @pytest.mark.parametrize("pp_filter", [True, False])
 @pytest.mark.parametrize("package_ns", [None, "myns"])
 @pytest.mark.parametrize("local", [False, True])
+@pytest.mark.parametrize(
+    "keep_dir,tmp_dir", [(False, ""), (True, ""), (True, "build2")]
+)
 @mock.patch.object(compile, "fetch_components")
+@mock.patch.object(compile, "mkdtemp")
 def test_compile_package(
+    mock_mkdtemp: mock.MagicMock,
     mock_fetch: mock.MagicMock,
     tmp_path: Path,
     config: Config,
     pp_filter: bool,
     package_ns: Optional[str],
     local: bool,
+    keep_dir: bool,
+    tmp_dir: str,
 ):
     mock_fetch.side_effect = _mock_fetch_components
 
-    config.local = local
+    tmp_dir_arg = tmp_dir
+    if not tmp_dir:
+        tmp_dir = "build"
+        tmp_dir_arg = ""
 
+    compile_dir = tmp_path / tmp_dir
+
+    def _mock_mkdtemp(prefix="tmp-"):
+        compile_dir.mkdir(parents=True, exist_ok=True)
+        return compile_dir
+
+    mock_mkdtemp.side_effect = _mock_mkdtemp
+
+    config.local = local
     pkg_path = _setup_package(tmp_path, package_ns)
-    compile_dir = tmp_path / "build"
     _prepare_component(compile_dir)
     if pp_filter:
         _add_postprocessing_filter(compile_dir)
 
     compile.compile_package(
-        config, pkg_path, "tests/defaults.yml", [], tmp_dir=compile_dir
+        config,
+        pkg_path,
+        "tests/defaults.yml",
+        [],
+        keep_dir=keep_dir,
+        tmp_dir=tmp_dir_arg,
     )
 
     output = pkg_path / "compiled" / "test-component"

--- a/tests/test_package_compile.py
+++ b/tests/test_package_compile.py
@@ -43,6 +43,7 @@ def test_setup_package_inventory(tmp_path: Path, config: Config):
 
 
 def _mock_fetch_components(cfg: Config):
+    print(cfg.work_dir)
     c = Component("test-component", cfg.work_dir)
     create_component_symlinks(cfg, c)
     cfg.register_component(c)
@@ -100,13 +101,16 @@ def test_compile_package(
     config.local = local
 
     pkg_path = _setup_package(tmp_path, package_ns)
-    _prepare_component(tmp_path)
+    compile_dir = tmp_path / "build"
+    _prepare_component(compile_dir)
     if pp_filter:
-        _add_postprocessing_filter(tmp_path)
+        _add_postprocessing_filter(compile_dir)
 
-    compile.compile_package(config, pkg_path, "tests/defaults.yml", [])
+    compile.compile_package(
+        config, pkg_path, "tests/defaults.yml", [], tmp_dir=compile_dir
+    )
 
-    output = tmp_path / "compiled" / "test-component"
+    output = pkg_path / "compiled" / "test-component"
 
     assert output.is_dir()
     assert (output / "test-component").is_dir()


### PR DESCRIPTION
Otherwise, we can't reliably avoid situations where we create infinitely deep directory structures when symlinking the package to `inventory/classes`.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
