### PR TITLE
Remove reclass warnings from `commodore inventory show` output

### DIFF
--- a/commodore/cli.py
+++ b/commodore/cli.py
@@ -737,7 +737,11 @@ def inventory_show(
         inv = extract_parameters(
             config,
             InventoryFacts(
-                global_config, tenant_config, extra_values, allow_missing_classes
+                global_config,
+                tenant_config,
+                extra_values,
+                allow_missing_classes,
+                ignore_class_notfound_warning=False,
             ),
         )
     except ValueError as e:
@@ -776,7 +780,11 @@ def component_versions(
         components = extract_components(
             config,
             InventoryFacts(
-                global_config, tenant_config, extra_values, allow_missing_classes
+                global_config,
+                tenant_config,
+                extra_values,
+                allow_missing_classes,
+                ignore_class_notfound_warning=False,
             ),
         )
     except ValueError as e:
@@ -815,7 +823,11 @@ def package_versions(
         pkgs = extract_packages(
             config,
             InventoryFacts(
-                global_config, tenant_config, extra_values, allow_missing_classes
+                global_config,
+                tenant_config,
+                extra_values,
+                allow_missing_classes,
+                ignore_class_notfound_warning=False,
             ),
         )
     except ValueError as e:

--- a/commodore/inventory/parameters.py
+++ b/commodore/inventory/parameters.py
@@ -49,11 +49,13 @@ class InventoryFacts:
         tenant_config: Optional[str],
         extra_class_files: Iterable[Path],
         allow_missing_classes: bool,
+        ignore_class_notfound_warning: bool = True,
     ):
         self._global_config = global_config
         self._tenant_config = tenant_config
         self._extra_class_files = extra_class_files
         self._allow_missing_classes = allow_missing_classes
+        self._ignore_class_notfound_warning = ignore_class_notfound_warning
 
     @property
     def global_config(self) -> str:
@@ -74,6 +76,10 @@ class InventoryFacts:
     @property
     def allow_missing_classes(self) -> bool:
         return self._allow_missing_classes
+
+    @property
+    def ignore_class_notfound_warning(self) -> bool:
+        return self._ignore_class_notfound_warning
 
     @property
     def tenant_id(self) -> str:
@@ -170,7 +176,9 @@ class InventoryFactory:
     def tenant_dir(self) -> Optional[Path]:
         return self._tenant_dir
 
-    def _reclass_config(self, allow_missing_classes: bool) -> dict:
+    def _reclass_config(
+        self, allow_missing_classes: bool, ignore_class_notfound_warning: bool = True
+    ) -> dict:
         return {
             "storage_type": "yaml_fs",
             "inventory_base_uri": str(self.directory.absolute()),
@@ -179,12 +187,19 @@ class InventoryFactory:
             "compose_node_name": False,
             "allow_none_override": True,
             "ignore_class_notfound": allow_missing_classes,
+            "ignore_class_notfound_warning": ignore_class_notfound_warning,
         }
 
     def _render_inventory(
-        self, target: Optional[str] = None, allow_missing_classes: bool = True
+        self,
+        target: Optional[str] = None,
+        allow_missing_classes: bool = True,
+        ignore_class_notfound_warning: bool = True,
     ) -> dict[str, Any]:
-        rc = self._reclass_config(allow_missing_classes)
+        rc = self._reclass_config(
+            allow_missing_classes,
+            ignore_class_notfound_warning=ignore_class_notfound_warning,
+        )
         storage = reclass.get_storage(
             rc["storage_type"],
             rc["nodes_uri"],
@@ -266,7 +281,9 @@ class InventoryFactory:
 
         return InventoryParameters(
             self._render_inventory(
-                "global", allow_missing_classes=invfacts.allow_missing_classes
+                "global",
+                allow_missing_classes=invfacts.allow_missing_classes,
+                ignore_class_notfound_warning=invfacts.ignore_class_notfound_warning,
             )
         )
 

--- a/tests/test_cli_functions.py
+++ b/tests/test_cli_functions.py
@@ -149,7 +149,7 @@ def test_component_versions_cli(
         yaml.safe_dump({"classes": ["global.test"]}, f)
 
     with open(global_config / "test.yml", "w") as f:
-        yaml.safe_dump({"parameters": parameters}, f)
+        yaml.safe_dump({"classes": ["foo.bar"], "parameters": parameters}, f)
 
     result = cli_runner(["inventory", "components", str(global_config)] + args)
 
@@ -185,7 +185,7 @@ def test_package_versions_cli(
         yaml.safe_dump({"classes": ["global.test"]}, f)
 
     with open(global_config / "test.yml", "w") as f:
-        yaml.safe_dump({"parameters": parameters}, f)
+        yaml.safe_dump({"classes": ["foo.bar"], "parameters": parameters}, f)
 
     result = cli_runner(["inventory", "packages", str(global_config)] + args)
 
@@ -230,7 +230,7 @@ def test_show_inventory_cli(
         yaml.safe_dump({"classes": ["global.test"]}, f)
 
     with open(global_config / "test.yml", "w") as f:
-        yaml.safe_dump({"parameters": parameters}, f)
+        yaml.safe_dump({"classes": ["foo.bar"], "parameters": parameters}, f)
 
     result = cli_runner(["inventory", "show", str(global_config)] + args)
 


### PR DESCRIPTION
If we set `allow_missing_classes=True` reclass will not fail if a referenced class does not exist. However it will still print a warning to stdout. This results in invalid JSON/YAML output for `commodore inventory show|components|packages` as it will start with one or more log lines if a class is not found.

With this PR we explicitly disable reclass wanings when calling `commodore inventory show --allow-missing-classes`.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
