### PR TITLE
Update `package new` to save the new package in `dependencies/`

### DIFF
--- a/tests/test_package_template.py
+++ b/tests/test_package_template.py
@@ -47,7 +47,7 @@ def test_run_package_new_command(
 
     pkg_dir = tmp_path / "test-package"
     if output_dir == "":
-        pkg_dir = tmp_path / "inventory" / "classes" / "test-package"
+        pkg_dir = tmp_path / "dependencies" / "pkg.test-package"
 
     expected_files = [
         Path(".editorconfig"),


### PR DESCRIPTION
We forgot to update `package new` to create the new packages in `dependencies/` when changing Commodore to symlink packages from `dependencies` into the inventory.

Follow-up to #546

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
