### PR TITLE
Fix bug in catalog update logic for initial compilation of a cluster

### DIFF
--- a/commodore/catalog.py
+++ b/commodore/catalog.py
@@ -75,8 +75,9 @@ def clean_catalog(repo: GitRepo):
     if catalogdir.is_dir():
         rm_tree_contents(catalogdir)
     else:
-        click.echo(" > Converting old-style catalog")
-        rm_tree_contents(repo.working_tree_dir)
+        click.echo(
+            f" > Skipping cleaning, catalog directory {catalogdir} doesn't exist"
+        )
 
 
 def _push_catalog(cfg: Config, repo: GitRepo, commit_message: str):


### PR DESCRIPTION
We've previously had to carefully clean the catalog before updating the Kapitan secret refs (cf. #50), as we'd otherwise delete the regenerated ref files during the initial catalog compilation for a cluster.

This was caused by the logic implemented in https://github.com/projectsyn/commodore/commit/a75c903d461664b4567e44d5c649c81e52e4d160 which was there to convert catalogs from the original format where
manifests were directly stored in the root of the catalog repo to the current format where we have top-level directories `manifests` and `refs` in the catalog repo.

In #505, we've refactored the catalog compile logic to support config packages. While doing so, we've accidentally moved `catalog_clean()` after the logic which regenerates the ref files, thus breaking initial compilation of new clusters, as the ref files are deleted as Commodore until now (incorrectly) assumed that an empty catalog is an old-style catalog.

Since we haven't had to care about being able to convert old-style catalogs since before the v0.1.0 release of Commodore, we  simply remove the logic which is supposed to delete the top-level manifests of an old-style catalog, and instead just print a message that we're not deleting anything if `catalog/manifests` doesn't exist.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.-->
