### PR TITLE
Fix dependency spec linting for dependencies in subpaths

### DIFF
--- a/commodore/inventory/lint_dependency_specification.py
+++ b/commodore/inventory/lint_dependency_specification.py
@@ -22,7 +22,7 @@ def lint_dependency_specification(
             )
             errcount += 1
 
-        unk_keys = set(dspec.keys()) - {"url", "version"}
+        unk_keys = set(dspec.keys()) - {"url", "version", "path"}
         if len(unk_keys) > 0:
             click.secho(
                 f"> {deptype_str} specification for {d} "

--- a/tests/test_inventory_lint_components.py
+++ b/tests/test_inventory_lint_components.py
@@ -31,6 +31,7 @@ LINT_FILECONTENTS = [
                     "c3": {
                         "url": "https://example.com/syn/component-c3.git",
                         "version": "v1.0.0",
+                        "path": "subpath",
                     },
                 },
             }


### PR DESCRIPTION
In Commodore v1.4, we introduced support for storing dependencies in subpaths of repositories. However, we didn't update the dependency specification linting to allow the new key `path` which is used to indicate the subpath.

This commit updates the dependency specification linting to allow key `path` in component and package specifications.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
