### PR TITLE
Add `/dependencies` to component template `.gitignore`

### DIFF
--- a/commodore/component-template/{{ cookiecutter.slug }}/.gitignore
+++ b/commodore/component-template/{{ cookiecutter.slug }}/.gitignore
@@ -1,5 +1,6 @@
 # Commodore
 /.cache
+/dependencies
 /helmcharts
 /manifests
 /vendor


### PR DESCRIPTION
We need to add `/dependencies` to the component template gitignore file, as `commodore component compile` creates that directory when fetching component dependencies for all components which haven't been migrated to use `${_base_directory}` instead of hardcoding their location relative to the commodore working directory.

Relates to https://github.com/projectsyn/modulesync-control/pull/81

Follow-up to #528

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
