### PR TITLE
Add support for dependencies in repository subpaths

### DIFF
--- a/commodore/cli.py
+++ b/commodore/cli.py
@@ -386,6 +386,24 @@ def component_delete(config: Config, slug, force, verbose):
     type=click.Path(file_okay=False, dir_okay=True),
     help="Specify output path for compiled component.",
 )
+@click.option(
+    "-r",
+    "--repo-directory",
+    default="",
+    show_default=False,
+    type=click.Path(file_okay=False, dir_okay=True),
+    help="Path to the root of the Git repo containing the component. "
+    + "The command assumes that the component is in the repo root, "
+    + "if this option is not provided.",
+)
+@click.option(
+    "-n",
+    "--name",
+    default="",
+    show_default=False,
+    help="Component name to use for Commodore. "
+    + "If not provided, the name is inferred from the Git repository name.",
+)
 @verbosity
 @pass_config
 # pylint: disable=too-many-arguments
@@ -396,10 +414,14 @@ def component_compile(
     alias: Optional[str],
     search_paths: Iterable[str],
     output: str,
+    repo_directory: str,
+    name: str,
     verbose: int,
 ):
     config.update_verbosity(verbose)
-    compile_component(config, path, alias, values, search_paths, output)
+    compile_component(
+        config, path, alias, values, search_paths, output, repo_directory, name
+    )
 
 
 @commodore.group(short_help="Interact with a Commodore config package")

--- a/commodore/component/__init__.py
+++ b/commodore/component/__init__.py
@@ -15,6 +15,7 @@ class Component:
     _repo: GitRepo
     _version: Optional[str] = None
     _dir: P
+    _sub_path: str
 
     # pylint: disable=too-many-arguments
     def __init__(
@@ -25,6 +26,7 @@ class Component:
         version: str = None,
         force_init: bool = False,
         directory: P = None,
+        sub_path: str = "",
     ):
         self._name = name
         if directory:
@@ -37,6 +39,7 @@ class Component:
             )
         self._repo = GitRepo(repo_url, self._dir, force_init=force_init)
         self.version = version
+        self._sub_path = sub_path
 
     @property
     def name(self) -> str:
@@ -63,8 +66,12 @@ class Component:
         self._version = version
 
     @property
-    def target_directory(self) -> P:
+    def repo_directory(self) -> P:
         return self._dir
+
+    @property
+    def target_directory(self) -> P:
+        return self._dir / self._sub_path
 
     @property
     def class_file(self) -> P:

--- a/commodore/dependency_mgmt/__init__.py
+++ b/commodore/dependency_mgmt/__init__.py
@@ -63,13 +63,14 @@ def fetch_components(cfg: Config):
     component_names, component_aliases = _discover_components(cfg)
     click.secho("Registering component aliases...", bold=True)
     cfg.register_component_aliases(component_aliases)
-    urls, versions = _read_components(cfg, component_names)
+    cspecs = _read_components(cfg, component_names)
     click.secho("Fetching components...", bold=True)
     for cn in component_names:
+        cspec = cspecs[cn]
         if cfg.debug:
             click.echo(f" > Fetching component {cn}...")
         c = Component(
-            cn, work_dir=cfg.work_dir, repo_url=urls[cn], version=versions[cn]
+            cn, work_dir=cfg.work_dir, repo_url=cspec.url, version=cspec.version
         )
         c.checkout()
         cfg.register_component(c)
@@ -126,14 +127,15 @@ def fetch_packages(cfg: Config):
     click.secho("Discovering config packages...", bold=True)
     cfg.inventory.ensure_dirs()
     pkgs = _discover_packages(cfg)
-    urls, versions = _read_packages(cfg, pkgs)
+    pspecs = _read_packages(cfg, pkgs)
 
     for p in pkgs:
+        pspec = pspecs[p]
         pkg = Package(
             p,
             target_dir=package_dependency_dir(cfg.work_dir, p),
-            url=urls[p],
-            version=versions[p],
+            url=pspec.url,
+            version=pspec.version,
         )
         pkg.checkout()
         cfg.register_package(p, pkg)

--- a/commodore/dependency_mgmt/__init__.py
+++ b/commodore/dependency_mgmt/__init__.py
@@ -73,7 +73,11 @@ def fetch_components(cfg: Config):
         if cfg.debug:
             click.echo(f" > Fetching component {cn}...")
         c = Component(
-            cn, work_dir=cfg.work_dir, repo_url=cspec.url, version=cspec.version
+            cn,
+            work_dir=cfg.work_dir,
+            repo_url=cspec.url,
+            version=cspec.version,
+            sub_path=cspec.path,
         )
         c.checkout()
         cfg.register_component(c)
@@ -90,11 +94,13 @@ def register_components(cfg: Config):
     click.secho("Discovering included components...", bold=True)
     try:
         components, component_aliases = _discover_components(cfg)
+        cspecs = _read_components(cfg, components)
     except KeyError as e:
         raise click.ClickException(f"While discovering components: {e}")
     click.secho("Registering components and aliases...", bold=True)
 
     for cn in components:
+        cspec = cspecs[cn]
         if cfg.debug:
             click.echo(f" > Registering component {cn}...")
         if not component_dir(cfg.work_dir, cn).is_dir():
@@ -103,7 +109,7 @@ def register_components(cfg: Config):
                 fg="yellow",
             )
             continue
-        component = Component(cn, work_dir=cfg.work_dir)
+        component = Component(cn, work_dir=cfg.work_dir, sub_path=cspec.path)
         cfg.register_component(component)
         create_component_symlinks(cfg, component)
 

--- a/commodore/dependency_mgmt/jsonnet_bundler.py
+++ b/commodore/dependency_mgmt/jsonnet_bundler.py
@@ -24,7 +24,9 @@ def jsonnet_dependencies(config: Config) -> Iterable:
                 "source": {
                     "local": {
                         "directory": os.path.relpath(
-                            component.target_directory, start=config.work_dir
+                            # TODO: Update again when we have proper monorepo handling
+                            component.repo_directory,
+                            start=config.work_dir,
                         ),
                     }
                 }

--- a/commodore/dependency_mgmt/version_parsing.py
+++ b/commodore/dependency_mgmt/version_parsing.py
@@ -22,6 +22,7 @@ class DependencySpec:
 
     url: str
     version: str
+    path: str
 
 
 def _read_versions(
@@ -67,10 +68,11 @@ def _read_versions(
                 f"{deptype_cap} '{depname}' doesn't have a version specified."
             )
 
-        dep = DependencySpec(info["url"], info["version"])
+        dep = DependencySpec(info["url"], info["version"], info.get("path", ""))
         if cfg.debug:
             click.echo(f" > URL for {depname}: {dep.url}")
             click.echo(f" > Version for {depname}: {dep.version}")
+            click.echo(f" > Subpath for {depname}: {dep.path}")
 
         dependencies[depname] = dep
 

--- a/commodore/dependency_mgmt/version_parsing.py
+++ b/commodore/dependency_mgmt/version_parsing.py
@@ -68,7 +68,11 @@ def _read_versions(
                 f"{deptype_cap} '{depname}' doesn't have a version specified."
             )
 
-        dep = DependencySpec(info["url"], info["version"], info.get("path", ""))
+        path = info.get("path", "")
+        if path.startswith("/"):
+            path = path[1:]
+
+        dep = DependencySpec(info["url"], info["version"], path)
         if cfg.debug:
             click.echo(f" > URL for {depname}: {dep.url}")
             click.echo(f" > Version for {depname}: {dep.version}")

--- a/commodore/package/__init__.py
+++ b/commodore/package/__init__.py
@@ -11,16 +11,19 @@ class Package:
     version
     """
 
+    # pylint: disable=too-many-arguments
     def __init__(
         self,
         name: str,
         target_dir: Path,
         url: Optional[str] = None,
         version: Optional[str] = None,
+        sub_path: str = "",
     ):
         self._name = name
         self._version = version
         self._gitrepo = GitRepo(remote=url, targetdir=target_dir)
+        self._sub_path = sub_path
 
     @property
     def url(self) -> Optional[str]:
@@ -31,8 +34,19 @@ class Package:
         return self._version
 
     @property
-    def target_dir(self) -> Optional[Path]:
+    def sub_path(self) -> str:
+        return self._sub_path
+
+    @property
+    def repository_dir(self) -> Optional[Path]:
         return self._gitrepo.working_tree_dir
+
+    @property
+    def target_dir(self) -> Optional[Path]:
+        if not self._gitrepo.working_tree_dir:
+            return None
+
+        return self._gitrepo.working_tree_dir / self._sub_path
 
     def checkout(self):
         self._gitrepo.checkout(self._version)

--- a/docs/modules/ROOT/pages/reference/architecture.adoc
+++ b/docs/modules/ROOT/pages/reference/architecture.adoc
@@ -45,11 +45,17 @@ Analogously, all configuration packages which are referenced in the `application
 Using the xref:commodore:ROOT:reference/concepts.adoc#_configuration_hierarchy[configuration hierarchy] for specifying component and configuration package locations and versions allows tight integration of dependency management with the rest of the configuration.
 
 The keys `parameters.components` and `parameters.packages` each hold a dictionary of dictionaries mapping dependency names to their remote repository location and version.
+Commodore supports dependencies stored in sub-paths of repositories.
 The remote repository location is specified in key `url`.
 The version is specified in key `version`.
 The version can be any Git https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddeftree-ishatree-ishalsotreeish[tree-ish].
 Commodore will exit with an error if no version is given for a dependency.
+The path in the repository is specified in key `path`.
+If key `path` isn't provided, Commodore assumes that the dependency is stored in the repository root.
+
 For each included dependency, Commodore fetches the remote repository and directly checks out the specified version.
+Regardless of the value of key `path`, Commodore fetches the complete repository.
+However, Commodore will create a symlink to the indicated path, when making the dependency available in the hierarchy.
 
 Commodore will make all included packages available, before discovering and fetching components.
 This ensures that configuration packages can include additional components and can customize component versions.
@@ -70,11 +76,13 @@ parameters:
 
   packages:
     dummy:
-      url: https://github.com/projectsyn/package-dummy.git
+      url: https://github.com/projectsyn/dummy.git
       version: main <1>
+      path: package <2>
 ----
 <1> Versions can be any Git tree-ish.
 This example uses the repository's `main` branch as the version
+<2> Dependencies can be stored in sub-paths of the repository
 
 [NOTE]
 ====

--- a/docs/modules/ROOT/pages/reference/concepts.adoc
+++ b/docs/modules/ROOT/pages/reference/concepts.adoc
@@ -33,6 +33,7 @@ Commodore also makes use of the inventory to manage xref:commodore:ROOT:referenc
 Commodore provides support to fetch additional inventory classes based on configurations present in the global and tenant repositories
 These inventory classes are stored in Git repositories.
 Commodore calls these bundles of inventory classes _configuration packages_.
+Commodore allows configuration packages to be stored in an arbitrary directory in the repository.
 
 Configuration packages can include components and provide arbitrary configuration parameters.
 Commodore clones the Git repositories containing configuration packages into `dependencies/pkg.<package-name>` and symlinks them to `inventory/classes/<package-name>` to make the contents available as Kapitan inventory classes.
@@ -42,9 +43,9 @@ See https://syn.tools/syn/SDDs/0028-reusable-config-packages.html[SDD 0028 - Reu
 
 == Components
 
-Each Commodore component is managed in an individual Git repository and
-provides all the code which necessary to install some software or tool.
+Each Commodore component is managed in an individual Git repository and provides all the code which necessary to install some software or tool.
 The repository name must be named the same as the component.
+Commodore allows components to be stored in an arbitrary directory in the repository.
 
 Each component includes the
 https://kapitan.dev/compile/#supported-input-types[Kapitan templates] (for

--- a/tests/test_component_compile.py
+++ b/tests/test_component_compile.py
@@ -222,5 +222,7 @@ def test_run_component_compile_command_instance(tmp_path, capsys, instance_aware
 
 def test_no_component_compile_command(tmp_path):
     with pytest.raises(ClickException) as excinfo:
-        compile_component(Config(tmp_path), tmp_path / "foo", None, [], [], "./")
+        compile_component(
+            Config(tmp_path), tmp_path / "foo", None, [], [], "./", "", ""
+        )
     assert "Could not find component class file" in str(excinfo)

--- a/tests/test_dependency_mgmt.py
+++ b/tests/test_dependency_mgmt.py
@@ -215,10 +215,16 @@ def _setup_register_components(tmp_path: Path):
     return component_dirs, other_dirs
 
 
+@patch("commodore.dependency_mgmt._read_components")
 @patch("commodore.dependency_mgmt._discover_components")
-def test_register_components(patch_discover, config: Config, tmp_path: Path):
+def test_register_components(
+    patch_discover, patch_read, config: Config, tmp_path: Path
+):
     component_dirs, other_dirs = _setup_register_components(tmp_path)
     patch_discover.return_value = (component_dirs, {})
+    patch_read.return_value = {
+        cn: DependencySpec("", "master", "") for cn in component_dirs
+    }
 
     dependency_mgmt.register_components(config)
 
@@ -229,13 +235,17 @@ def test_register_components(patch_discover, config: Config, tmp_path: Path):
         assert c not in component_names
 
 
+@patch("commodore.dependency_mgmt._read_components")
 @patch("commodore.dependency_mgmt._discover_components")
 def test_register_components_and_aliases(
-    patch_discover, config: Config, tmp_path: Path
+    patch_discover, patch_read, config: Config, tmp_path: Path
 ):
     component_dirs, other_dirs = _setup_register_components(tmp_path)
     alias_data = {"fooer": "foo"}
     patch_discover.return_value = (component_dirs, alias_data)
+    patch_read.return_value = {
+        cn: DependencySpec("", "master", "") for cn in component_dirs
+    }
 
     dependency_mgmt.register_components(config)
 
@@ -254,14 +264,18 @@ def test_register_components_and_aliases(
             assert alias not in aliases
 
 
+@patch("commodore.dependency_mgmt._read_components")
 @patch("commodore.dependency_mgmt._discover_components")
 def test_register_unknown_components(
-    patch_discover, config: Config, tmp_path: Path, capsys
+    patch_discover, patch_read, config: Config, tmp_path: Path, capsys
 ):
     component_dirs, other_dirs = _setup_register_components(tmp_path)
     unknown_components = ["qux", "quux"]
     component_dirs.extend(unknown_components)
     patch_discover.return_value = (component_dirs, {})
+    patch_read.return_value = {
+        cn: DependencySpec("", "master", "") for cn in component_dirs
+    }
 
     dependency_mgmt.register_components(config)
 
@@ -270,9 +284,10 @@ def test_register_unknown_components(
         assert f"Skipping registration of component {cn}" in captured.out
 
 
+@patch("commodore.dependency_mgmt._read_components")
 @patch("commodore.dependency_mgmt._discover_components")
 def test_register_dangling_aliases(
-    patch_discover, config: Config, tmp_path: Path, capsys
+    patch_discover, patch_read, config: Config, tmp_path: Path, capsys
 ):
     component_dirs, other_dirs = _setup_register_components(tmp_path)
     # add some dangling aliases
@@ -283,6 +298,9 @@ def test_register_dangling_aliases(
     alias_data["bazzer"] = "baz"
 
     patch_discover.return_value = (component_dirs, alias_data)
+    patch_read.return_value = {
+        cn: DependencySpec("", "master", "") for cn in component_dirs
+    }
 
     dependency_mgmt.register_components(config)
 

--- a/tests/test_dependency_mgmt_version_parsing.py
+++ b/tests/test_dependency_mgmt_version_parsing.py
@@ -23,30 +23,23 @@ from commodore.dependency_mgmt import version_parsing
 @patch.object(version_parsing, "kapitan_inventory")
 def test_read_components(patch_inventory, config: Config):
     components = _setup_mock_inventory(patch_inventory)
-    component_urls, component_versions = version_parsing._read_components(
-        config, ["test-component"]
-    )
+    cspecs = version_parsing._read_components(config, ["test-component"])
 
     # check that exactly 'test-component' is discovered
-    assert {"test-component"} == set(component_urls.keys())
-    assert components["test-component"]["url"] == component_urls["test-component"]
-    assert (
-        components["test-component"]["version"] == component_versions["test-component"]
-    )
+    assert {"test-component"} == set(cspecs.keys())
+    assert components["test-component"]["url"] == cspecs["test-component"].url
+    assert components["test-component"]["version"] == cspecs["test-component"].version
 
 
 @patch.object(version_parsing, "kapitan_inventory")
 def test_read_components_multiple(patch_inventory, config: Config):
     components = _setup_mock_inventory(patch_inventory)
-    component_urls, component_versions = version_parsing._read_components(
-        config, components.keys()
-    )
+    cspecs = version_parsing._read_components(config, components.keys())
     # check that exactly 'test-component' is discovered
-    assert set(components.keys()) == set(component_urls.keys())
-    assert set(components.keys()) == set(component_versions.keys())
-    assert all(components[cn]["url"] == component_urls[cn] for cn in components.keys())
+    assert set(components.keys()) == set(cspecs.keys())
+    assert all(components[cn]["url"] == cspecs[cn].url for cn in components.keys())
     assert all(
-        components[cn].get("version", None) == component_versions[cn]
+        components[cn].get("version", None) == cspecs[cn].version
         for cn in components.keys()
     )
 
@@ -151,9 +144,14 @@ def test_read_packages(
         }
     }
 
-    pkg_urls, pkg_versions = version_parsing._read_packages(
+    pspecs = version_parsing._read_packages(
         config,
         pkg_names,
     )
+    pkg_urls = {}
+    pkg_versions = {}
+    for p, pspec in pspecs.items():
+        pkg_urls[p] = pspec.url
+        pkg_versions[p] = pspec.version
     assert pkg_urls == expected_urls
     assert pkg_versions == expected_versions


### PR DESCRIPTION
This PR adds support for storing dependencies (components and packages) in a subpath of a repository. This is a prerequisite for supporting repositories which contain multiple dependencies.

Currently, Commodore will clone a repository multiple times if multiple dependencies are stored in the same repository. We'll introduce repository deduplication in a follow-up PR (#549).

Part of #518 

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
