### PR TITLE
Deprecate parameter `--repo-directory` for component compile

### DIFF
--- a/commodore/cli.py
+++ b/commodore/cli.py
@@ -415,9 +415,7 @@ def component_delete(config: Config, slug, force, verbose):
     default="",
     show_default=False,
     type=click.Path(file_okay=False, dir_okay=True),
-    help="Path to the root of the Git repo containing the component. "
-    + "The command assumes that the component is in the repo root, "
-    + "if this option is not provided.",
+    help="DEPRECATED.  This option has no effect anymore.",
 )
 @click.option(
     "-n",
@@ -442,9 +440,12 @@ def component_compile(
     verbose: int,
 ):
     config.update_verbosity(verbose)
-    compile_component(
-        config, path, alias, values, search_paths, output, repo_directory, name
-    )
+    if repo_directory:
+        click.secho(
+            " > Parameter `-r`/`--repo-directory` is deprecated and has no effect"
+        )
+
+    compile_component(config, path, alias, values, search_paths, output, name)
 
 
 @commodore.group(short_help="Interact with a Commodore config package")

--- a/docs/modules/ROOT/pages/reference/cli.adoc
+++ b/docs/modules/ROOT/pages/reference/cli.adoc
@@ -126,6 +126,10 @@ This command doesn't have any command line options.
   provide multiple files. Files specified later win when resolving inventory
   values.
 
+*-n, --name* NAME::
+  Provide component name to use when compiling.
+  By default, the component name is derived from the directory which is being compiled.
+
 *-a, --alias* ALIAS::
   Provide component alias to use when compiling component.
 

--- a/docs/modules/ROOT/pages/reference/commands.adoc
+++ b/docs/modules/ROOT/pages/reference/commands.adoc
@@ -68,18 +68,22 @@ The command also removes the deleted component as a dependency in `jsonnetfile.j
 
 This command compiles a single component.
 
-This is the main mode of operation for developing new components, as it allows
-fast iteration while working on a component.
+This is the main mode of operation for developing new components, as it allows fast iteration while working on a component.
 
-This command will create a fake inventory which mocks out all the
-infrastructure which a component would expect to be available when it's
-included in a cluster's configuration.
+This command will create a fake inventory which mocks out all the infrastructure which a component would expect to be available when it's included in a cluster's configuration.
 
-The command takes so called values files which provide custom configuration
-values for any configuration that could be provided from the hierarchical
-configuration repositories.
+The command takes so called values files which provide custom configuration values for any configuration that could be provided from the hierarchical configuration repositories.
+
+The command expects that the component is stored in a directory which matches the component's name.
+By default the component's name is derived from the leaf directory of `PATH`.
+This works reasonably well for components which are stored in the root of a Git repository, as generally component repositories are named `component-<name>`.
+If this isn't the case, the option `--name` (or `-n`) must be used to provide the component name to avoid compilation errors.
 
 The option `--alias` (or `-a`) can be used to compile an instance-aware component with a specific instance.
+
+The command tries to discover whether the provided `PATH` is part of a Git repository.
+If a Git repository is found the command computes the path's subpath in the repository, and ensures that the component is handled as a component stored in a repo subdirectory internally.
+If no Git repository is found, the provided path is treated as if it were the root of a Git repository.
 
 == Inventory Show
 

--- a/docs/modules/ROOT/pages/reference/deprecation-notices.adoc
+++ b/docs/modules/ROOT/pages/reference/deprecation-notices.adoc
@@ -3,6 +3,13 @@
 This page lists deprecations of Commodore features organized by version.
 We include a link to relevant documentation, if applicable.
 
+== https://github.com/projectsyn/commodore/releases/tag/v1.8.0[v1.8.0]
+
+=== Parameter `-r / --repo-directory` for `component compile` is deprecated
+
+We instead discover the component's Git repository by recursively searching for a git repository in the component's parent directories.
+When the parameter is provided, a deprecation notice is printed and the value of the parameter is discarded.
+
 == https://github.com/projectsyn/commodore/releases/tag/v1.0.0[v1.0.0]
 
 * Support for external postprocessing filter definitions is removed [<<_external_pp_filters,deprecated in v0.16.0>>].

--- a/tests/test_cli_functions.py
+++ b/tests/test_cli_functions.py
@@ -403,3 +403,34 @@ def test_package_sync_cli(
     result = cli_runner(["package", "sync", "pkgs.yaml"])
     print(result.stdout)
     assert result.exit_code == (1 if ghtoken is None else 0)
+
+
+@pytest.mark.parametrize("repo_dir", [False, True])
+@mock.patch.object(cli, "compile_component")
+def test_compile_component_cli(mock_compile, tmp_path, repo_dir, cli_runner):
+    cpath = tmp_path / "test-component"
+    cpath.mkdir()
+
+    def _compile(cfg, path, alias, values, search_paths, output, name):
+        assert cfg.verbose == 0
+        assert path == str(cpath)
+        assert values == ()
+        assert alias is None
+        assert search_paths == ()
+        assert output == "./"
+        assert name == ""
+
+    mock_compile.side_effect = _compile
+
+    repo_dir_arg = []
+    if repo_dir:
+        repo_dir_arg = ["-r", str(tmp_path)]
+    result = cli_runner(["component", "compile", str(cpath)] + repo_dir_arg)
+
+    assert result.exit_code == 0
+
+    if repo_dir:
+        assert (
+            result.stdout
+            == " > Parameter `-r`/`--repo-directory` is deprecated and has no effect\n"
+        )

--- a/tests/test_component_compile.py
+++ b/tests/test_component_compile.py
@@ -92,7 +92,7 @@ def _cli_command_string(
     p: P, component: str, instance: Optional[str] = None, subpath: Optional[str] = None
 ) -> str:
     if subpath:
-        cpath = f"'{p}/{component}/{subpath}' -r '{p}/{component}'"
+        cpath = f"'{p}/{component}/{subpath}' -n {component}"
     else:
         cpath = f"'{p}/dependencies/{component}'"
     cmd = f"commodore -d '{p}' component compile -o '{p}/testdir' {cpath}"
@@ -270,9 +270,7 @@ def test_component_compile_subpath(tmp_path):
 
 def test_no_component_compile_command(tmp_path):
     with pytest.raises(ClickException) as excinfo:
-        compile_component(
-            Config(tmp_path), tmp_path / "foo", None, [], [], "./", "", ""
-        )
+        compile_component(Config(tmp_path), tmp_path / "foo", None, [], [], "./", "")
     assert (
         f"Can't compile component, repository {tmp_path / 'foo'} doesn't exist"
         in str(excinfo)


### PR DESCRIPTION
We don't need users to provide the location of the repo directory in `component compile` since we strictly speaking don't need the component to even be in a Git repository for standalone compilation. We  use GitPython's `search_parent_directories=True` to try to find the repo in which the provided target dir is located, but fall back on just using the indicated target directory as the component directory for standalone compilation.

If we find a Git repository holding the component, we compute the component subpath based on the relative location of the target directory to the repo working tree directory. In this case, we use the working tree directory of the repo as the component "target directory" so that standalone compilation of a component stored in a repo subdirectory is as close as possible to compiling the component in a cluster catalog.

We don't remove the `--repo-directory` parameter, but print a deprecation warning when users provide it, and ignore the provided value in the implementation.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog


<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
