### PR TITLE
Ensure that there's no chance that test cases compete for ports

### DIFF
--- a/commodore/login.py
+++ b/commodore/login.py
@@ -40,6 +40,7 @@ class OIDCCallbackServer:
         client: WebApplicationClient,
         token_url: str,
         lieutenant_url: Optional[str],
+        port: int = 18000,
     ):
         self.client = client
         self.token_endpoint = token_url
@@ -49,7 +50,7 @@ class OIDCCallbackServer:
             OIDCCallbackHandler, client, token_url, lieutenant_url, self.done_queue
         )
 
-        self.server = HTTPServer(("", 18000), handler)
+        self.server = HTTPServer(("", port), handler)
         self.thread = threading.Thread(target=self.server.serve_forever)
         self.thread.daemon = True
 

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -375,16 +375,16 @@ def test_run_callback_server(config, tmp_path):
     config.oidc_client = "test-client"
     token_url = "https://idp.example.com/token"
     c = WebApplicationClient(config.oidc_client)
-    s = login.OIDCCallbackServer(c, token_url, config.api_url)
+    s = login.OIDCCallbackServer(c, token_url, config.api_url, 19000)
 
     s.start()
 
-    resp = requests.get("http://localhost:18000/healthz")
+    resp = requests.get("http://localhost:19000/healthz")
     assert resp.status_code == 200
     assert resp.text == "ok"
 
     # calls to /healthz don't close the server, so we make a second request
-    resp = requests.get("http://localhost:18000/?foo=bar")
+    resp = requests.get("http://localhost:19000/?foo=bar")
     assert resp.status_code == 422
     assert resp.text == "invalid callback: no code provided"
 


### PR DESCRIPTION
We added more tests for `login.py` a while ago. Those tests introduced a race condition between test cases as we have two different tests which try to bind to port 18000 to test the OIDC callback handler.

This commit makes the port configurable, and uses a different port for the callback handler unit tests.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
