### PR TITLE
Refactor dependency repository handling to avoid multiple clones of the same repository

### DIFF
--- a/commodore/dependency_mgmt/__init__.py
+++ b/commodore/dependency_mgmt/__init__.py
@@ -73,10 +73,11 @@ def fetch_components(cfg: Config):
         cspec = cspecs[cn]
         if cfg.debug:
             click.echo(f" > Fetching component {cn}...")
+        cdep = cfg.register_dependency_repo(cspec.url)
         c = Component(
             cn,
             work_dir=cfg.work_dir,
-            repo_url=cspec.url,
+            dependency=cdep,
             version=cspec.version,
             sub_path=cspec.path,
         )
@@ -110,7 +111,14 @@ def register_components(cfg: Config):
                 fg="yellow",
             )
             continue
-        component = Component(cn, work_dir=cfg.work_dir, sub_path=cspec.path)
+        cdep = cfg.register_dependency_repo(cspec.url)
+        component = Component(
+            cn,
+            work_dir=cfg.work_dir,
+            dependency=cdep,
+            sub_path=cspec.path,
+            version=cspec.version,
+        )
         cfg.register_component(component)
         create_component_symlinks(cfg, component)
 
@@ -141,10 +149,11 @@ def fetch_packages(cfg: Config):
 
     for p in pkgs:
         pspec = pspecs[p]
+        pdep = cfg.register_dependency_repo(pspec.url)
         pkg = Package(
             p,
+            dependency=pdep,
             target_dir=package_dependency_dir(cfg.work_dir, p),
-            url=pspec.url,
             version=pspec.version,
             sub_path=pspec.path,
         )
@@ -174,7 +183,9 @@ def register_packages(cfg: Config):
                 fg="yellow",
             )
             continue
-        pkg = Package(p, target_dir=pkg_dir, sub_path=pspecs[p].path)
+        pspec = pspecs[p]
+        pdep = cfg.register_dependency_repo(pspec.url)
+        pkg = Package(p, dependency=pdep, target_dir=pkg_dir, sub_path=pspec.path)
         cfg.register_package(p, pkg)
         create_package_symlink(cfg, p, pkg)
 

--- a/commodore/gitrepo.py
+++ b/commodore/gitrepo.py
@@ -404,6 +404,12 @@ class GitRepo:
 
     def checkout(self, version: Optional[str] = None):
         remote_heads = self._repo.remote().fetch(prune=True, tags=True)
+        if not remote_heads:
+            # Somehow, we don't get the new fetch infos on the first fetch after
+            # changing the remote, so we retry once if we didn't get any fetch infos
+            # from the first call.
+            remote_heads = self._repo.remote().fetch(prune=True, tags=True)
+
         if version is None:
             # Handle case where we want the default branch of the remote
             version = self._default_version()

--- a/commodore/gitrepo.py
+++ b/commodore/gitrepo.py
@@ -60,6 +60,15 @@ def _normalize_git_ssh(url: str) -> str:
     return reconstruct_url(urlparts)
 
 
+def normalize_git_url(url: str) -> str:
+    """Normalize HTTP(s) and SSH Git URLs"""
+    if "@" in url and ("://" not in url or url.startswith("ssh://")):
+        url = _normalize_git_ssh(url)
+    elif url.startswith("http://") or url.startswith("https://"):
+        url = url_normalize(url)
+    return url
+
+
 def _colorize_diff(line: str) -> str:
     if line.startswith("--- ") or line.startswith("+++ ") or line.startswith("@@ "):
         return click.style(line, fg="yellow")
@@ -199,10 +208,7 @@ class GitRepo:
 
     @remote.setter
     def remote(self, remote: str):
-        if "@" in remote and ("://" not in remote or remote.startswith("ssh://")):
-            remote = _normalize_git_ssh(remote)
-        elif remote.startswith("http://") or remote.startswith("https://"):
-            remote = url_normalize(remote)
+        remote = normalize_git_url(remote)
         try:
             self._repo.remote().set_url(remote)
         except ValueError:

--- a/commodore/gitrepo.py
+++ b/commodore/gitrepo.py
@@ -407,9 +407,11 @@ class GitRepo:
     def checkout(self, version: Optional[str] = None):
         remote_heads = self.fetch()
         if not remote_heads:
-            # Somehow, we don't get the new fetch infos on the first fetch after
-            # changing the remote, so we retry once if we didn't get any fetch infos
-            # from the first call.
+            # GitPython's fetch-info parsing chokes on lines like
+            # "   (refs/remotes/origin/HEAD has become dangling)"
+            # see also https://github.com/gitpython-developers/GitPython/issues/962.
+            # We handle this case by simply performing a second fetch which should
+            # return fetch-infos with flags = 4 (HEAD_UPTODATE).
             remote_heads = self.fetch()
 
         if version is None:

--- a/commodore/gitrepo.py
+++ b/commodore/gitrepo.py
@@ -167,11 +167,12 @@ class GitRepo:
         author_name: Optional[str] = None,
         author_email: Optional[str] = None,
         config=None,
+        bare=False,
     ):
         if not force_init and targetdir.exists():
             self._repo = Repo(targetdir)
         else:
-            self._repo = Repo.init(targetdir)
+            self._repo = Repo.init(targetdir, bare=bare)
 
         if remote:
             self.remote = remote

--- a/commodore/multi_dependency.py
+++ b/commodore/multi_dependency.py
@@ -23,6 +23,10 @@ class MultiDependency:
     def url(self) -> str:
         return self._repo.remote
 
+    @url.setter
+    def url(self, repo_url: str):
+        self._repo.remote = repo_url
+
     def get_component(self, name: str) -> Optional[Path]:
         return self._components.get(name)
 
@@ -71,8 +75,16 @@ class MultiDependency:
 
 
 def dependency_dir(base_dir: Path, repo_url: str) -> Path:
-    # Normalize URL here, as we don't require that we always are passed a normalized
-    # URL.
+    return base_dir / ".repos" / dependency_key(repo_url)
+
+
+def dependency_key(repo_url: str) -> str:
+    """Create normalized and scheme-agnostic key for the given repo URL.
+
+    This is also used to determine the subpath where the bare checkout is created."""
     repo_url = normalize_git_url(repo_url)
     url_parts = deconstruct_url(repo_url)
-    return base_dir / ".repos" / url_parts.host / url_parts.path[1:]
+    depkey = ""
+    if url_parts.host:
+        depkey = f"{url_parts.host}/"
+    return depkey + url_parts.path[1:]

--- a/commodore/multi_dependency.py
+++ b/commodore/multi_dependency.py
@@ -36,12 +36,11 @@ class MultiDependency:
 
         self._components[name] = target_dir
 
-    def deregister_component(self, name: str) -> bool:
+    def deregister_component(self, name: str):
         try:
             del self._components[name]
-            return True
-        except KeyError:
-            return False
+        except KeyError as e:
+            raise ValueError(f"can't deregister unknown component {name}") from e
 
     def checkout_component(self, name: str, version: str):
         """Create or update worktree for component `name`."""
@@ -59,12 +58,11 @@ class MultiDependency:
 
         self._packages[name] = target_dir
 
-    def deregister_package(self, name: str) -> bool:
+    def deregister_package(self, name: str):
         try:
             del self._packages[name]
-            return True
-        except KeyError:
-            return False
+        except KeyError as e:
+            raise ValueError(f"can't deregister unknown package {name}") from e
 
     def checkout_package(self, name: str, version: str):
         """Create or update worktree for package `name`."""

--- a/commodore/multi_dependency.py
+++ b/commodore/multi_dependency.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from url_normalize.tools import deconstruct_url
+
+from commodore.gitrepo import GitRepo, normalize_git_url
+
+
+class MultiDependency:
+    _repo: GitRepo
+    _components: dict[str, Path]
+    _packages: dict[str, Path]
+
+    def __init__(self, repo_url: str, dependencies_dir: Path):
+        repo_dir = dependency_dir(dependencies_dir, repo_url)
+        self._repo = GitRepo(repo_url, repo_dir, bare=True)
+        self._components = {}
+        self._packages = {}
+
+    @property
+    def url(self) -> str:
+        return self._repo.remote
+
+    def get_component(self, name: str) -> Optional[Path]:
+        return self._components.get(name)
+
+    def register_component(self, name: str, target_dir: Path):
+        if name in self._components:
+            raise ValueError(f"component {name} already registered")
+
+        self._components[name] = target_dir
+
+    def deregister_component(self, name: str) -> bool:
+        try:
+            del self._components[name]
+            return True
+        except KeyError:
+            return False
+
+    def checkout_component(self, name: str, version: str):
+        """Create or update worktree for component `name`."""
+        target_dir = self.get_component(name)
+        if not target_dir:
+            raise ValueError(f"can't checkout unknown component {name}")
+        self._repo.checkout_worktree(target_dir, version=version)
+
+    def get_package(self, name: str) -> Optional[Path]:
+        return self._packages.get(name)
+
+    def register_package(self, name: str, target_dir: Path):
+        if name in self._packages:
+            raise ValueError(f"package {name} already registered")
+
+        self._packages[name] = target_dir
+
+    def deregister_package(self, name: str) -> bool:
+        try:
+            del self._packages[name]
+            return True
+        except KeyError:
+            return False
+
+    def checkout_package(self, name: str, version: str):
+        """Create or update worktree for package `name`."""
+        target_dir = self.get_package(name)
+        if not target_dir:
+            raise ValueError(f"can't checkout unknown package {name}")
+        self._repo.checkout_worktree(target_dir, version=version)
+
+
+def dependency_dir(base_dir: Path, repo_url: str) -> Path:
+    # Normalize URL here, as we don't require that we always are passed a normalized
+    # URL.
+    repo_url = normalize_git_url(repo_url)
+    url_parts = deconstruct_url(repo_url)
+    return base_dir / ".repos" / url_parts.host / url_parts.path[1:]

--- a/docs/modules/ROOT/pages/reference/architecture.adoc
+++ b/docs/modules/ROOT/pages/reference/architecture.adoc
@@ -38,7 +38,7 @@ Note that this only works to remove dependencies which have been included previo
 
 Commodore uses the prefix `pkg.` to distinguish configuration package dependencies from component dependencies.
 
-Commodore currently has no mechanism to automatically discover depedencies based on their names.
+Commodore currently has no mechanism to automatically discover dependencies based on their names.
 Instead all components which are referenced in the `applications` array must be listed in key `parameters.components` in the hierarchy.
 Analogously, all configuration packages which are referenced in the `applications` array must be listed in key `parameters.packages` in the hierarchy.
 

--- a/docs/modules/ROOT/pages/reference/architecture.adoc
+++ b/docs/modules/ROOT/pages/reference/architecture.adoc
@@ -53,11 +53,14 @@ Commodore will exit with an error if no version is given for a dependency.
 The path in the repository is specified in key `path`.
 If key `path` isn't provided, Commodore assumes that the dependency is stored in the repository root.
 
-For each included dependency, Commodore fetches the remote repository and directly checks out the specified version.
-Regardless of the value of key `path`, Commodore fetches the complete repository.
-However, Commodore will create a symlink to the indicated path, when making the dependency available in the hierarchy.
+Commodore uses https://git-scm.com/docs/git-worktree[Git worktrees] to make dependencies available in `dependencies/<dependency-name>`.
+This allows Commodore to ensure that each remote repository is cloned exactly once.
+The initial clone of repository `https://git.example.com/path/to/repo.git` is created in `dependencies/.repos/git.example.com/path/to/repo.git` as a bare checkout.
+For each dependency which is stored in this repository, Commodore ensures that the Git worktree in `dependencies/<dependency-name>` exists and is checked out with the specified `version`.
+Regardless of the value of key `path`, Commodore creates a checkout of the  complete repository in `dependencies/<dependency-name>`.
+However, Commodore will create a symlink to the specified path when making the dependency available in the hierarchy.
 
-Commodore will make all included packages available, before discovering and fetching components.
+Commodore will make all included packages available before discovering and fetching components.
 This ensures that configuration packages can include additional components and can customize component versions.
 
 Commodore will read `parameters.components` from the hierarchy _before component defaults are included_.

--- a/tests/test_component_compile.py
+++ b/tests/test_component_compile.py
@@ -26,12 +26,11 @@ def _prepare_component(tmp_path, component_name="test-component", subpath=""):
         component_root = tmp_path / "dependencies" / component_name
     else:
         call_component_new(tmp_path / "tmp", lib="--lib")
-        Repo.init(tmp_path / component_name)
         component_root = tmp_path / component_name / subpath
         shutil.copytree(
             tmp_path / "tmp" / "dependencies" / "test-component", component_root
         )
-        shutil.rmtree(component_root / ".git")
+        shutil.move(str(component_root / ".git"), str(tmp_path / component_name))
 
     with open(component_root / "component/main.jsonnet", "a") as file:
         file.write(

--- a/tests/test_component_compile.py
+++ b/tests/test_component_compile.py
@@ -273,4 +273,7 @@ def test_no_component_compile_command(tmp_path):
         compile_component(
             Config(tmp_path), tmp_path / "foo", None, [], [], "./", "", ""
         )
-    assert "Could not find component class file" in str(excinfo)
+    assert (
+        f"Can't compile component, repository {tmp_path / 'foo'} doesn't exist"
+        in str(excinfo)
+    )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,6 +13,7 @@ import click
 
 from commodore.config import Config
 from commodore.package import Package
+from commodore.multi_dependency import dependency_key
 
 
 def test_verify_component_aliases_no_instance(config):
@@ -232,3 +233,60 @@ def test_register_get_package(config: Config, tmp_path: P, mockdep):
     config.register_package("test", p)
 
     assert config.get_packages() == {"test": p}
+
+
+def test_register_get_dependency(config: Config, tmp_path: P):
+    repo_url = "https://git.example.com/repo.git"
+
+    # No dependencies registered initially
+    assert len(config._dependency_repos) == 0
+
+    md = config.register_dependency_repo(repo_url)
+
+    depkey = dependency_key(repo_url)
+
+    assert len(config._dependency_repos) == 1
+    assert config._dependency_repos.get(depkey) == md
+
+
+def test_register_get_dependency_deduplicates(config: Config, tmp_path: P):
+    repo_url_1 = "https://git.example.com/repo1.git"
+    repo_url_2 = "https://git.example.com/repo2.git"
+
+    assert len(config._dependency_repos) == 0
+
+    md = config.register_dependency_repo(repo_url_1)
+
+    depkey = dependency_key(repo_url_1)
+
+    assert len(config._dependency_repos) == 1
+    assert config._dependency_repos.get(depkey) == md
+
+    md1_dup = config.register_dependency_repo(repo_url_1)
+
+    assert len(config._dependency_repos) == 1
+    assert md1_dup == md
+
+    md2 = config.register_dependency_repo(repo_url_2)
+
+    depkey2 = dependency_key(repo_url_2)
+
+    assert len(config._dependency_repos) == 2
+    assert config._dependency_repos.get(depkey2) == md2
+    assert set(config._dependency_repos.keys()) == {depkey, depkey2}
+
+
+def test_register_dependency_prefer_ssh(config: Config, tmp_path: P):
+    repo_url_https = "https://git.example.com/repo.git"
+    repo_url_ssh = "ssh://git@git.example.com/repo.git"
+
+    md = config.register_dependency_repo(repo_url_https)
+    assert md.url == repo_url_https
+
+    md2 = config.register_dependency_repo(repo_url_ssh)
+    assert md2 == md
+    assert md.url == repo_url_ssh
+
+    md3 = config.register_dependency_repo(repo_url_https)
+    assert md3 == md
+    assert md.url == repo_url_ssh

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -224,11 +224,11 @@ def test_expired_token_cache(test_patch):
     assert conf.api_token is None
 
 
-def test_register_get_package(config: Config, tmp_path: P):
+def test_register_get_package(config: Config, tmp_path: P, mockdep):
     # No preregistered packages
     assert config.get_packages() == {}
 
-    p = Package("test", target_dir=tmp_path / "pkg")
+    p = Package("test", mockdep, tmp_path / "pkg")
     config.register_package("test", p)
 
     assert config.get_packages() == {"test": p}

--- a/tests/test_dependency_mgmt_jsonnet_bundler.py
+++ b/tests/test_dependency_mgmt_jsonnet_bundler.py
@@ -7,9 +7,13 @@ from commodore.config import Config
 from commodore.dependency_mgmt import jsonnet_bundler
 
 
-def test_write_jsonnetfile(config: Config, tmp_path: Path):
-    config.register_component(Component("test-component", work_dir=tmp_path))
-    config.register_component(Component("test-component-2", work_dir=tmp_path))
+def test_write_jsonnetfile(config: Config, tmp_path: Path, mockdep):
+    config.register_component(
+        Component("test-component", dependency=mockdep, work_dir=tmp_path)
+    )
+    config.register_component(
+        Component("test-component-2", dependency=mockdep, work_dir=tmp_path)
+    )
     dirs = [
         "dependencies/test-component",
         "dependencies/test-component-2",

--- a/tests/test_gitrepo.py
+++ b/tests/test_gitrepo.py
@@ -180,3 +180,13 @@ def test_gitrepo_push_empty_remote(tmp_path: Path):
     r.stage_all()
     r.commit("Initial commit")
     r.push()
+
+
+def test_gitrepo_checkout_bare(tmp_path: Path):
+    repo_url, ri = setup_remote(tmp_path)
+    r = gitrepo.GitRepo(repo_url, targetdir=tmp_path / "bare.git", bare=True)
+
+    assert (tmp_path / "bare.git" / "config").is_file()
+    assert (tmp_path / "bare.git" / "HEAD").is_file()
+
+    assert r.repo.bare

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -16,7 +16,7 @@ from url_normalize import url_normalize
 
 import commodore.helpers as helpers
 from commodore.config import Config
-from commodore.component import Component, component_dir
+from commodore.multi_dependency import MultiDependency, dependency_dir
 
 
 def test_apierror():
@@ -32,9 +32,10 @@ def test_apierror():
 def test_clean_working_tree(tmp_path: Path):
     cfg = Config(work_dir=tmp_path)
     cfg.inventory.ensure_dirs()
-    d = component_dir(tmp_path, "test")
+    repo_url = "https://fake.repo.url"
+    d = dependency_dir(cfg.inventory.dependencies_dir, repo_url)
     assert not d.is_dir()
-    Component("test", work_dir=tmp_path)
+    MultiDependency("https://fake.repo.url", cfg.inventory.dependencies_dir)
     assert d.is_dir()
     helpers.clean_working_tree(cfg)
     assert d.is_dir()

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -66,12 +66,12 @@ def test_tenant_config_dir():
     )
 
 
-def test_component_file(tmp_path: P):
+def test_component_file(tmp_path: P, mockdep):
     assert (
         str(Inventory().component_file("foo")) == "inventory/classes/components/foo.yml"
     )
     assert (
-        str(Inventory().component_file(Component("baz", work_dir=tmp_path)))
+        str(Inventory().component_file(Component("baz", mockdep, work_dir=tmp_path)))
         == "inventory/classes/components/baz.yml"
     )
     assert (
@@ -80,10 +80,10 @@ def test_component_file(tmp_path: P):
     )
 
 
-def test_defaults_file(tmp_path: P):
+def test_defaults_file(tmp_path: P, mockdep):
     assert str(Inventory().defaults_file("foo")) == "inventory/classes/defaults/foo.yml"
     assert (
-        str(Inventory().defaults_file(Component("baz", work_dir=tmp_path)))
+        str(Inventory().defaults_file(Component("baz", mockdep, work_dir=tmp_path)))
         == "inventory/classes/defaults/baz.yml"
     )
     assert (
@@ -92,10 +92,10 @@ def test_defaults_file(tmp_path: P):
     )
 
 
-def test_target_file(tmp_path: P):
+def test_target_file(tmp_path: P, mockdep):
     assert str(Inventory().target_file("foo")) == "inventory/targets/foo.yml"
     assert (
-        str(Inventory().target_file(Component("baz", work_dir=tmp_path)))
+        str(Inventory().target_file(Component("baz", mockdep, work_dir=tmp_path)))
         == "inventory/targets/baz.yml"
     )
     assert (

--- a/tests/test_multi_dependency.py
+++ b/tests/test_multi_dependency.py
@@ -5,38 +5,44 @@ from pathlib import Path
 import pytest
 
 from git import Repo
-from url_normalize.url_normalize import deconstruct_url
+from url_normalize.tools import deconstruct_url
 
 from commodore import multi_dependency
 
 from test_gitrepo import setup_remote
 
 
-@pytest.mark.parametrize(
-    "repo_url,expected",
-    [
-        (
-            "https://github.com/projectsyn/component-argocd.git",
-            "github.com/projectsyn/component-argocd.git",
-        ),
-        (
-            "git@github.com:projectsyn/component-argocd.git",
-            "github.com/projectsyn/component-argocd.git",
-        ),
-        (
-            "ssh://git@github.com/projectsyn/component-argocd.git",
-            "github.com/projectsyn/component-argocd.git",
-        ),
-        (
-            "file:///tmp/path/to/repo.git",
-            "tmp/path/to/repo.git",
-        ),
-    ],
-)
+CASES = [
+    (
+        "https://github.com/projectsyn/component-argocd.git",
+        "github.com/projectsyn/component-argocd.git",
+    ),
+    (
+        "git@github.com:projectsyn/component-argocd.git",
+        "github.com/projectsyn/component-argocd.git",
+    ),
+    (
+        "ssh://git@github.com/projectsyn/component-argocd.git",
+        "github.com/projectsyn/component-argocd.git",
+    ),
+    (
+        "file:///tmp/path/to/repo.git",
+        "tmp/path/to/repo.git",
+    ),
+]
+
+
+@pytest.mark.parametrize("repo_url,expected", CASES)
 def test_dependency_dir(tmp_path: Path, repo_url: str, expected: str):
     path = multi_dependency.dependency_dir(tmp_path, repo_url)
     repos_dir = tmp_path / ".repos"
     assert path == repos_dir / expected
+
+
+@pytest.mark.parametrize("repo_url,expected", CASES)
+def test_dependency_key(tmp_path: Path, repo_url: str, expected: str):
+    depkey = multi_dependency.dependency_key(repo_url)
+    assert depkey == expected
 
 
 def test_multi_dependency_init(tmp_path: Path):

--- a/tests/test_multi_dependency.py
+++ b/tests/test_multi_dependency.py
@@ -118,26 +118,29 @@ def test_multi_dependency_deregister(tmp_path: Path):
     assert md.get_component("test") == tmp_path / "tc"
     assert md.get_package("test") == tmp_path / "tp"
 
-    dc_nonexist = md.deregister_component("foo")
+    with pytest.raises(ValueError) as e:
+        md.deregister_component("foo")
 
-    assert not dc_nonexist
+    assert str(e.value) == "can't deregister unknown component foo"
+
     assert md.get_component("test") == tmp_path / "tc"
     assert md.get_package("test") == tmp_path / "tp"
 
-    dp_nonexist = md.deregister_package("pkg.test")
+    with pytest.raises(ValueError) as e:
+        md.deregister_package("pkg.test")
 
-    assert not dp_nonexist
+    assert str(e.value) == "can't deregister unknown package pkg.test"
+
     assert md.get_component("test") == tmp_path / "tc"
     assert md.get_package("test") == tmp_path / "tp"
 
-    dc = md.deregister_component("test")
+    md.deregister_component("test")
 
-    assert dc
     assert md.get_component("test") is None
     assert md.get_package("test") == tmp_path / "tp"
 
-    dp = md.deregister_package("test")
-    assert dp
+    md.deregister_package("test")
+
     assert md.get_component("test") is None
     assert md.get_package("test") is None
 

--- a/tests/test_multi_dependency.py
+++ b/tests/test_multi_dependency.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from git import Repo
+from url_normalize.url_normalize import deconstruct_url
+
+from commodore import multi_dependency
+
+from test_gitrepo import setup_remote
+
+
+@pytest.mark.parametrize(
+    "repo_url,expected",
+    [
+        (
+            "https://github.com/projectsyn/component-argocd.git",
+            "github.com/projectsyn/component-argocd.git",
+        ),
+        (
+            "git@github.com:projectsyn/component-argocd.git",
+            "github.com/projectsyn/component-argocd.git",
+        ),
+        (
+            "ssh://git@github.com/projectsyn/component-argocd.git",
+            "github.com/projectsyn/component-argocd.git",
+        ),
+        (
+            "file:///tmp/path/to/repo.git",
+            "tmp/path/to/repo.git",
+        ),
+    ],
+)
+def test_dependency_dir(tmp_path: Path, repo_url: str, expected: str):
+    path = multi_dependency.dependency_dir(tmp_path, repo_url)
+    repos_dir = tmp_path / ".repos"
+    assert path == repos_dir / expected
+
+
+def test_multi_dependency_init(tmp_path: Path):
+    repo_url, ri = setup_remote(tmp_path)
+    _ = multi_dependency.MultiDependency(repo_url, tmp_path)
+
+    repo_url_parts = deconstruct_url(repo_url)
+    print(repo_url, repo_url_parts)
+    bare_clone_path = (
+        tmp_path / ".repos" / repo_url_parts.host / repo_url_parts.path[1:]
+    )
+
+    assert bare_clone_path.is_dir()
+    # Smoke test that the directory is actually a bare clone
+    assert (bare_clone_path / "config").exists()
+    assert (bare_clone_path / "HEAD").exists()
+
+    b = Repo.init(bare_clone_path)
+    assert b.bare
+    assert b.working_tree_dir is None
+
+
+def test_multi_dependency_register_component(tmp_path: Path):
+    repo_url, ri = setup_remote(tmp_path)
+    md = multi_dependency.MultiDependency(repo_url, tmp_path)
+
+    assert md.get_component("test-component") is None
+    assert md.get_package("test-component") is None
+
+    md.register_component("test-component", tmp_path / "tc")
+
+    assert md.get_component("test-component") == tmp_path / "tc"
+    assert md.get_package("test-component") is None
+
+    with pytest.raises(ValueError) as e:
+        md.register_component("test-component", tmp_path / "tp2")
+
+    assert str(e.value) == "component test-component already registered"
+
+
+def test_multi_dependency_register_package(tmp_path: Path):
+    repo_url, ri = setup_remote(tmp_path)
+    md = multi_dependency.MultiDependency(repo_url, tmp_path)
+
+    assert md.get_component("test-package") is None
+    assert md.get_package("test-package") is None
+
+    md.register_package("test-package", tmp_path / "tp")
+
+    assert md.get_component("test-package") is None
+    assert md.get_package("test-package") == tmp_path / "tp"
+
+    with pytest.raises(ValueError) as e:
+        md.register_package("test-package", tmp_path / "tp2")
+
+    assert str(e.value) == "package test-package already registered"
+
+
+def test_multi_dependency_deregister(tmp_path: Path):
+    repo_url, ri = setup_remote(tmp_path)
+    md = multi_dependency.MultiDependency(repo_url, tmp_path)
+
+    assert md.get_component("test") is None
+    assert md.get_package("test") is None
+
+    md.register_component("test", tmp_path / "tc")
+
+    assert md.get_component("test") == tmp_path / "tc"
+    assert md.get_package("test") is None
+
+    md.register_package("test", tmp_path / "tp")
+
+    assert md.get_component("test") == tmp_path / "tc"
+    assert md.get_package("test") == tmp_path / "tp"
+
+    dc_nonexist = md.deregister_component("foo")
+
+    assert not dc_nonexist
+    assert md.get_component("test") == tmp_path / "tc"
+    assert md.get_package("test") == tmp_path / "tp"
+
+    dp_nonexist = md.deregister_package("pkg.test")
+
+    assert not dp_nonexist
+    assert md.get_component("test") == tmp_path / "tc"
+    assert md.get_package("test") == tmp_path / "tp"
+
+    dc = md.deregister_component("test")
+
+    assert dc
+    assert md.get_component("test") is None
+    assert md.get_package("test") == tmp_path / "tp"
+
+    dp = md.deregister_package("test")
+    assert dp
+    assert md.get_component("test") is None
+    assert md.get_package("test") is None
+
+
+def test_multi_dependency_checkout_component_exc(tmp_path: Path):
+    repo_url, ri = setup_remote(tmp_path)
+    md = multi_dependency.MultiDependency(repo_url, tmp_path)
+
+    with pytest.raises(ValueError) as e:
+        md.checkout_component("test", "master")
+
+    assert "can't checkout unknown component test" in str(e.value)
+
+
+def test_multi_dependency_checkout_component(tmp_path: Path):
+    repo_url, ri = setup_remote(tmp_path)
+    md = multi_dependency.MultiDependency(repo_url, tmp_path)
+
+    target_dir = tmp_path / "test"
+    assert not target_dir.is_dir()
+
+    md.register_component("test", target_dir)
+    md.checkout_component("test", "master")
+
+    assert target_dir.is_dir()
+    assert (target_dir / ".git").is_file()
+    assert (target_dir / "test.txt").is_file()
+
+    test = Repo.init(target_dir)
+    assert not test.head.is_detached
+    assert test.head.commit.hexsha == ri.commit_shas["master"]
+
+
+def test_multi_dependency_checkout_package_exc(tmp_path: Path):
+    repo_url, ri = setup_remote(tmp_path)
+    md = multi_dependency.MultiDependency(repo_url, tmp_path)
+
+    with pytest.raises(ValueError) as e:
+        md.checkout_package("test", "master")
+
+    assert "can't checkout unknown package test" in str(e.value)
+
+
+def test_multi_dependency_checkout_package(tmp_path: Path):
+    repo_url, ri = setup_remote(tmp_path)
+    md = multi_dependency.MultiDependency(repo_url, tmp_path)
+
+    target_dir = tmp_path / "test"
+    assert not target_dir.is_dir()
+
+    md.register_package("test", target_dir)
+    md.checkout_package("test", "master")
+
+    assert target_dir.is_dir()
+    assert (target_dir / ".git").is_file()
+    assert (target_dir / "test.txt").is_file()
+
+    test = Repo.init(target_dir)
+    assert not test.head.is_detached
+    assert test.head.commit.hexsha == ri.commit_shas["master"]
+
+
+@pytest.mark.parametrize(
+    "versions",
+    [
+        {"component": "master", "package": "test-branch"},
+        {"component": "master", "package": "master"},
+    ],
+)
+def test_multi_dependency_checkout_multiple(tmp_path: Path, versions: dict[str, str]):
+    repo_url, ri = setup_remote(tmp_path)
+    md = multi_dependency.MultiDependency(repo_url, tmp_path)
+
+    component_dir = tmp_path / "test-component"
+    package_dir = tmp_path / "test-package"
+    assert not component_dir.is_dir()
+    assert not package_dir.is_dir()
+
+    md.register_component("test", component_dir)
+    md.register_package("test", package_dir)
+
+    md.checkout_component("test", versions["component"])
+
+    assert component_dir.is_dir()
+    assert (component_dir / ".git").is_file()
+    assert (component_dir / "test.txt").is_file()
+    assert not (component_dir / "branch.txt").exists()
+    assert not package_dir.is_dir()
+
+    cr = Repo.init(component_dir)
+    assert not cr.head.is_detached
+    assert cr.head.commit.hexsha == ri.commit_shas[versions["component"]]
+
+    md.checkout_package("test", versions["package"])
+
+    # Verify that component checkout hasn't changed
+    assert component_dir.is_dir()
+    assert (component_dir / ".git").is_file()
+    assert (component_dir / "test.txt").is_file()
+    assert not (component_dir / "branch.txt").exists()
+    assert not cr.head.is_detached
+    assert cr.head.commit.hexsha == ri.commit_shas[versions["component"]]
+
+    # Verify that package checkout exists now
+    assert package_dir.is_dir()
+    assert (package_dir / ".git").is_file()
+    assert (package_dir / "test.txt").is_file()
+    if versions["package"] == "test-branch":
+        assert (package_dir / "branch.txt").is_file()
+    else:
+        assert not (package_dir / "branch.txt").exists()
+
+    pr = Repo.init(package_dir)
+    assert not pr.head.is_detached
+    assert pr.head.commit.hexsha == ri.commit_shas[versions["package"]]

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -3,19 +3,24 @@ from pathlib import Path
 import git
 import yaml
 
+from commodore.multi_dependency import MultiDependency
+
 from commodore import package
 
 
 def test_package_init(tmp_path: Path):
+    pkg_url = "https://git.example.com/pkg.git"
+    pdep = MultiDependency(pkg_url, tmp_path / "repo.git")
     p = package.Package(
         "test",
+        dependency=pdep,
         target_dir=tmp_path / "pkg",
-        url="https://git.example.com/pkg.git",
         version="master",
     )
     assert p.url == "https://git.example.com/pkg.git"
     assert p.version == "master"
     assert p.target_dir == tmp_path / "pkg"
+    assert p.repository_dir == tmp_path / "pkg"
 
 
 def _setup_package_remote(pkg_name: str, rpath: Path):
@@ -31,10 +36,11 @@ def _setup_package_remote(pkg_name: str, rpath: Path):
 def test_package_checkout(tmp_path: Path):
     _setup_package_remote("test", tmp_path / "pkg.git")
 
+    pdep = MultiDependency(f"file://{tmp_path}/pkg.git", tmp_path / ".pkg")
     p = package.Package(
         "test",
+        dependency=pdep,
         target_dir=tmp_path / "pkg",
-        url=f"file://{tmp_path}/pkg.git",
         version="master",
     )
     p.checkout()

--- a/tests/test_package_compile.py
+++ b/tests/test_package_compile.py
@@ -5,6 +5,7 @@ from unittest import mock
 from typing import Optional
 
 import click
+import git
 import pytest
 import yaml
 
@@ -15,6 +16,8 @@ from commodore.helpers import yaml_dump, yaml_load
 
 from commodore.package import compile
 from test_component_compile import _prepare_component, _add_postprocessing_filter
+
+from conftest import MockMultiDependency
 
 
 def test_setup_package_inventory(tmp_path: Path, config: Config):
@@ -43,8 +46,10 @@ def test_setup_package_inventory(tmp_path: Path, config: Config):
 
 
 def _mock_fetch_components(cfg: Config):
-    print(cfg.work_dir)
-    c = Component("test-component", cfg.work_dir)
+    cdep = MockMultiDependency(
+        git.Repo.init(cfg.inventory.dependencies_dir / ".repos" / "test-component.git")
+    )
+    c = Component("test-component", cdep, cfg.work_dir)
     create_component_symlinks(cfg, c)
     cfg.register_component(c)
     cfg.register_component_aliases({"test-component": "test-component"})

--- a/tests/test_postprocess.py
+++ b/tests/test_postprocess.py
@@ -10,6 +10,7 @@ from textwrap import dedent
 
 from commodore.config import Config
 from commodore.component import Component
+from commodore.multi_dependency import MultiDependency
 from commodore.postprocess import (
     postprocess_components,
     builtin_filters,
@@ -152,9 +153,8 @@ def _setup(tmp_path, f, alias="test-component"):
     os.makedirs(pp_file.parent, exist_ok=True)
 
     config = Config(work_dir=tmp_path)
-    component = Component(
-        "test-component", work_dir=tmp_path, repo_url="https://fake.repo.url"
-    )
+    cdep = MultiDependency("https://fake.repo.url/", tmp_path / "dependencies")
+    component = Component("test-component", dependency=cdep, work_dir=tmp_path)
     config.register_component(component)
     aliases = {alias: "test-component"}
     config.register_component_aliases(aliases)

--- a/tests/test_render_inventory.py
+++ b/tests/test_render_inventory.py
@@ -2,11 +2,15 @@ import os
 
 from pathlib import Path
 
+import git
+
 from commodore.cluster import update_target
 from commodore.component import Component
 from commodore.config import Config
 from commodore.dependency_mgmt import create_component_symlinks
 from commodore.helpers import kapitan_inventory, yaml_dump, yaml_load
+
+from conftest import MockMultiDependency
 
 
 def _setup(tmp_path: Path):
@@ -22,7 +26,8 @@ def _setup(tmp_path: Path):
     os.makedirs(cfg.inventory.params_dir)
 
     os.makedirs(tmp_path / "dependencies" / "test")
-    c = Component("test", work_dir=tmp_path, force_init=True)
+    cdep = MockMultiDependency(git.Repo.init(tmp_path / "repo.git"))
+    c = Component("test", cdep, work_dir=tmp_path)
     os.makedirs(c.class_file.parent)
 
     yaml_dump(


### PR DESCRIPTION
This PR changes how Commodore handles dependencies to implicitly assume that any set of dependencies may share a repository. To faciliate this, the PR changes the disk layout for the checked out dependencies to use git worktree with a bare "main" clone of the repository stored in dependencies/.repos/git.host/path/to/repo.git where the path under dependencies/.repos is constructed from the remote URL.

Resolves #518 

Replacement for #549 which got closed accidentally.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
