### PR TITLE
Update suggested Commodore-in-Docker helpers

### DIFF
--- a/docs/modules/ROOT/pages/explanation/running-commodore.adoc
+++ b/docs/modules/ROOT/pages/explanation/running-commodore.adoc
@@ -124,12 +124,18 @@ commodore() {
     --volume "${HOME}/.ssh/known_hosts:/app/.ssh/known_hosts:ro" \
     --volume "${HOME}/.gitconfig:/app/.gitconfig:ro" \
     --volume "${HOME}/.cache:/app/.cache" \
-    --volume "${PWD}:/app/data" \
-    --workdir /app/data \
+    --volume "${PWD}:${PWD}" \
+    --workdir "${PWD}" \
     projectsyn/commodore:${COMMODORE_VERSION:=latest} \
     $*
 }
 ----
+
+[NOTE]
+====
+We mount the current working directory on the host (`${PWD}`) to the same directory in the container.
+This is necessary to ensure that commands such as `catalog compile` and `component new` create Git repository checkouts which work both in the container and on the host.
+====
 
 === macOS
 
@@ -167,12 +173,18 @@ commodore() {
     --volume "${HOME}/.ssh/known_hosts:/app/.ssh/known_hosts:ro" \
     --volume "${HOME}/.gitconfig:/app/.gitconfig:ro" \
     --volume "${HOME}/.cache:/app/.cache" \
-    --volume "${PWD}:/app/data" \
-    --workdir /app/data \
+    --volume "${PWD}:${PWD}" \
+    --workdir "${PWD}" \
     projectsyn/commodore:latest \
     $*
 }
 ----
+
+[NOTE]
+====
+We mount the current working directory on the host (`${PWD}`) to the same directory in the container.
+This is necessary to ensure that commands such as `catalog compile` and `component new` create Git repository checkouts which work both in the container and on the host.
+====
 
 Instead you can also mount your SSH key into the container.
 The container will pickup that key and add it do an SSH agent running inside the container.
@@ -192,8 +204,8 @@ commodore() {
     --volume "${HOME}/.ssh:/app/.ssh:ro" \
     --volume "${HOME}/.gitconfig:/app/.gitconfig:ro" \
     --volume "${HOME}/.cache:/app/.cache" \
-    --volume "${PWD}:/app/data" \
-    --workdir /app/data \
+    --volume "${PWD}:${PWD}" \
+    --workdir "${PWD}" \
     projectsyn/commodore:latest \
     $*
 }


### PR DESCRIPTION
We need to mount the host working directory into the same location in the container so that `git worktree` based checkouts of components and packages are valid both on the host and in the container.

This needs a identity-mapping of the working directory because Git uses the absolute path to the git directory when creating a worktree checkout.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
