### PR TITLE
Add flag for providing fallback dynamic facts for `catalog compile`

### DIFF
--- a/commodore/cli.py
+++ b/commodore/cli.py
@@ -848,4 +848,6 @@ def commodore_fetch_token(
 
 def main():
     load_dotenv(dotenv_path=find_dotenv(usecwd=True))
-    commodore.main(prog_name="commodore", auto_envvar_prefix="COMMODORE")
+    commodore.main(
+        prog_name="commodore", auto_envvar_prefix="COMMODORE", max_content_width=100
+    )

--- a/commodore/cluster.py
+++ b/commodore/cluster.py
@@ -20,10 +20,18 @@ from .inventory import Inventory
 class Cluster:
     _cluster_response: dict
     _tenant_response: dict
+    _fallback_dynamic_facts: dict[str, Any]
 
-    def __init__(self, cluster_response: dict, tenant_response: dict):
+    def __init__(
+        self,
+        cluster_response: dict,
+        tenant_response: dict,
+        fallback_dynamic_facts: dict[str, Any] = {},
+    ):
         self._cluster = cluster_response
         self._tenant = tenant_response
+        self._fallback_dynamic_facts = fallback_dynamic_facts
+
         if (
             "tenant" not in self._cluster
             or self._cluster["tenant"] != self._tenant["id"]
@@ -95,7 +103,7 @@ class Cluster:
 
     @property
     def dynamic_facts(self) -> dict[str, Any]:
-        return self._cluster.get("dynamicFacts", {})
+        return self._cluster.get("dynamicFacts", self._fallback_dynamic_facts)
 
 
 def load_cluster_from_api(cfg: Config, cluster_id: str) -> Cluster:
@@ -107,7 +115,7 @@ def load_cluster_from_api(cfg: Config, cluster_id: str) -> Cluster:
     tenant_response = lieutenant_query(
         cfg.api_url, cfg.api_token, "tenants", cluster_response["tenant"]
     )
-    return Cluster(cluster_response, tenant_response)
+    return Cluster(cluster_response, tenant_response, cfg.dynamic_facts)
 
 
 def read_cluster_and_tenant(inv: Inventory) -> tuple[str, str]:

--- a/commodore/cluster.py
+++ b/commodore/cluster.py
@@ -103,6 +103,13 @@ class Cluster:
 
     @property
     def dynamic_facts(self) -> dict[str, Any]:
+        if "dynamicFacts" in self._cluster and self._fallback_dynamic_facts:
+            empty = "" if self._cluster["dynamicFacts"] else "empty "
+            click.secho(
+                f" > Cluster API response contains {empty}dynamic facts, ignoring "
+                + " dynamic facts provided on the command line."
+            )
+
         return self._cluster.get("dynamicFacts", self._fallback_dynamic_facts)
 
 

--- a/commodore/config.py
+++ b/commodore/config.py
@@ -349,7 +349,7 @@ def parse_dynamic_fact_value(raw_value: str) -> Any:
             v = json.loads(json_val)
         except json.JSONDecodeError as e:
             click.secho(
-                f" > Expected value '{json_val}' to be parsable JSON, "
+                f"Expected value '{json_val}' to be parsable JSON, "
                 + f"but parsing failed with '{e}', skipping",
                 fg="yellow",
             )
@@ -379,14 +379,14 @@ def parse_dynamic_facts_from_cli(raw_facts: Iterable[str]) -> dict[str, Any]:
     for f in raw_facts:
         if "=" not in f:
             click.secho(
-                f" > Ignoring dynamic fact {f} which is not in format key=value",
+                f"Ignoring dynamic fact {f} which is not in format key=value",
                 fg="yellow",
             )
             continue
         raw_key, raw_value = f.split("=", maxsplit=1)
         if not raw_value:
             click.secho(
-                f"Ignoring malformed dynamic fact {f} with no value. "
+                f"Ignoring malformed dynamic fact '{f}' with no value. "
                 + "Please specify empty string value as 'json:\"\"'",
                 fg="yellow",
             )

--- a/commodore/config.py
+++ b/commodore/config.py
@@ -384,6 +384,11 @@ def parse_dynamic_facts_from_cli(raw_facts: Iterable[str]) -> dict[str, Any]:
             )
             continue
         raw_key, raw_value = f.split("=", maxsplit=1)
+        if not raw_key:
+            click.secho(
+                f"Ignoring malformed dynamic fact '{f}' with no key.", fg="yellow"
+            )
+            continue
         if not raw_value:
             click.secho(
                 f"Ignoring malformed dynamic fact '{f}' with no value. "

--- a/docs/modules/ROOT/pages/reference/cli.adoc
+++ b/docs/modules/ROOT/pages/reference/cli.adoc
@@ -100,6 +100,18 @@ After that, all the symlinks and dependencies which are required to compile the 
   This command line parameter overrides the tenant git repository revision configured on the cluster object in Lieutenant.
   When this option is provided, Commodore will abort without compiling the catalog if `--push` is also provided.
 
+*-d, --dynamic-fact* KEY=VALUE::
+  Fallback dynamic facts to use when compiling a cluster which hasn't reported its dynamic facts yet.
+  Commodore will never use values provided through this parameter if the cluster response from the API has a dynamic facts field.
+  Can be repeated.
+  Commodore expects each fact to be specified as `key=value`.
+  Nested keys can be provided as `path.to.key`.
+  Commodore will parse values as JSON if they're prefixed by `json:`.
+  If the same key is provided multiple times, the last occurrence overrides the previous values.
+  When providing a value for a key as JSON, previously specified subkeys of that key will be overwritten.
+  Nested keys are ignored if any non-leaf level of the requested key already contains a non-dictionary value.
+  If a value prefixed with `json:` isn't valid JSON, it will be skipped.
+
 *--help*::
   Show catalog clean usage and options then exit.
 

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -151,6 +151,7 @@ def test_facts(api_data):
 @pytest.mark.parametrize(
     "dynamic_facts",
     [
+        {},
         {
             "kubernetes_version": {
                 "major": "1",
@@ -193,3 +194,29 @@ def test_dynamic_facts(api_data, dynamic_facts):
     api_data["cluster"]["dynamicFacts"] = dynamic_facts.copy()
     cluster = Cluster(api_data["cluster"], api_data["tenant"])
     assert dynamic_facts == cluster.dynamic_facts
+
+
+@pytest.mark.parametrize(
+    "dynfacts,fallback",
+    [
+        ({}, {}),
+        ({}, {"foo": "bar"}),
+        ({"foo": "bar"}, {"baz": "qux"}),
+        (None, {}),
+        (None, {"foo": "bar"}),
+    ],
+)
+def test_dynamic_facts_fallback(api_data, dynfacts, fallback):
+    # The `api_data` test fixture contains some dynamic facts by default. We clear those
+    # to ensure a clean base for testing the dynamic facts logic.
+    del api_data["cluster"]["dynamicFacts"]
+    cluster = Cluster(api_data["cluster"], api_data["tenant"])
+    assert {} == cluster.dynamic_facts
+
+    if dynfacts is not None:
+        api_data["cluster"]["dynamicFacts"] = dynfacts.copy()
+    cluster = Cluster(api_data["cluster"], api_data["tenant"], fallback)
+    if dynfacts is not None:
+        assert dynfacts == cluster.dynamic_facts
+    else:
+        assert fallback == cluster.dynamic_facts

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -348,6 +348,8 @@ def test_parse_dynamic_fact_value(value: str, expected: Any):
         ([], {}),
         (["key"], {}),
         (["key="], {}),
+        (["="], {}),
+        (["=value"], {}),
         (['key=json:""'], {"key": ""}),
         (["key=value"], {"key": "value"}),
         (["key=value", "foo=bar"], {"key": "value", "foo": "bar"}),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import time
 
 import pytest
@@ -5,13 +7,18 @@ import textwrap
 from pathlib import Path as P
 
 from unittest.mock import patch
-from typing import Optional
+from typing import Any, Iterable, Optional
 
 import jwt
 
 import click
 
-from commodore.config import Config
+from commodore.config import (
+    Config,
+    parse_sub_key,
+    parse_dynamic_fact_value,
+    parse_dynamic_facts_from_cli,
+)
 from commodore.package import Package
 from commodore.multi_dependency import dependency_key
 
@@ -290,3 +297,73 @@ def test_register_dependency_prefer_ssh(config: Config, tmp_path: P):
     md3 = config.register_dependency_repo(repo_url_https)
     assert md3 == md
     assert md.url == repo_url_ssh
+
+
+@pytest.mark.parametrize(
+    "key,base_dict,expected_key,expected_dict",
+    [
+        ("toplevel", {}, "toplevel", {}),
+        ("path.to.key", {}, "key", {"path": {"to": {}}}),
+        ("path.to.key", {"path": {"to": "value"}}, None, {"path": {"to": "value"}}),
+        (
+            "path.to.key",
+            {"path": {"to": {"other": "value"}}},
+            "key",
+            {"path": {"to": {"other": "value"}}},
+        ),
+        ("path.", {}, None, {}),
+        ("path..foo", {}, None, {}),
+        (".foo", {}, None, {}),
+    ],
+)
+def test_parse_sub_key(
+    key: str,
+    base_dict: dict[str, Any],
+    expected_key: str,
+    expected_dict: dict[str, Any],
+):
+    leaf_key, leaf_dict = parse_sub_key(base_dict, key)
+    assert leaf_key == expected_key
+    assert base_dict == expected_dict
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("foo", "foo"),
+        ("test:foo", "test:foo"),
+        ("json:foo", None),
+        ('json:{"foo":"bar"', None),
+        ('json:"foo"', "foo"),
+        ("json:1", 1),
+        ('json:["a"]', ["a"]),
+        ('json:{"test":{"key":"value"}}', {"test": {"key": "value"}}),
+    ],
+)
+def test_parse_dynamic_fact_value(value: str, expected: Any):
+    parsed = parse_dynamic_fact_value(value)
+    assert parsed == expected
+
+
+@pytest.mark.parametrize(
+    "args,expected",
+    [
+        ([], {}),
+        (["key"], {}),
+        (["key="], {}),
+        (['key=json:""'], {"key": ""}),
+        (["key=value"], {"key": "value"}),
+        (["key=value", "foo=bar"], {"key": "value", "foo": "bar"}),
+        (["key=value=x"], {"key": "value=x"}),
+        (["key=value", "key=another"], {"key": "another"}),
+        (["key=value", "key.foo=bar"], {"key": "value"}),
+        (["key.foo=bar", "key=value"], {"key": "value"}),
+        (["key.foo=bar", "key.baz=qux"], {"key": {"foo": "bar", "baz": "qux"}}),
+        (["key=json:[1,2,3]"], {"key": [1, 2, 3]}),
+        (["key=json:[1,2,3"], {}),
+        (["path.to.key=json:foo"], {}),
+    ],
+)
+def test_parse_dynamic_facts_from_cli(args: Iterable[str], expected: dict[str, Any]):
+    dynamic_facts = parse_dynamic_facts_from_cli(args)
+    assert dynamic_facts == expected

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,7 +15,7 @@ import click
 
 from commodore.config import (
     Config,
-    parse_sub_key,
+    set_fact_value,
     parse_dynamic_fact_value,
     parse_dynamic_facts_from_cli,
 )
@@ -300,30 +300,27 @@ def test_register_dependency_prefer_ssh(config: Config, tmp_path: P):
 
 
 @pytest.mark.parametrize(
-    "key,base_dict,expected_key,expected_dict",
+    "key,base_dict,expected_dict",
     [
-        ("toplevel", {}, "toplevel", {}),
-        ("path.to.key", {}, "key", {"path": {"to": {}}}),
-        ("path.to.key", {"path": {"to": "value"}}, None, {"path": {"to": "value"}}),
+        ("toplevel", {}, {"toplevel": "sentinel"}),
+        ("path.to.key", {}, {"path": {"to": {"key": "sentinel"}}}),
+        ("path.to.key", {"path": {"to": "value"}}, {"path": {"to": "value"}}),
         (
             "path.to.key",
             {"path": {"to": {"other": "value"}}},
-            "key",
-            {"path": {"to": {"other": "value"}}},
+            {"path": {"to": {"other": "value", "key": "sentinel"}}},
         ),
-        ("path.", {}, None, {}),
-        ("path..foo", {}, None, {}),
-        (".foo", {}, None, {}),
+        ("path.", {}, {}),
+        ("path..foo", {}, {}),
+        (".foo", {}, {}),
     ],
 )
-def test_parse_sub_key(
+def test_set_fact_value(
     key: str,
     base_dict: dict[str, Any],
-    expected_key: str,
     expected_dict: dict[str, Any],
 ):
-    leaf_key, leaf_dict = parse_sub_key(base_dict, key)
-    assert leaf_key == expected_key
+    set_fact_value(base_dict, key, "sentinel")
     assert base_dict == expected_dict
 
 


### PR DESCRIPTION
We support providing dynamic facts as `--dynamic-fact key=value` in command `catalog compile`. The key can specify a nested key as `path.to.key`, and the value can optionally be parsed as JSON if it's prefixed with a literal `json:`. Facts specified later on the command line take precedence over previously specified facts. Nested facts will not be considered if one of their key segments (except the leaf) already holds a non-dictionary value.

Dynamic facts provided on the command line are only used for catalog compilation when the Lieutenant API response for the cluster which is getting compiled doesn't contain field `dynamicFacts`.

This enables us to cleanly support compilation of a cluster catalog before Steward is deployed on the cluster.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
