### PR TITLE
Explicitly specify `oauthlib` as a dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1394,7 +1394,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8, <3.11"
-content-hash = "dcfc22df3aef6d8d63a3c4e7b1eef0d5a1ad5c0841bcacd32bba63bcab3b39b0"
+content-hash = "4f02ee6c56c61a2531f8b51aa4d2223fe13056408e55e57ab6c68bd3ae12f72c"
 
 [metadata.files]
 addict = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,8 @@ python-dotenv = "^0.20.0"
 importlib-metadata = "^4.11.3"
 pyxdg = "^0.27"
 cruft = "^2.10.2"
+# Kapitan requires exactly 3.1.1
+oauthlib = "3.1.1"
 
 [tool.poetry.dev-dependencies]
 tox = "^3.25.0"

--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,7 @@
   },
   "ignoreDeps": [
     "gitpython",
+    "oauthlib",
     "requests"
   ],
   "labels": [


### PR DESCRIPTION
We use `oauthlib` in `commodore/login.py` but didn't explicitly specify the dependency until now.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
