### PR TITLE
Restrict cookiecutter version to <2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ include = [
 python = ">=3.8, <3.11"
 kapitan = "0.30.0"
 click = "8.1.3"
+# Cruft requires < 2.0
 cookiecutter = "1.7.3"
 # Kapitan requires exactly 3.1.24
 gitpython = "3.1.24"

--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,12 @@
     "pyjwt",
     "requests"
   ],
+  "packageRules": [
+    {
+      "matchPackageNames": ["cookiecutter"],
+      "allowedVersions": "<2.0"
+    }
+  ],
   "labels": [
     "dependency"
   ]


### PR DESCRIPTION
Cruft requires cookiecutter < 2.0, so we configure Renovate to not create PRs for cookiecutter 2.x.

Discovered in #520 
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
