### PR TITLE
Create new components and packages as Git worktree checkouts

### DIFF
--- a/commodore/component/template.py
+++ b/commodore/component/template.py
@@ -83,6 +83,17 @@ class ComponentTemplater(Templater):
                     abort=True,
                 )
             rmtree(component.target_directory)
+            # We check for other checkouts here, because our MultiDependency doesn't
+            # know if there's other dependencies which would be registered on it.
+            if not cdep.has_checkouts():
+                # Also delete bare copy of component repo, if there's no other
+                # worktree checkouts for the same dependency repo.
+                rmtree(cdep.repo_directory)
+            else:
+                click.echo(
+                    f" > Not deleting bare copy of repository {cdep.url}. "
+                    + "Other worktrees refer to the same reposiotry."
+                )
 
             click.secho(f"Component {self.slug} successfully deleted 🎉", bold=True)
         else:

--- a/commodore/dependency_templater.py
+++ b/commodore/dependency_templater.py
@@ -135,17 +135,9 @@ class Templater(ABC):
                 + f"{self.target_dir} already exists."
             )
 
-        want_worktree = True
-        try:
-            # Use target_dir.relative_to(work_dir / "dependencies") to determine whether
-            # the new dependency is created in a commodore working tree (i.e. as a
-            # subdirectory of `work_dir / "dependencies"`).
-            _ = self.target_dir.absolute().relative_to(
-                self.config.inventory.dependencies_dir.absolute()
-            )
-        except ValueError:
-            want_worktree = False
-
+        want_worktree = (
+            self.config.inventory.dependencies_dir in self.target_dir.parents
+        )
         if want_worktree:
             md = MultiDependency(self.repo_url, self.config.inventory.dependencies_dir)
             md.initialize_worktree(self.target_dir)

--- a/commodore/dependency_templater.py
+++ b/commodore/dependency_templater.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import datetime
 import re
+import tempfile
+import shutil
 
 from abc import ABC, abstractmethod
 from pathlib import Path
@@ -11,6 +13,7 @@ import click
 
 from commodore.config import Config
 from commodore.gitrepo import GitRepo
+from commodore.multi_dependency import MultiDependency
 
 SLUG_REGEX = re.compile("^[a-z][a-z0-9-]+[a-z0-9]$")
 
@@ -132,20 +135,42 @@ class Templater(ABC):
                 + f"{self.target_dir} already exists."
             )
 
-        self.template_renderer(
-            self.template,
-            no_input=True,
-            output_dir=self.target_dir.parent,
-            extra_context=self.cookiecutter_args,
-        )
+        want_worktree = True
+        try:
+            # Use target_dir.relative_to(work_dir / "dependencies") to determine whether
+            # the new dependency is created in a commodore working tree (i.e. as a
+            # subdirectory of `work_dir / "dependencies"`).
+            _ = self.target_dir.absolute().relative_to(
+                self.config.inventory.dependencies_dir.absolute()
+            )
+        except ValueError:
+            want_worktree = False
 
-        self.commit("Initial commit")
+        if want_worktree:
+            md = MultiDependency(self.repo_url, self.config.inventory.dependencies_dir)
+            md.initialize_worktree(self.target_dir)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self.template_renderer(
+                self.template,
+                no_input=True,
+                output_dir=Path(tmpdir),
+                extra_context=self.cookiecutter_args,
+            )
+            shutil.copytree(
+                Path(tmpdir) / self.slug, self.target_dir, dirs_exist_ok=True
+            )
+
+        self.commit("Initial commit", amend=want_worktree)
         click.secho(
             f"{self.deptype.capitalize()} {self.name} successfully added 🎉", bold=True
         )
 
-    def commit(self, msg: str) -> None:
-        repo = GitRepo(self.repo_url, targetdir=self.target_dir, force_init=True)
+    def commit(self, msg: str, amend=False, init=True) -> None:
+        # If we're amending an existing commit, we don't want to force initialize the
+        # repo.
+        repo = GitRepo(self.repo_url, self.target_dir, force_init=not amend and init)
+
         repo.stage_all()
         repo.stage_files(self.additional_files)
-        repo.commit(msg)
+        repo.commit(msg, amend=amend)

--- a/commodore/multi_dependency.py
+++ b/commodore/multi_dependency.py
@@ -27,6 +27,10 @@ class MultiDependency:
     def url(self, repo_url: str):
         self._repo.remote = repo_url
 
+    @property
+    def repo_directory(self) -> Path:
+        return Path(self._repo.repo.common_dir).resolve().absolute()
+
     def get_component(self, name: str) -> Optional[Path]:
         return self._components.get(name)
 

--- a/commodore/multi_dependency.py
+++ b/commodore/multi_dependency.py
@@ -75,6 +75,10 @@ class MultiDependency:
             raise ValueError(f"can't checkout unknown package {name}")
         self._repo.checkout_worktree(target_dir, version=version)
 
+    def initialize_worktree(self, target_dir: Path) -> None:
+        """Initialize a worktree in `target_dir`."""
+        self._repo.initialize_worktree(target_dir)
+
     def has_checkouts(self) -> bool:
         return len(self._repo.worktrees) > 1
 

--- a/commodore/multi_dependency.py
+++ b/commodore/multi_dependency.py
@@ -75,6 +75,9 @@ class MultiDependency:
             raise ValueError(f"can't checkout unknown package {name}")
         self._repo.checkout_worktree(target_dir, version=version)
 
+    def has_checkouts(self) -> bool:
+        return len(self._repo.worktrees) > 1
+
 
 def dependency_dir(base_dir: Path, repo_url: str) -> Path:
     return base_dir / ".repos" / dependency_key(repo_url)

--- a/docs/modules/ROOT/pages/reference/commands.adoc
+++ b/docs/modules/ROOT/pages/reference/commands.adoc
@@ -40,6 +40,7 @@ check with the user whether they really want to remove the items listed above.
   commodore component new SLUG
 
 This command creates a new component repository under `dependencies/` in Commodore's working directory.
+Commodore creates a Git worktree checkout for the new component.
 The component repository is created using a Cookiecutter template which provides a skeleton for writing a new component.
 The command requires the argument `SLUG` to match the regular expression `^[a-z][a-z0-9-]+[a-z0-9]$`.
 Optionally, the template can be used to add a component library and postprocessing filter configuration.
@@ -152,7 +153,8 @@ If necessary, the command will call `commodore login` internally to fetch a vali
   commodore package new SLUG
 
 This command creates a new config package repository.
-If not specified explicitly, the command will create the new package under `inventory/classes/` in Commodore's working directory.
+If not specified explicitly, the command will create the new package under `dependencies/` in Commodore's working directory.
+If the new package is created in `dependencies`, Commodore will create a Git worktree checkout.
 The package repository is created using a Cookiecutter template which provides a skeleton for writing a new package.
 The command requires the argument `SLUG` to match the regular expression `^[a-z][a-z0-9-]+[a-z0-9]$`.
 Additionally, the command prevents users from creating packages using reserved names or prefixes.

--- a/tests/test_gitrepo.py
+++ b/tests/test_gitrepo.py
@@ -531,3 +531,18 @@ def test_gitrepo_list_worktrees(tmp_path: Path):
     assert len(worktrees_after_delete) == 1
     assert worktrees_after_delete[0].working_tree_dir == r.working_tree_dir
     assert worktrees_after_delete[0].repo.head.commit.hexsha == ri.commit_shas["master"]
+
+
+def test_gitrepo_init_worktree(tmp_path):
+    repo_path = tmp_path / "repo.git"
+    r = gitrepo.GitRepo(
+        "ssh://git@git.example.com/repo.git",
+        repo_path,
+        author_name="John Doe",
+        author_email="john.doe@example.com",
+        bare=True,
+    )
+    r.initialize_worktree(tmp_path / "repo")
+
+    assert r.repo.head.commit.author.name == "John Doe"
+    assert r.repo.head.commit.author.email == "john.doe@example.com"

--- a/tests/test_gitrepo.py
+++ b/tests/test_gitrepo.py
@@ -546,3 +546,16 @@ def test_gitrepo_init_worktree(tmp_path):
 
     assert r.repo.head.commit.author.name == "John Doe"
     assert r.repo.head.commit.author.email == "john.doe@example.com"
+
+
+def test_gitrepo_commit_amend(tmp_path: Path):
+    r, ri = setup_repo(tmp_path)
+    r._author = git.Actor("John Doe", "john.doe@example.com")
+
+    r.commit("Amended", amend=True)
+
+    assert r.repo.head.commit.message == "Amended\n"
+    assert r.repo.head.commit.author.name == "John Doe"
+    assert r.repo.head.commit.author.email == "john.doe@example.com"
+    assert r.repo.head.commit.committer.name == "John Doe"
+    assert r.repo.head.commit.committer.email == "john.doe@example.com"

--- a/tests/test_multi_dependency.py
+++ b/tests/test_multi_dependency.py
@@ -47,7 +47,7 @@ def test_dependency_key(tmp_path: Path, repo_url: str, expected: str):
 
 def test_multi_dependency_init(tmp_path: Path):
     repo_url, ri = setup_remote(tmp_path)
-    _ = multi_dependency.MultiDependency(repo_url, tmp_path)
+    md = multi_dependency.MultiDependency(repo_url, tmp_path)
 
     repo_url_parts = deconstruct_url(repo_url)
     print(repo_url, repo_url_parts)
@@ -59,6 +59,8 @@ def test_multi_dependency_init(tmp_path: Path):
     # Smoke test that the directory is actually a bare clone
     assert (bare_clone_path / "config").exists()
     assert (bare_clone_path / "HEAD").exists()
+
+    assert md.repo_directory == bare_clone_path
 
     b = Repo.init(bare_clone_path)
     assert b.bare

--- a/tests/test_multi_dependency.py
+++ b/tests/test_multi_dependency.py
@@ -150,6 +150,7 @@ def test_multi_dependency_deregister(tmp_path: Path):
 def test_multi_dependency_checkout_component_exc(tmp_path: Path):
     repo_url, ri = setup_remote(tmp_path)
     md = multi_dependency.MultiDependency(repo_url, tmp_path)
+    assert not md.has_checkouts()
 
     with pytest.raises(ValueError) as e:
         md.checkout_component("test", "master")
@@ -163,10 +164,12 @@ def test_multi_dependency_checkout_component(tmp_path: Path):
 
     target_dir = tmp_path / "test"
     assert not target_dir.is_dir()
+    assert not md.has_checkouts()
 
     md.register_component("test", target_dir)
     md.checkout_component("test", "master")
 
+    assert md.has_checkouts()
     assert target_dir.is_dir()
     assert (target_dir / ".git").is_file()
     assert (target_dir / "test.txt").is_file()
@@ -179,6 +182,7 @@ def test_multi_dependency_checkout_component(tmp_path: Path):
 def test_multi_dependency_checkout_package_exc(tmp_path: Path):
     repo_url, ri = setup_remote(tmp_path)
     md = multi_dependency.MultiDependency(repo_url, tmp_path)
+    assert not md.has_checkouts()
 
     with pytest.raises(ValueError) as e:
         md.checkout_package("test", "master")
@@ -189,6 +193,7 @@ def test_multi_dependency_checkout_package_exc(tmp_path: Path):
 def test_multi_dependency_checkout_package(tmp_path: Path):
     repo_url, ri = setup_remote(tmp_path)
     md = multi_dependency.MultiDependency(repo_url, tmp_path)
+    assert not md.has_checkouts()
 
     target_dir = tmp_path / "test"
     assert not target_dir.is_dir()
@@ -196,6 +201,7 @@ def test_multi_dependency_checkout_package(tmp_path: Path):
     md.register_package("test", target_dir)
     md.checkout_package("test", "master")
 
+    assert md.has_checkouts()
     assert target_dir.is_dir()
     assert (target_dir / ".git").is_file()
     assert (target_dir / "test.txt").is_file()


### PR DESCRIPTION
Only create worktrees when creating components or packages in a Commodore working tree (i.e. as subdirectories of `dependencies/`).
    
We also change the generic dependency template rendering to always render the template in a temp directory and moving the result into the final location, because we can't make an existing directory a Git worktree and cookiecutter doesn't support rendering a template into an existing directory, so we need to create the worktree first, then copy the templated dependency into it.


Follow-up to #551 

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
