### PR TITLE
Use each repo's default branch as the PR base branch for `package sync`

### DIFF
--- a/commodore/cli.py
+++ b/commodore/cli.py
@@ -726,7 +726,8 @@ def package_sync(
     The command clones each package and runs `package update` on the local copy. If
     there are any changes, the command creates a PR for the changes. For each package,
     the command parses the package's `.cruft.json` to determine the template repository
-    and template version for the package.
+    and template version for the package. The command bases each PR on the default
+    branch of the corresponding package repository as reported by the GitHub API.
 
     The command requires a GitHub Access token with the 'public_repo' permission, which
     is required to create PRs on public repositories. If you want to manage private

--- a/commodore/package/sync.py
+++ b/commodore/package/sync.py
@@ -53,7 +53,7 @@ def sync_packages(
         except github.UnknownObjectException:
             click.secho(f" > Repository {pn} doesn't exist, skipping...", fg="yellow")
             continue
-        p = Package.clone(config, gr.clone_url, pname, version="master")
+        p = Package.clone(config, gr.clone_url, pname, version=gr.default_branch)
 
         if not (p.target_dir / ".cruft.json").is_file():
             click.echo(f" > Skipping repo {pn} which doesn't have `.cruft.json`")
@@ -137,7 +137,7 @@ def ensure_pr(
             sync_pr = gr.create_pull(
                 "Update from package template",
                 pr_body,
-                "master",
+                gr.default_branch,
                 branch_name,
             )
         else:

--- a/docs/modules/ROOT/pages/reference/commands.adoc
+++ b/docs/modules/ROOT/pages/reference/commands.adoc
@@ -199,6 +199,7 @@ The command expects that the YAML file contains a single document with a list of
 The command clones each package and runs `package update` on the local copy.
 If there are any changes, the command creates a PR for the changes.
 For each package, the command parses the package's `.cruft.json` to determine the template repository and template version for the package.
+The command bases each PR on the default branch of the corresponding package repository as reported by the GitHub API.
 
 The command requires a GitHub Access token with the 'public_repo' permission, which is required to create PRs on public repositories.
 If you want to manage private repos, the access token may require additional permissions.


### PR DESCRIPTION
Follow-up for #572. Labeled as `ignore` since `package sync` has not been released yet.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
