### PR TITLE
Pass `SSH_AUTH_SOCK` environment variable to tox-based tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,7 @@ commands = \
     bench: -m bench \
     !bench: -m "not bench and not integration" -n auto \
     {posargs}
+passenv = SSH_AUTH_SOCK
 
 [testenv:bandit]
 description = PyCQA security linter


### PR DESCRIPTION
This is necessary to allow the tests to use SSH keys stored in the agent when running tests locally.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
