### PR TITLE
Fix `Component.render_jsonnetfile_json()` when no repo detected

### DIFF
--- a/commodore/component/__init__.py
+++ b/commodore/component/__init__.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 import _jsonnet
 import click
+import git
 
 from commodore.gitrepo import GitRepo
 from commodore.multi_dependency import MultiDependency
@@ -148,12 +149,15 @@ class Component:
         jsonnetfile_jsonnet = self._dir / "jsonnetfile.jsonnet"
         jsonnetfile_json = self._dir / "jsonnetfile.json"
         if jsonnetfile_jsonnet.is_file():
-            if jsonnetfile_json.name in self.repo.repo.tree():
-                click.secho(
-                    f" > [WARN] Component {self.name} repo contains both jsonnetfile.json "
-                    + "and jsonnetfile.jsonnet, continuing with jsonnetfile.jsonnet",
-                    fg="yellow",
-                )
+            try:
+                if jsonnetfile_json.name in self.repo.repo.tree():
+                    click.secho(
+                        f" > [WARN] Component {self.name} repo contains both jsonnetfile.json "
+                        + "and jsonnetfile.jsonnet, continuing with jsonnetfile.jsonnet",
+                        fg="yellow",
+                    )
+            except git.InvalidGitRepositoryError:
+                pass
             # pylint: disable=c-extension-no-member
             output = _jsonnet.evaluate_file(
                 str(jsonnetfile_jsonnet),


### PR DESCRIPTION
We gracefully degrade in `render_jsonnetfile_json()` and don't print a warning if both `jsonnetfile.json` and `jsonnetfile.jsonnet` are present in the component directory, if we can't detect a Git repository for the component.

Follow-up to #582, labelled `ignore` since #582 isn't released yet.
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
