### PR TITLE
Explicitly specify `pyjwt` as a dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1394,7 +1394,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8, <3.11"
-content-hash = "4f02ee6c56c61a2531f8b51aa4d2223fe13056408e55e57ab6c68bd3ae12f72c"
+content-hash = "4323265c3272b6287752309687265c23cfe2dc33f410ccbf8c797a89027c0b20"
 
 [metadata.files]
 addict = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,8 @@ pyxdg = "^0.27"
 cruft = "^2.10.2"
 # Kapitan requires exactly 3.1.1
 oauthlib = "3.1.1"
+# Kapitan requires exactly 2.1.0
+pyjwt = "2.1.0"
 
 [tool.poetry.dev-dependencies]
 tox = "^3.25.0"

--- a/renovate.json
+++ b/renovate.json
@@ -16,6 +16,7 @@
   "ignoreDeps": [
     "gitpython",
     "oauthlib",
+    "pyjwt",
     "requests"
   ],
   "labels": [


### PR DESCRIPTION
We use `pyjwt` (`import jwt`) in `commodore/config.py`, but didn't explicitly specify the dependency until now.

Follow-up to #515 

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
