### PR TITLE
Add logic to try refreshing OIDC token in `login()`

### DIFF
--- a/commodore/config.py
+++ b/commodore/config.py
@@ -307,8 +307,8 @@ class Config:
                 r = requests.get(url_normalize(self.api_url))
                 api_cfg = json.loads(r.text)
                 if "oidc" in api_cfg:
-                    self.oidc_client = api_cfg["oidc"]["clientId"]
-                    self.oidc_discovery_url = api_cfg["oidc"]["discoveryUrl"]
+                    self.oidc_client = api_cfg["oidc"].get("clientId")
+                    self.oidc_discovery_url = api_cfg["oidc"].get("discoveryUrl")
             except (requests.RequestException, json.JSONDecodeError) as e:
                 # We do this on a best effort basis
                 click.echo(f" > Unable to auto-discover OIDC config: {e}")

--- a/commodore/config.py
+++ b/commodore/config.py
@@ -136,7 +136,8 @@ class Config:
     @property
     def api_token(self):
         if self._api_token is None and self.api_url:
-            token = tokencache.get(self.api_url)
+            tokens = tokencache.get(self.api_url)
+            token = tokens.get("id_token")
             if token is not None:
                 # We don't verify the signature, we just want to know if the token is expired
                 # lieutenant will decide if it's valid

--- a/commodore/config.py
+++ b/commodore/config.py
@@ -8,9 +8,11 @@ from enum import Enum
 from pathlib import Path as P
 from typing import Any, Iterable, Optional
 
-import jwt
-
 import click
+import jwt
+import requests
+
+from url_normalize import url_normalize
 
 from commodore.component import Component, component_parameters_key
 from .gitrepo import GitRepo
@@ -288,6 +290,27 @@ class Config:
                 if "deprecation_notice" in cmeta:
                     msg += f" {cmeta['deprecation_notice']}"
                 self.register_deprecation_notice(msg)
+
+    def discover_oidc_config(self) -> None:
+        """Check the configured Lieutenant API URL for OIDC client details, if no OIDC
+        client details are given on the command line.
+
+        Update the provided config object in place if the API provides OIDC client
+        details."""
+        if (
+            self.oidc_client is None
+            and self.oidc_discovery_url is None
+            and self.api_url is not None
+        ):
+            try:
+                r = requests.get(url_normalize(self.api_url))
+                api_cfg = json.loads(r.text)
+                if "oidc" in api_cfg:
+                    self.oidc_client = api_cfg["oidc"]["clientId"]
+                    self.oidc_discovery_url = api_cfg["oidc"]["discoveryUrl"]
+            except (requests.RequestException, json.JSONDecodeError) as e:
+                # We do this on a best effort basis
+                click.echo(f" > Unable to auto-discover OIDC config: {e}")
 
 
 def _component_is_aliasable(cluster_parameters: dict, component_name: str):

--- a/commodore/login.py
+++ b/commodore/login.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import sys
 import threading
+import time
 import webbrowser
 
 from functools import partial
@@ -13,6 +14,7 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from urllib.parse import urlparse, parse_qs
 
 import click
+import jwt
 import requests
 
 # pylint: disable=redefined-builtin
@@ -202,6 +204,58 @@ def get_idp_cfg(discovery_url: str) -> Any:
         return resp
 
 
+def refresh_tokens(
+    config: Config, client: WebApplicationClient, token_endpoint: str
+) -> bool:
+    """Try refreshing the access and id tokens using the current refresh token.
+
+    Tokens are fetched from the token cache based on the data in `config`. The new
+    tokens are written to the token cache.
+
+    Returns `True` if refreshing the token was successful."""
+    if config.api_url is None:
+        # We can't refresh tokens if we don't know the API URL to fetch the old tokens
+        # from the cache.
+        return False
+
+    tokens = tokencache.get(config.api_url)
+    refresh_token = tokens.get("refresh_token")
+    if refresh_token is None:
+        return False
+    # We don't verify the signature, we just want to know if the refresh token is
+    # expired.
+    try:
+        t = jwt.decode(
+            refresh_token, algorithms=["RS256"], options={"verify_signature": False}
+        )
+    except jwt.exceptions.InvalidTokenError:
+        # We can't parse the refresh token, notify caller that they need to request a
+        # fresh set of tokens.
+        return False
+
+    if "exp" in t and t["exp"] > time.time():
+        # Only try to refresh the tokens if the refresh token isn't expired yet.
+        token_url, headers, body = client.prepare_refresh_token_request(
+            token_url=token_endpoint,
+            refresh_token=refresh_token,
+            client_id=config.oidc_client,
+        )
+        try:
+            token_response = requests.post(token_url, headers=headers, data=body)
+            token_response.raise_for_status()
+        except (ConnectionError, HTTPError) as e:
+            click.echo(f" > Failed to refresh OIDC token with {e}")
+            return False
+
+        # If refresh request was successful, parse response and store new
+        # tokens in tokencache
+        new_tokens = client.parse_request_body_response(token_response.text)
+        tokencache.save(config.api_url, new_tokens)
+        return True
+
+    return False
+
+
 def login(config: Config):
     config.discover_oidc_config()
 
@@ -210,9 +264,18 @@ def login(config: Config):
     if config.oidc_discovery_url is None:
         raise click.ClickException("Required OIDC discovery URL not set")
 
+    if config.api_token:
+        # Short-circuit if we already have a valid API token
+        return
+
     client = WebApplicationClient(config.oidc_client)
     idp_cfg = get_idp_cfg(config.oidc_discovery_url)
+    if refresh_tokens(config, client, idp_cfg["token_endpoint"]):
+        # Short-circuit if refreshing the token was successful.
+        return
 
+    # Request new token through login flow if we weren't able to refresh the existing
+    # token.
     server = OIDCCallbackServer(client, idp_cfg["token_endpoint"], config.api_url)
     server.start()
 

--- a/commodore/tokencache.py
+++ b/commodore/tokencache.py
@@ -1,19 +1,25 @@
+from __future__ import annotations
+
 import json
 import os
 
 from pathlib import Path
-from typing import Optional
+from typing import Any
 
+import click
 from xdg.BaseDirectory import xdg_cache_home
 
 cache_name = Path(xdg_cache_home) / "commodore" / "token"
 
 
-def save(lieutenant: str, token: str):
+def save(lieutenant: str, token: dict[str, Any]):
     try:
         with open(cache_name, "r", encoding="utf-8") as f:
             cache = json.load(f)
     except (IOError, FileNotFoundError):
+        cache = {}
+    except json.JSONDecodeError:
+        click.secho(" > Dropping invalid JSON for token cache", fg="yellow")
         cache = {}
 
     cache[lieutenant] = token
@@ -23,10 +29,13 @@ def save(lieutenant: str, token: str):
         f.write(json.dumps(cache, indent=1))
 
 
-def get(lieutenant: str) -> Optional[str]:
+def get(lieutenant: str) -> dict[str, Any]:
     try:
         with open(cache_name, "r", encoding="utf-8") as f:
             cache = json.load(f)
-    except (IOError, FileNotFoundError):
-        return None
-    return cache.get(lieutenant)
+    except (IOError, FileNotFoundError, json.JSONDecodeError):
+        return {}
+    data = cache.get(lieutenant, {})
+    if isinstance(data, str):
+        data = {}
+    return data

--- a/docs/modules/ROOT/pages/reference/commands.adoc
+++ b/docs/modules/ROOT/pages/reference/commands.adoc
@@ -138,7 +138,10 @@ If any errors are found the command exits with return value 1.
 
 This command allows you to authenticate yourself to Lieutenant using OIDC, if OIDC integrations is enabled for your Lieutenant instance.
 
-The command will open a web-browser where you can authenticate yourself to the configured IdP.
+The command will try to refresh expired access tokens if a still valid refresh token is found locally.
+
+If no valid tokens are found locally, the command will open a web-browser where you can authenticate yourself to the configured IdP.
+
 Commodore will use the returned token for future commands if no other token is explicitly provided.
 
 == Fetch Token

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -203,13 +203,21 @@ def test_print_deprecation_notices(config, capsys):
 
 def mock_get_token(url: str) -> Optional[str]:
     if url == "https://syn.example.com":
-        return jwt.encode(
-            {"exp": time.time() + 100, "from_cache": True}, "secret", algorithm="HS256"
-        )
+        return {
+            "id_token": jwt.encode(
+                {"exp": time.time() + 100, "from_cache": True},
+                "secret",
+                algorithm="HS256",
+            )
+        }
     elif url == "https://expired.example.com":
-        return jwt.encode(
-            {"exp": time.time() - 100, "from_cache": True}, "secret", algorithm="HS256"
-        )
+        return {
+            "id_token": jwt.encode(
+                {"exp": time.time() - 100, "from_cache": True},
+                "secret",
+                algorithm="HS256",
+            )
+        }
 
     else:
         return None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,17 +1,17 @@
 from __future__ import annotations
 
+import json
 import time
-
-import pytest
 import textwrap
+
 from pathlib import Path as P
 
 from unittest.mock import patch
 from typing import Any, Iterable, Optional
 
-import jwt
-
 import click
+import jwt
+import pytest
 import responses
 
 from commodore.config import (

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -88,7 +88,7 @@ def test_login(mock_tokencache, mock_browser, config: Config, tmp_path):
 def mocked_login(expected_token):
     def mock(config: Config):
         with open(f"{xdg_cache_home}/commodore/token", "w") as f:
-            json.dump({config.api_url: expected_token}, f)
+            json.dump({config.api_url: {"id_token": expected_token}}, f)
 
     return mock
 
@@ -108,7 +108,7 @@ def test_fetch_token(mock_login, config: Config, tmp_path, fs, cached):
 
     expected_token = jwt.encode(expected_token_payload, "aaaaaa")
     if cached:
-        cache_contents = {config.api_url: expected_token}
+        cache_contents = {config.api_url: {"id_token": expected_token}}
 
     _setup_responses(config.api_url, auth_url, expected_token)
     fs.create_file(

--- a/tests/test_tokencache.py
+++ b/tests/test_tokencache.py
@@ -10,38 +10,76 @@ from commodore import tokencache
 def test_get_token(fs):
     fs.create_file(
         f"{xdg_cache_home}/commodore/token",
-        contents='{"https://syn.example.com":"token","https://syn2.example.com":"token2"}',
+        contents='{"https://syn.example.com":{"id_token": "thetoken"},'
+        + '"https://syn2.example.com":{"id_token": "token2"}}',
     )
-    assert tokencache.get("https://syn.example.com") == "token"
-    assert tokencache.get("https://syn2.example.com") == "token2"
+    assert tokencache.get("https://syn.example.com") == {"id_token": "thetoken"}
+    assert tokencache.get("https://syn2.example.com") == {"id_token": "token2"}
 
 
 def test_get_nonexistent_token(fs):
     fs.create_file(
         f"{xdg_cache_home}/commodore/token",
-        contents='{"https://syn.example.com":"token","https://syn2.example.com":"token2"}',
+        contents='{"https://syn.example.com":{"id_token":"token"},'
+        + '"https://syn2.example.com":{"id_token":"token2"}}',
     )
-    assert tokencache.get("https://syn3.example.com") is None
+    assert tokencache.get("https://syn3.example.com") == {}
+
+
+def test_ignore_broken_json_cache(fs):
+    fs.create_file(
+        f"{xdg_cache_home}/commodore/token",
+        contents='{"https://syn.example.com":{"id_token":"token"}',
+    )
+    assert tokencache.get("https://syn.example.com") == {}
 
 
 def test_save_token(fs):
-    tokencache.save("https://syn.example.com", "save")
-    tokencache.save("https://syn2.example.com", "save2")
+    tokencache.save("https://syn.example.com", {"id_token": "save"})
+    tokencache.save("https://syn2.example.com", {"id_token": "save2"})
 
     with open(f"{xdg_cache_home}/commodore/token") as f:
         cache = json.load(f)
         assert cache == {
-            "https://syn.example.com": "save",
-            "https://syn2.example.com": "save2",
+            "https://syn.example.com": {"id_token": "save"},
+            "https://syn2.example.com": {"id_token": "save2"},
         }
 
 
 def test_save_and_get_token(fs):
-    tokencache.save("https://syn.example.com", "token")
-    tokencache.save("https://syn2.example.com", "token2")
-    tokencache.save("https://syn3.example.com", "token3")
-    tokencache.save("https://syn2.example.com", "Foo")
+    tokencache.save("https://syn.example.com", {"id_token": "token"})
+    tokencache.save("https://syn2.example.com", {"id_token": "token2"})
+    tokencache.save("https://syn3.example.com", {"id_token": "token3"})
+    tokencache.save("https://syn2.example.com", {"id_token": "Foo"})
 
-    assert tokencache.get("https://syn.example.com") == "token"
-    assert tokencache.get("https://syn2.example.com") == "Foo"
-    assert tokencache.get("https://syn3.example.com") == "token3"
+    assert tokencache.get("https://syn.example.com") == {"id_token": "token"}
+    assert tokencache.get("https://syn2.example.com") == {"id_token": "Foo"}
+    assert tokencache.get("https://syn3.example.com") == {"id_token": "token3"}
+
+
+def test_drop_old_cache_entry(fs):
+    fs.create_file(
+        f"{xdg_cache_home}/commodore/token",
+        contents='{"https://syn.example.com":"thetoken",'
+        + '"https://syn2.example.com":{"id_token": "token2"}}',
+    )
+    assert tokencache.get("https://syn.example.com") == {}
+    assert tokencache.get("https://syn2.example.com") == {"id_token": "token2"}
+
+
+def test_update_broken_json_cache(fs):
+    cachef = fs.create_file(
+        f"{xdg_cache_home}/commodore/token",
+        contents='{"https://syn.example.com":{"id_token":"token"}',
+    )
+    tokencache.save("https://syn2.example.com", {"id_token": "token2"})
+    assert tokencache.get("https://syn2.example.com") == {"id_token": "token2"}
+    assert (
+        cachef.contents
+        == '{\n "https://syn2.example.com": {\n  "id_token": "token2"\n }\n}'
+    )
+
+    tokencache.save("https://syn.example.com", {"id_token": "token"})
+
+    assert tokencache.get("https://syn2.example.com") == {"id_token": "token2"}
+    assert tokencache.get("https://syn.example.com") == {"id_token": "token"}


### PR DESCRIPTION
We implement OIDC token refresh if our access token is expired, but we still have a valid refresh token in the tokencache for the current Lieutenant URL. If the token refresh succeeds, we short-circuit `login()` without performing a browser-based login.

If the token refresh fails for any reason, we fall back to browser-based login.

Closes #494 

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
