### PR TITLE
Hard-code component name in component template `Makefile.vars.mk`

### DIFF
--- a/commodore/component-template/{{ cookiecutter.slug }}/Makefile.vars.mk
+++ b/commodore/component-template/{{ cookiecutter.slug }}/Makefile.vars.mk
@@ -1,11 +1,11 @@
-# Commodore takes the root dir name as the component name
-COMPONENT_NAME ?= $(shell basename ${PWD} | sed s/component-//)
+# The component name is hard-coded from the template
+COMPONENT_NAME ?= {{ cookiecutter.slug }}
 
 git_dir         ?= $(shell git rev-parse --git-common-dir)
 compiled_path   ?= compiled/$(COMPONENT_NAME)/$(COMPONENT_NAME)
 root_volume     ?= -v "$${PWD}:/$(COMPONENT_NAME)"
 compiled_volume ?= -v "$${PWD}/$(compiled_path):/$(COMPONENT_NAME)"
-commodore_args  ?= --search-paths .
+commodore_args  ?= --search-paths . -n $(COMPONENT_NAME)
 
 ifneq "$(git_dir)" ".git"
 	git_volume        ?= -v "$(git_dir):$(git_dir):ro"


### PR DESCRIPTION
This should reduce the amount of patching required when setting up a component in a subdirectory from the template.

Modulesync PR: https://github.com/projectsyn/modulesync-control/pull/84

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
