### PR TITLE
Clone config packages to `dependencies/pkg.{package-name}`

### DIFF
--- a/commodore/package/__init__.py
+++ b/commodore/package/__init__.py
@@ -36,3 +36,7 @@ class Package:
 
     def checkout(self):
         self._gitrepo.checkout(self._version)
+
+
+def package_dependency_dir(work_dir: Path, pname: str) -> Path:
+    return work_dir / "dependencies" / f"pkg.{pname}"

--- a/commodore/package/compile.py
+++ b/commodore/package/compile.py
@@ -20,15 +20,9 @@ from commodore.inventory import Inventory
 from commodore.postprocess import postprocess_components
 
 
-# pylint: disable=too-many-arguments disable=too-many-locals
-def compile_package(
-    cfg: Config,
-    pkg_path_: str,
-    root_class: str,
-    value_files_: Iterable[str],
-    tmp_dir: Optional[str] = "",
-    keep_dir: bool = False,
-):
+def resolve_and_create_work_dir(
+    cfg: Config, tmp_dir: Optional[str], keep_dir: bool
+) -> tuple[Path, bool]:
     if tmp_dir:
         if not tmp_dir.startswith("/"):
             temp_dir = Path(cfg.work_dir, tmp_dir).resolve()
@@ -41,6 +35,20 @@ def compile_package(
         keep_dir = True
     else:
         temp_dir = Path(mkdtemp(prefix="package-")).resolve()
+
+    return temp_dir, keep_dir
+
+
+# pylint: disable=too-many-arguments disable=too-many-locals
+def compile_package(
+    cfg: Config,
+    pkg_path_: str,
+    root_class: str,
+    value_files_: Iterable[str],
+    tmp_dir: Optional[str] = "",
+    keep_dir: bool = False,
+):
+    temp_dir, keep_dir = resolve_and_create_work_dir(cfg, tmp_dir, keep_dir)
     cfg.work_dir = temp_dir
 
     # Clean working tree before compiling package, some of our symlinking logic expects

--- a/commodore/package/compile.py
+++ b/commodore/package/compile.py
@@ -55,6 +55,10 @@ def compile_package(
     # package name (possibly with a prefix `package-`). As long as a package only uses
     # relative includes internally, the package name shouldn't matter for compilation.
     pkg_name = pkg_path.stem.replace("package-", "")
+    # Handle package directory naming scheme for packages which are part of a cluster
+    # catalog separately.
+    if pkg_path.name.startswith("pkg."):
+        pkg_name = pkg_path.name.replace("pkg.", "")
 
     root_class_name = root_class.replace(".yml", "").replace("/", ".")
     # Convert root class file to class name

--- a/docs/modules/ROOT/pages/reference/concepts.adoc
+++ b/docs/modules/ROOT/pages/reference/concepts.adoc
@@ -35,7 +35,7 @@ These inventory classes are stored in Git repositories.
 Commodore calls these bundles of inventory classes _configuration packages_.
 
 Configuration packages can include components and provide arbitrary configuration parameters.
-Commodore clones the Git repositories containing configuration packages directly into `inventory/classes` to make the contents available as Kapitan inventory classes.
+Commodore clones the Git repositories containing configuration packages into `dependencies/pkg.<package-name>` and symlinks them to `inventory/classes/<package-name>` to make the contents available as Kapitan inventory classes.
 To ensure components included through packages are processed correctly, Commodore ensures that configuration packages are present before discovering components.
 
 See https://syn.tools/syn/SDDs/0028-reusable-config-packages.html[SDD 0028 - Reusable Commodore Component Configuration Packages] for more details on the design of configuration packages.

--- a/tests/test_dependency_mgmt.py
+++ b/tests/test_dependency_mgmt.py
@@ -17,6 +17,7 @@ from commodore import dependency_mgmt
 from commodore.config import Config
 from commodore.component import Component
 from commodore.inventory import Inventory
+from commodore.package import package_dependency_dir
 
 from test_package import _setup_package_remote
 
@@ -494,7 +495,7 @@ def test_register_packages(
     _setup_packages(tmp_path / "upstream", packages)
     for p in packages:
         git.Repo.clone_from(
-            f"file://{tmp_path}/upstream/{p}.git", config.inventory.package_dir(p)
+            f"file://{tmp_path}/upstream/{p}.git", package_dependency_dir(tmp_path, p)
         )
 
     dependency_mgmt.register_packages(config)
@@ -511,7 +512,7 @@ def test_register_packages_skip_nonexistent(
     discover_pkgs.return_value = packages
     _setup_packages(tmp_path / "upstream", packages)
     git.Repo.clone_from(
-        f"file://{tmp_path}/upstream/foo.git", config.inventory.package_dir("foo")
+        f"file://{tmp_path}/upstream/foo.git", package_dependency_dir(tmp_path, "foo")
     )
 
     dependency_mgmt.register_packages(config)


### PR DESCRIPTION
Instead of cloning packages directly into `inventory/classes` we now clone them to `dependencies/pkg.{package-name}` and symlink them into `inventory/classes`.

This is a first step towards supporting dependencies in repository subdirectories, and unifies the location for cloned component and package repositories in the Commodore working directory.

Part of #518 

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
