### PR TITLE
Deduplicate requested test cases for `package new` and `package update`

### DIFF
--- a/commodore/cli.py
+++ b/commodore/cli.py
@@ -483,7 +483,8 @@ def package(config: Config, verbose: int):
     show_default=True,
     multiple=True,
     help="Additional test cases to generate in the new package. Can be repeated. "
-    + "Test case `defaults` will always be generated.",
+    + "Test case `defaults` will always be generated."
+    + "Commodore will deduplicate test cases by name.",
 )
 @verbosity
 @pass_config
@@ -550,7 +551,8 @@ def package_new(
     show_default=True,
     multiple=True,
     help="Additional test cases to generate in the new package. Can be repeated. "
-    + "Already existing test cases will always be kept.",
+    + "Already existing test cases will always be kept. "
+    + "Commodore will deduplicate test cases by name.",
 )
 @click.option(
     "--remove-test-case",
@@ -583,8 +585,9 @@ def package_update(
         t.golden_tests = golden_tests
     if update_copyright_year:
         t.copyright_year = None
-    t.test_cases.extend(additional_test_case)
-    t.test_cases = [tc for tc in t.test_cases if tc not in remove_test_case]
+    test_cases = t.test_cases
+    test_cases.extend(additional_test_case)
+    t.test_cases = [tc for tc in test_cases if tc not in remove_test_case]
 
     t.update()
 

--- a/commodore/package/template.py
+++ b/commodore/package/template.py
@@ -23,7 +23,7 @@ class PackageTemplater(Templater):
     template_url: str
     template_version: str
     template_commit: str
-    test_cases: list[str] = ["defaults"]
+    _test_cases: list[str] = ["defaults"]
     copyright_year: Optional[str] = None
     _target_dir: Optional[Path] = None
 
@@ -53,6 +53,24 @@ class PackageTemplater(Templater):
         t.copyright_holder = cookiecutter_args["copyright_holder"]
         t.copyright_year = cookiecutter_args["copyright_year"]
         return t
+
+    @property
+    def test_cases(self) -> list[str]:
+        """Return list of test cases.
+
+        The getter deduplicates the stored list before returning it.
+
+        Don't use `append()` on the returned list to add test cases to the package, as
+        the getter returns a copy of the list stored in the object."""
+        cases = []
+        for t in self._test_cases:
+            if t not in cases:
+                cases.append(t)
+        return cases
+
+    @test_cases.setter
+    def test_cases(self, test_cases: list[str]):
+        self._test_cases = test_cases
 
     def _cruft_renderer(
         self,

--- a/docs/modules/ROOT/pages/reference/cli.adoc
+++ b/docs/modules/ROOT/pages/reference/cli.adoc
@@ -234,6 +234,7 @@ This command doesn't have any command line options.
   Additional test cases to generate in the new package.
   Can be repeated.
   Test case `defaults` will always be generated.
+  Commodore will deduplicate the provided test cases.
 
 == Package Update
 
@@ -248,6 +249,7 @@ This command doesn't have any command line options.
 *--additional-test-case, -t* CASE::
   Additional test cases to add to the package.
   Can be repeated.
+  Commodore will deduplicate the provided test cases.
 
 *--remove-test-case* CASE::
   Test cases to remove from the package.


### PR DESCRIPTION
We previously didn't deduplicate the set of test cases requested when creating or updating a package. This can lead to noisy updates when users specify a new test case which already exists in the package.

This commit adds logic to remove duplicates in the getter for the list of test cases.  We deduplicate the list in the getter rather than the setter, to avoid introducing invisible duplicates if users use `append()` on the returned list.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
