### PR TITLE
Fix component template `.gitignore` entries

### DIFF
--- a/commodore/component-template/{{ cookiecutter.slug }}/.gitignore
+++ b/commodore/component-template/{{ cookiecutter.slug }}/.gitignore
@@ -1,14 +1,14 @@
 # Commodore
-.cache/
-helmcharts/
-manifests/
-vendor/
-jsonnetfile.lock.json
-crds/
-compiled/
+/.cache
+/helmcharts
+/manifests
+/vendor
+/jsonnetfile.lock.json
+/crds
+/compiled
 
 # Antora
-_archive/
-_public/
+/_archive
+/_public
 
 # Additional entries


### PR DESCRIPTION
We only want to ignore the directories created by Commodore in the component root. With the current component template `.gitignore`, we may accidentally ignore folders in the golden test output, or elsewhere.

Part of https://github.com/projectsyn/modulesync-control/issues/77
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
