### PR TITLE
Update Commodore-in-Docker to support GPG-signing commits on Linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,7 @@ FROM base AS runtime
 RUN apt-get update && apt-get install -y --no-install-recommends \
       curl \
       git \
+      gpg \
       libnss-wrapper \
       openssh-client \
  && rm -rf /var/lib/apt/lists/* \
@@ -67,7 +68,9 @@ RUN ln -s /usr/local/bin/helm3 /usr/local/bin/helm
 COPY ./tools/entrypoint.sh /usr/local/bin/
 
 RUN chgrp 0 /app/ \
- && chmod g+rwX /app/
+ && chmod g+rwX /app/ \
+ && mkdir /app/.gnupg \
+ && chmod ug+w /app/.gnupg
 
 USER 1001
 

--- a/docs/modules/ROOT/pages/explanation/running-commodore.adoc
+++ b/docs/modules/ROOT/pages/explanation/running-commodore.adoc
@@ -110,6 +110,13 @@ On Linux it's possible to use SSH agent and mounting the agents socket into the 
 [source,bash]
 ----
 commodore() {
+  local pubring="${HOME}/.gnupg/pubring.kbx"
+  if command -v gpgconf &>/dev/null && test -f "${pubring}"; then
+    gpg_opts=--volume="${pubring}:/app/.gnupg/pubring.kbx:ro"\ --volume="$(gpgconf --list-dir agent-extra-socket):/app/.gnupg/S.gpg-agent:ro"
+  else
+    gpg_opts=
+  fi
+
   docker run \
     --interactive=true \
     --tty \
@@ -124,6 +131,7 @@ commodore() {
     --volume "${HOME}/.ssh/known_hosts:/app/.ssh/known_hosts:ro" \
     --volume "${HOME}/.gitconfig:/app/.gitconfig:ro" \
     --volume "${HOME}/.cache:/app/.cache" \
+    ${gpg_opts} \
     --volume "${PWD}:${PWD}" \
     --workdir "${PWD}" \
     projectsyn/commodore:${COMMODORE_VERSION:=latest} \


### PR DESCRIPTION
We update the Commodore `Dockerfile` to install `gpg` and initialize the `~/.gnupg/` directory in the container. Additionally, we update the Commodore-in-Docker command for Linux to ensure that Git commits can be GPG-signed in the container when the user's `.gitconfig` contains `commit.gpgsign=true`. To allow this, we mount the user's `pubring.kbx` and the user's GPG `agent-extra-socket` in the container, if GPG is available and configured.

We check for availability by looking for the `gpgconf` command on the host system, and for configuration by looking for the user's
`pubring.kbx`.

Please note that the Commodore-in-Docker command for macOS doesn't provide out-of-the box support for GPG-signing commits in the container at this time.

Resolves #579 

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
