### PR TITLE
Add CLI commands to extract package versions and show rendered inventory

### DIFF
--- a/commodore/inventory/render.py
+++ b/commodore/inventory/render.py
@@ -9,7 +9,12 @@ import click
 
 from commodore.config import Config
 
-from .parameters import ClassNotFound, InventoryFactory, InventoryFacts
+from .parameters import (
+    ClassNotFound,
+    InventoryFactory,
+    InventoryFacts,
+    InventoryParameters,
+)
 
 
 def _cleanup_work_dir(cfg: Config, work_dir: Path):
@@ -18,9 +23,25 @@ def _cleanup_work_dir(cfg: Config, work_dir: Path):
         shutil.rmtree(work_dir)
 
 
+def extract_packages(
+    cfg: Config, invfacts: InventoryFacts
+) -> dict[str, dict[str, str]]:
+    return _get_inventory(cfg, invfacts).parameters("packages")
+
+
 def extract_components(
     cfg: Config, invfacts: InventoryFacts
 ) -> dict[str, dict[str, str]]:
+    return _get_inventory(cfg, invfacts).parameters("components")
+
+
+def extract_parameters(
+    cfg: Config, invfacts: InventoryFacts
+) -> dict[str, dict[str, str]]:
+    return _get_inventory(cfg, invfacts).parameters()
+
+
+def _get_inventory(cfg: Config, invfacts: InventoryFacts) -> InventoryParameters:
     if cfg.debug:
         click.echo(
             f"Called with: global_config={invfacts.global_config} "
@@ -46,7 +67,6 @@ def extract_components(
 
     try:
         inv = invfactory.reclass(invfacts)
-        components = inv.parameters("components")
     except ClassNotFound as e:
         _cleanup_work_dir(cfg, work_dir)
         raise ValueError(
@@ -57,4 +77,4 @@ def extract_components(
 
     _cleanup_work_dir(cfg, work_dir)
 
-    return components
+    return inv

--- a/docs/modules/ROOT/pages/reference/cli.adoc
+++ b/docs/modules/ROOT/pages/reference/cli.adoc
@@ -165,13 +165,13 @@ This command doesn't have any command line options.
 *--help*::
   Show component new usage and options then exit.
 
-== Inventory Components
+== Inventory Components / Packages / Show
 
 *-f, --values*::
   Specify an additional inventory class in a YAML file.
   This option can be repeated to provide multiple files.
   Files specified later win when resolving inventory values.
-  Use this mechanism to specify any facts (such as the cluster's distribution) that should be taken into account when extracting component versions.
+  Use this mechanism to specify any facts (such as the cluster's distribution) that should be taken into account when rendering the inventory.
 
 *-o, --output-format*::
   The output format for the command. Supported values are `json` and `yaml`. Defaults to `yaml`.

--- a/docs/modules/ROOT/pages/reference/commands.adoc
+++ b/docs/modules/ROOT/pages/reference/commands.adoc
@@ -81,16 +81,18 @@ configuration repositories.
 
 The option `--alias` (or `-a`) can be used to compile an instance-aware component with a specific instance.
 
-== Inventory Components
+== Inventory Show
 
-  commodore inventory components GLOBAL_CONFIG [TENANT_CONFIG]
+  commodore inventory show|components|packages GLOBAL_CONFIG [TENANT_CONFIG]
 
-This command lists all the components defined in `parameters.components` in the Commodore hierarchy in directory `GLOBAL_CONFIG`.
+The command `commodore inventory show` prints the `parameters` in the Commodore hierarchy in directory `GLOBAL_CONFIG`.
 If provided, the command also takes into account the tenant repo in directory `TENANT_CONFIG`.
 
-NOTE: The command doesn't currently support cloning either the global or tenant repository from a Git repo URL.
+The commands `commodore inventory components` and `commodore inventory packages` also render the inventory, but only print a list of all components or packages.
 
-The component takes a repeatable argument `-f / --values` which allows the user to specify additional files that should be used as classes when rendering the contents of `parameters.components`.
+NOTE: The commands don't currently support cloning either the global or tenant repository from a Git repo URL.
+
+The commands take a repeatable argument `-f / --values` which allows the user to specify additional files that should be used as classes when rendering the inventory.
 
 When providing a tenant repo, users must specify the tenant ID and cluster ID for which the inventory should be rendered in a value class to obtain accurate results.
 See a sample `cluster-info.yaml` which can be used for this purpose below.
@@ -107,7 +109,7 @@ parameters:
 <2> Specify the tenant ID.
 This must match the tenant ID associated with the provided tenant repo for accurate results.
 
-The command supports both YAML and JSON output.
+The commands support both YAML and JSON output.
 
 == Inventory Lint
 

--- a/docs/modules/ROOT/pages/reference/commands.adoc
+++ b/docs/modules/ROOT/pages/reference/commands.adoc
@@ -88,7 +88,7 @@ The option `--alias` (or `-a`) can be used to compile an instance-aware componen
 The command `commodore inventory show` prints the `parameters` in the Commodore hierarchy in directory `GLOBAL_CONFIG`.
 If provided, the command also takes into account the tenant repo in directory `TENANT_CONFIG`.
 
-The commands `commodore inventory components` and `commodore inventory packages` also render the inventory, but only print a list of all components or packages.
+The commands `commodore inventory components` and `commodore inventory packages` also render the inventory, but only print the list of all components and packages respectively.
 
 NOTE: The commands don't currently support cloning either the global or tenant repository from a Git repo URL.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -52,8 +52,18 @@ def test_component_compile_command():
     assert exit_status == 0
 
 
+def test_inventory_show_command():
+    exit_status = call("commodore inventory show --help", shell=True)
+    assert exit_status == 0
+
+
 def test_inventory_components_command():
     exit_status = call("commodore inventory components --help", shell=True)
+    assert exit_status == 0
+
+
+def test_inventory_packages_command():
+    exit_status = call("commodore inventory packages --help", shell=True)
     assert exit_status == 0
 
 


### PR DESCRIPTION
This PR introduces tow new command for the command group `inventory`.

The command `inventory packages` is the equivalent to `inventory components`. It calls reclass to render the inventory of a global defaults or tenant repo and returns all packages (URLs and versions) defined in that repo.

The command `inventory show` also renders the inventory, but returns all parameters, not just package or component infos.

Both commands can take an extra values file and can return the output in json or yaml
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
