### PR TITLE
component-template: Add `lint_kubent` make targets to check for deprecated API versions

### DIFF
--- a/commodore/component-template/{{ cookiecutter.slug }}/Makefile
+++ b/commodore/component-template/{{ cookiecutter.slug }}/Makefile
@@ -15,7 +15,7 @@ help: ## Show this help
 all: lint
 
 .PHONY: lint
-lint: lint_jsonnet lint_yaml lint_adoc ## All-in-one linting
+lint: lint_jsonnet lint_yaml lint_adoc{%- if cookiecutter.add_golden == "y" %} lint_kubent{% endif %} ## All-in-one linting
 
 .PHONY: lint_jsonnet
 lint_jsonnet: $(JSONNET_FILES) ## Lint jsonnet files
@@ -28,6 +28,12 @@ lint_yaml: ## Lint yaml files
 .PHONY: lint_adoc
 lint_adoc: ## Lint documentation
 	$(VALE_CMD) $(VALE_ARGS)
+
+{%- if cookiecutter.add_golden == "y" %}
+.PHONY: lint_kubent
+lint_kubent: ## Lint deprecated Kubernetes API versions
+	$(KUBENT_DOCKER) $(KUBENT_ARGS) -f $(KUBENT_FILES)
+{%- endif %}
 
 .PHONY: format
 format: format_jsonnet ## All-in-one formatting
@@ -70,6 +76,10 @@ golden-diff-all: $(test_instances) ## Run golden-diff for all instances. Note: t
 .PHONY: gen-golden-all
 gen-golden-all: recursive_target=gen-golden
 gen-golden-all: $(test_instances) ## Run gen-golden for all instances. Note: this doesn't work when running make with multiple parallel jobs (-j != 1).
+
+.PHONY: lint_kubent_all
+lint_kubent_all: recursive_target=lint_kubent
+lint_kubent_all: $(test_instances) ## Lint deprecated Kubernetes API versions for all golden test instances. Will exit on first error. Note: this doesn't work when running make with multiple parallel jobs (-j != 1).
 
 .PHONY: $(test_instances)
 $(test_instances):

--- a/commodore/component-template/{{ cookiecutter.slug }}/Makefile
+++ b/commodore/component-template/{{ cookiecutter.slug }}/Makefile
@@ -31,7 +31,7 @@ lint_adoc: ## Lint documentation
 
 {%- if cookiecutter.add_golden == "y" %}
 .PHONY: lint_kubent
-lint_kubent: ## Lint deprecated Kubernetes API versions
+lint_kubent: ## Check for deprecated Kubernetes API versions
 	$(KUBENT_DOCKER) $(KUBENT_ARGS) -f $(KUBENT_FILES)
 {%- endif %}
 

--- a/commodore/component-template/{{ cookiecutter.slug }}/Makefile.vars.mk
+++ b/commodore/component-template/{{ cookiecutter.slug }}/Makefile.vars.mk
@@ -35,6 +35,16 @@ COMMODORE_CMD  ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) docker.io/projects
 COMPILE_CMD    ?= $(COMMODORE_CMD) component compile . $(commodore_args)
 JB_CMD         ?= $(DOCKER_CMD) $(DOCKER_ARGS) --entrypoint /usr/local/bin/jb docker.io/projectsyn/commodore:latest install
 
+{%- if cookiecutter.add_golden == "y" %}
+GOLDEN_FILES    ?= $(shell find tests/golden/$(instance) -type f)
+
+KUBENT_FILES    ?= $(shell echo "$(GOLDEN_FILES)" | sed 's/ /,/g')
+KUBENT_ARGS     ?= -c=false --helm2=false --helm3=false -e
+# Use our own kubent image until the upstream image is available
+KUBENT_IMAGE    ?= docker.io/projectsyn/kubent:latest
+KUBENT_DOCKER   ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) --entrypoint=/app/kubent $(KUBENT_IMAGE)
+{%- endif %}
+
 instance ?= defaults
 {%- if cookiecutter.add_matrix == "y" and cookiecutter.add_golden == "y" %}
 test_instances = tests/defaults.yml


### PR DESCRIPTION
The `lint_kubent` target runs `kubent` on a single golden test instance, defaulting to instance `defaults`. The commit also adds a target `lint_kubent_all` which will run `kubent` for all targets separately.

We don't run `kubent` over all golden tests simultaneously because the tool doesn't support linting multiple Kubernetes objects with the same name and namespace in a single run.

The commit ensures that the `kubent` lint targets are only added to components which are created with golden tests enabled.

See also https://github.com/projectsyn/modulesync-control/pull/82

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.- [ ] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
