### PR TITLE
Add new command `component update`

### DIFF
--- a/commodore/cli.py
+++ b/commodore/cli.py
@@ -385,6 +385,80 @@ def component_new(
     f.create()
 
 
+@component.command(
+    name="update", short_help="Update an existing component from a template"
+)
+@click.argument(
+    "component_path", type=click.Path(exists=True, dir_okay=True, file_okay=False)
+)
+@click.option(
+    "--copyright",
+    "copyright_holder",
+    show_default=True,
+    help="Update the copyright holder in the license file.",
+)
+@click.option(
+    "--update-copyright-year/--no-update-copyright-year",
+    default=False,
+    show_default=True,
+    help="Update year in copyright notice.",
+)
+@click.option(
+    "--golden-tests/--no-golden-tests",
+    default=None,
+    show_default=True,
+    help="Add or remove golden tests.",
+)
+@click.option(
+    "--matrix-tests/--no-matrix-tests",
+    default=None,
+    show_default=True,
+    help="Add or remove matrix tests.",
+)
+@click.option(
+    "--lib/--no-lib",
+    default=None,
+    show_default=True,
+    help="Add or remove the component library.",
+)
+@click.option(
+    "--pp/--no-pp",
+    default=None,
+    show_default=True,
+    help="Add or remove the postprocessing filter configuration.",
+)
+@verbosity
+@pass_config
+def component_update(
+    config: Config,
+    verbose: int,
+    component_path: str,
+    copyright_holder: str,
+    golden_tests: Optional[bool],
+    matrix_tests: Optional[bool],
+    lib: Optional[bool],
+    pp: Optional[bool],
+    update_copyright_year: bool,
+):
+    config.update_verbosity(verbose)
+
+    t = ComponentTemplater.from_existing(config, Path(component_path))
+    if copyright_holder:
+        t.copyright_holder = copyright_holder
+    if update_copyright_year:
+        t.copyright_year = None
+    if golden_tests is not None:
+        t.golden_tests = golden_tests
+    if matrix_tests is not None:
+        t.matrix_tests = matrix_tests
+    if lib is not None:
+        t.library = lib
+    if pp is not None:
+        t.post_process = pp
+
+    t.update()
+
+
 @component.command(name="delete", short_help="Remove component from inventory.")
 @click.argument("slug")
 @click.option(

--- a/commodore/cli.py
+++ b/commodore/cli.py
@@ -440,6 +440,13 @@ def component_update(
     pp: Optional[bool],
     update_copyright_year: bool,
 ):
+    """This command updates the component at COMPONENT_PATH to the latest version of the
+    template which was originally used to create it, if the template version is given as
+    a Git branch.
+
+    The command can also add or remove component features, based on the provided command
+    line options.
+    """
     config.update_verbosity(verbose)
 
     t = ComponentTemplater.from_existing(config, Path(component_path))

--- a/commodore/component/template.py
+++ b/commodore/component/template.py
@@ -28,7 +28,6 @@ class ComponentTemplater(Templater):
             "github_owner": self.github_owner,
             "name": self.name,
             "slug": self.slug,
-            "release_date": self.today.strftime("%Y-%m-%d"),
         }
 
     @property

--- a/commodore/component/template.py
+++ b/commodore/component/template.py
@@ -6,6 +6,7 @@ from shutil import rmtree
 import click
 import git
 
+from commodore.config import Config
 from commodore.component import Component, component_dir
 from commodore.dependency_templater import Templater
 from commodore.multi_dependency import MultiDependency
@@ -15,6 +16,16 @@ class ComponentTemplater(Templater):
     library: bool
     post_process: bool
     matrix_tests: bool
+
+    @classmethod
+    def from_existing(cls, config: Config, path: Path):
+        return cls._base_from_existing(config, path, "component")
+
+    def _initialize_from_cookiecutter_args(self, cookiecutter_args: dict[str, str]):
+        super()._initialize_from_cookiecutter_args(cookiecutter_args)
+        self.library = cookiecutter_args["add_lib"] == "y"
+        self.post_process = cookiecutter_args["add_pp"] == "y"
+        self.matrix_tests = cookiecutter_args["add_matrix"] == "y"
 
     @property
     def cookiecutter_args(self) -> dict[str, str]:

--- a/commodore/component/template.py
+++ b/commodore/component/template.py
@@ -29,21 +29,11 @@ class ComponentTemplater(Templater):
 
     @property
     def cookiecutter_args(self) -> dict[str, str]:
-        return {
-            "add_lib": "y" if self.library else "n",
-            "add_pp": "y" if self.post_process else "n",
-            "add_golden": "y" if self.golden_tests else "n",
-            "add_matrix": "y" if self.matrix_tests else "n",
-            "copyright_holder": self.copyright_holder,
-            "copyright_year": (
-                self.today.strftime("%Y")
-                if not self.copyright_year
-                else self.copyright_year
-            ),
-            "github_owner": self.github_owner,
-            "name": self.name,
-            "slug": self.slug,
-        }
+        args = super().cookiecutter_args
+        args["add_lib"] = "y" if self.library else "n"
+        args["add_pp"] = "y" if self.post_process else "n"
+        args["add_matrix"] = "y" if self.matrix_tests else "n"
+        return args
 
     @property
     def deptype(self) -> str:

--- a/commodore/component/template.py
+++ b/commodore/component/template.py
@@ -31,14 +31,11 @@ class ComponentTemplater(Templater):
         }
 
     @property
-    def target_dir(self) -> Path:
-        if self.output_dir:
-            return self.output_dir / self.slug
-        return component_dir(self.config.work_dir, self.slug)
-
-    @property
     def deptype(self) -> str:
         return "component"
+
+    def dependency_dir(self) -> Path:
+        return component_dir(self.config.work_dir, self.slug)
 
     def delete(self):
         cdir = component_dir(self.config.work_dir, self.slug)

--- a/commodore/component/template.py
+++ b/commodore/component/template.py
@@ -35,7 +35,11 @@ class ComponentTemplater(Templater):
             "add_golden": "y" if self.golden_tests else "n",
             "add_matrix": "y" if self.matrix_tests else "n",
             "copyright_holder": self.copyright_holder,
-            "copyright_year": self.today.strftime("%Y"),
+            "copyright_year": (
+                self.today.strftime("%Y")
+                if not self.copyright_year
+                else self.copyright_year
+            ),
             "github_owner": self.github_owner,
             "name": self.name,
             "slug": self.slug,

--- a/commodore/dependency_templater.py
+++ b/commodore/dependency_templater.py
@@ -30,6 +30,7 @@ class Templater(ABC):
     golden_tests: bool
     today: datetime.date
     output_dir: Optional[Path] = None
+    _target_dir: Optional[Path] = None
     template_url: str
     template_version: Optional[str] = None
 
@@ -66,16 +67,28 @@ class Templater(ABC):
 
     @property
     @abstractmethod
-    def target_dir(self) -> Path:
-        """Return Path indicating where to render the template to."""
-
-    @property
-    @abstractmethod
     def cookiecutter_args(self) -> dict[str, str]:
         """Cookiecutter template inputs.
 
         Passed to the rendering function as `extra_context`
         """
+
+    @abstractmethod
+    def dependency_dir(self) -> Path:
+        """Location of dependency in the Commodore working directory.
+
+        Used by `target_dir()` if neither `_target_dir` nor `_output_dir` is set."""
+
+    @property
+    def target_dir(self) -> Path:
+        """Return Path indicating where to render the template to."""
+        if self._target_dir:
+            return self._target_dir
+
+        if self.output_dir:
+            return self.output_dir / self.slug
+
+        return self.dependency_dir()
 
     def _validate_slug(self, value: str) -> str:
         if value.startswith(f"{self.deptype}-"):

--- a/commodore/dependency_templater.py
+++ b/commodore/dependency_templater.py
@@ -91,14 +91,6 @@ class Templater(ABC):
         prefixed with the value of this property.
         """
 
-    @property
-    @abstractmethod
-    def cookiecutter_args(self) -> dict[str, str]:
-        """Cookiecutter template inputs.
-
-        Passed to the rendering function as `extra_context`
-        """
-
     @abstractmethod
     def dependency_dir(self) -> Path:
         """Location of dependency in the Commodore working directory.
@@ -115,6 +107,25 @@ class Templater(ABC):
             return self.output_dir / self.slug
 
         return self.dependency_dir()
+
+    @property
+    def cookiecutter_args(self) -> dict[str, str]:
+        """Cookiecutter template inputs.
+
+        Passed to the rendering function as `extra_context`
+        """
+        return {
+            "add_golden": "y" if self.golden_tests else "n",
+            "copyright_holder": self.copyright_holder,
+            "copyright_year": (
+                self.today.strftime("%Y")
+                if not self.copyright_year
+                else self.copyright_year
+            ),
+            "github_owner": self.github_owner,
+            "name": self.name,
+            "slug": self.slug,
+        }
 
     def _initialize_from_cookiecutter_args(self, cookiecutter_args: dict[str, str]):
         self.golden_tests = cookiecutter_args["add_golden"] == "y"

--- a/commodore/dependency_templater.py
+++ b/commodore/dependency_templater.py
@@ -14,7 +14,7 @@ from typing import Optional, Sequence
 import click
 
 from commodore.config import Config
-from commodore.cruft import create as cruft_create
+from commodore.cruft import create as cruft_create, update as cruft_update
 from commodore.gitrepo import GitRepo
 from commodore.multi_dependency import MultiDependency
 
@@ -207,6 +207,36 @@ class Templater(ABC):
         click.secho(
             f"{self.deptype.capitalize()} {self.name} successfully added 🎉", bold=True
         )
+
+    def update(self, print_completion_message: bool = True) -> bool:
+        cruft_update(
+            self.target_dir,
+            cookiecutter_input=False,
+            checkout=self.template_version,
+            extra_context=self.cookiecutter_args,
+        )
+
+        commit_msg = (
+            f"Update from template\n\nTemplate version: {self.template_version}"
+        )
+        if self.template_commit:
+            commit_msg += f" ({self.template_commit[:7]})"
+
+        updated = self.commit(commit_msg, init=False)
+
+        if print_completion_message:
+            if updated:
+                click.secho(
+                    f"{self.deptype.capitalize()} {self.name} successfully updated 🎉",
+                    bold=True,
+                )
+            else:
+                click.secho(
+                    f"{self.deptype.capitalize()} {self.name} already up-to-date 🎉",
+                    bold=True,
+                )
+
+        return updated
 
     def commit(self, msg: str, amend=False, init=True) -> bool:
         # If we're amending an existing commit, we don't want to force initialize the

--- a/commodore/package/template.py
+++ b/commodore/package/template.py
@@ -13,7 +13,6 @@ from commodore.dependency_templater import Templater
 from commodore.package import package_dependency_dir
 
 
-# pylint: disable=too-many-instance-attributes
 class PackageTemplater(Templater):
     _test_cases: list[str] = ["defaults"]
 

--- a/commodore/package/template.py
+++ b/commodore/package/template.py
@@ -102,14 +102,7 @@ class PackageTemplater(Templater):
     def deptype(self) -> str:
         return "package"
 
-    @property
-    def target_dir(self) -> Path:
-        if self._target_dir:
-            return self._target_dir
-
-        if self.output_dir:
-            return self.output_dir / self.slug
-
+    def dependency_dir(self) -> Path:
         return package_dependency_dir(self.config.work_dir, self.slug)
 
     def update(self, print_completion_message: bool = True) -> bool:

--- a/commodore/package/template.py
+++ b/commodore/package/template.py
@@ -5,7 +5,6 @@ from pathlib import Path
 import click
 
 from commodore.config import Config
-from commodore.cruft._commands import update as cruft_update
 from commodore.dependency_mgmt.discovery import (
     RESERVED_PACKAGE_PATTERN,
     TENANT_PREFIX_PATTERN,
@@ -81,33 +80,3 @@ class PackageTemplater(Templater):
 
     def dependency_dir(self) -> Path:
         return package_dependency_dir(self.config.work_dir, self.slug)
-
-    def update(self, print_completion_message: bool = True) -> bool:
-        cruft_update(
-            self.target_dir,
-            cookiecutter_input=False,
-            checkout=self.template_version,
-            extra_context=self.cookiecutter_args,
-        )
-
-        commit_msg = (
-            f"Update from template\n\nTemplate version: {self.template_version}"
-        )
-        if self.template_commit:
-            commit_msg += f" ({self.template_commit[:7]})"
-
-        updated = self.commit(commit_msg, init=False)
-
-        if print_completion_message:
-            if updated:
-                click.secho(
-                    f"{self.deptype.capitalize()} {self.name} successfully updated 🎉",
-                    bold=True,
-                )
-            else:
-                click.secho(
-                    f"{self.deptype.capitalize()} {self.name} already up-to-date 🎉",
-                    bold=True,
-                )
-
-        return updated

--- a/commodore/package/template.py
+++ b/commodore/package/template.py
@@ -57,21 +57,10 @@ class PackageTemplater(Templater):
 
     @property
     def cookiecutter_args(self) -> dict[str, str]:
-        return {
-            "add_golden": "y" if self.golden_tests else "n",
-            "copyright_holder": self.copyright_holder,
-            "copyright_year": (
-                self.today.strftime("%Y")
-                if not self.copyright_year
-                else self.copyright_year
-            ),
-            "github_owner": self.github_owner,
-            "name": self.name,
-            "slug": self.slug,
-            # The template expects the test cases in a single string separated by
-            # spaces.
-            "test_cases": " ".join(self.test_cases),
-        }
+        args = super().cookiecutter_args
+        # The template expects the test cases in a single string separated by spaces.
+        args["test_cases"] = " ".join(self.test_cases)
+        return args
 
     @property
     def deptype(self) -> str:

--- a/commodore/package/template.py
+++ b/commodore/package/template.py
@@ -1,12 +1,8 @@
 from __future__ import annotations
 
-import json
-
 from pathlib import Path
-from typing import Optional
 
 import click
-
 
 from commodore.config import Config
 from commodore.cruft._commands import update as cruft_update
@@ -21,34 +17,15 @@ from commodore.package import package_dependency_dir
 # pylint: disable=too-many-instance-attributes
 class PackageTemplater(Templater):
     _test_cases: list[str] = ["defaults"]
-    copyright_year: Optional[str] = None
-    _target_dir: Optional[Path] = None
 
     @classmethod
-    def from_existing(cls, config: Config, package_path: Path):
-        if not package_path.is_dir():
-            raise click.ClickException("Provided package path isn't a directory")
-        with open(package_path / ".cruft.json", encoding="utf-8") as cfg:
-            cruft_json = json.load(cfg)
+    def from_existing(cls, config: Config, path: Path):
+        return cls._base_from_existing(config, path, "package")
 
-        cookiecutter_args = cruft_json["context"]["cookiecutter"]
-        t = PackageTemplater(
-            config,
-            cruft_json["template"],
-            cruft_json.get("checkout"),
-            cookiecutter_args["slug"],
-            name=cookiecutter_args["name"],
-        )
-        t._target_dir = package_path
-        t.output_dir = package_path.absolute().parent
-
+    def _initialize_from_cookiecutter_args(self, cookiecutter_args: dict[str, str]):
+        super()._initialize_from_cookiecutter_args(cookiecutter_args)
         if "test_cases" in cookiecutter_args:
-            t.test_cases = cookiecutter_args["test_cases"].split(" ")
-        t.golden_tests = cookiecutter_args["add_golden"] == "y"
-        t.github_owner = cookiecutter_args["github_owner"]
-        t.copyright_holder = cookiecutter_args["copyright_holder"]
-        t.copyright_year = cookiecutter_args["copyright_year"]
-        return t
+            self.test_cases = cookiecutter_args["test_cases"].split(" ")
 
     @property
     def test_cases(self) -> list[str]:

--- a/docs/modules/ROOT/pages/reference/cli.adoc
+++ b/docs/modules/ROOT/pages/reference/cli.adoc
@@ -181,6 +181,41 @@ This command doesn't have any command line options.
 *--help*::
   Show component new usage and options then exit.
 
+== Component Update
+
+*--lib / --no-lib*::
+  Add or remove the component library template.
+  When neither is provided, the command will reuse the previous value for the flag.
+  Defaults to _unset_.
+
+*--pp / --no-pp*::
+  Add or remove the component postprocessing config.
+  When neither is provided, the command will reuse the previous value for the flag.
+   Defaults to _unset_.
+
+*--golden-tests / --no-golden-tests*::
+  Enable or disable golden tests for the component.
+  When neither is provided, the command will reuse the previous value for the flag.
+  Defaults to _unset_.
+
+*--matrix-tests / --no-matrix-tests*::
+  Enable test matrix for the component compile and golden tests.
+  When neither is provided, the command will reuse the previous value for the flag.
+  Defaults to _unset_.
+
+*--copyright* TEXT::
+  Update the copyright holder in the license file.
+  When this flag isn't provided the copyright holder is left unchanged.
+  Defaults to _unset_.
+
+*--update-copyright-year / --no-update-copyright-year*::
+  Update the year in the copyright notice to the current year.
+  Defaults to _false_.
+
+*--help*::
+  Show component new usage and options then exit.
+
+
 == Inventory Components / Packages / Show
 
 *-f, --values*::

--- a/docs/modules/ROOT/pages/reference/commands.adoc
+++ b/docs/modules/ROOT/pages/reference/commands.adoc
@@ -49,6 +49,15 @@ If argument `--output-dir` isn't given, the command expects to run in a director
 
 The template also provides many meta-files in the component repository, such as the readme and changelog, standardized license, contributing and code of conduct files, a documentation template, and GitHub issue templates and actions configuration.
 
+== Component Update
+
+  commodore component update PATH
+
+This command updates an existing component repository stored in `PATH`.
+The command will always update the component to the latest version of the template which was originally used to create the component.
+The command has a number of command line options to enable or disable component features, such as golden tests.
+
+
 == Component Delete
 
   commodore component delete COMPONENT_NAME

--- a/tests/test_component_template.py
+++ b/tests/test_component_template.py
@@ -15,6 +15,7 @@ from test_component import setup_directory
 
 def call_component_new(
     tmp_path: P,
+    cli_runner: RunnerFunc,
     component_name="test-component",
     lib="--no-lib",
     pp="--no-pp",
@@ -22,14 +23,12 @@ def call_component_new(
     matrix="--no-matrix-tests",
     output_dir="",
 ):
+    args = ["-d", str(tmp_path), "component", "new"]
     if output_dir:
-        output_dir = f"--output-dir {output_dir}"
-    exit_status = call(
-        f"commodore -d '{tmp_path}' -vvv component new {component_name} "
-        + f"{lib} {pp} {golden} {matrix} {output_dir}",
-        shell=True,
-    )
-    assert exit_status == 0
+        args.extend(["--output-dir", str(output_dir)])
+    args.extend([component_name, lib, pp, golden, matrix])
+    result = cli_runner(args)
+    assert result.exit_code == 0
 
 
 @pytest.mark.parametrize("lib", ["--no-lib", "--lib"])
@@ -46,7 +45,7 @@ def call_component_new(
     ["--no-matrix-tests", "--matrix-tests"],
 )
 def test_run_component_new_command(
-    tmp_path: P, lib: str, pp: str, golden: str, matrix: str
+    tmp_path: P, cli_runner: RunnerFunc, lib: str, pp: str, golden: str, matrix: str
 ):
     """
     Run the component new command
@@ -57,6 +56,7 @@ def test_run_component_new_command(
     component_name = "test-component"
     call_component_new(
         tmp_path,
+        cli_runner,
         component_name=component_name,
         lib=lib,
         pp=pp,
@@ -187,14 +187,14 @@ def test_run_component_new_command(
             assert cmd == expected_cmd[matrix]
 
 
-def test_run_component_new_command_with_output_dir(tmp_path: P):
+def test_run_component_new_command_with_output_dir(tmp_path: P, cli_runner: RunnerFunc):
     """Verify that rendered component is put into specified output directory.
 
     This test doesn't validate the contents of the rendered files, that part is covered
     in `test_run_component_new_command()`."""
     component_name = "test-component"
     call_component_new(
-        tmp_path, component_name=component_name, output_dir=str(tmp_path)
+        tmp_path, cli_runner, component_name=component_name, output_dir=str(tmp_path)
     )
 
     assert (tmp_path / component_name).is_dir()

--- a/tests/test_component_template.py
+++ b/tests/test_component_template.py
@@ -460,3 +460,19 @@ def test_component_update_copyright_year(tmp_path: P, cli_runner: RunnerFunc):
         lines = lic.readlines()
         year = date.today().year
         assert lines[0] == f"Copyright {year}, VSHN AG <info@vshn.ch>\n"
+
+
+def test_component_update_no_cruft_json(tmp_path: P, cli_runner: RunnerFunc):
+    component_name = "test-component"
+    call_component_new(tmp_path, cli_runner, component_name)
+
+    component_path = tmp_path / "dependencies" / component_name
+    cruftjson_file = component_path / ".cruft.json"
+    cruftjson_file.unlink()
+
+    result = cli_runner(["component", "update", str(component_path)])
+    assert result.exit_code == 1
+    assert (
+        result.stdout
+        == "Error: Provided component path doesn't have `.cruft.json`, can't update.\n"
+    )

--- a/tests/test_package_compile.py
+++ b/tests/test_package_compile.py
@@ -17,7 +17,7 @@ from commodore.helpers import yaml_dump, yaml_load
 from commodore.package import compile
 from test_component_compile import _prepare_component, _add_postprocessing_filter
 
-from conftest import MockMultiDependency
+from conftest import MockMultiDependency, RunnerFunc
 
 
 def test_setup_package_inventory(tmp_path: Path, config: Config):
@@ -101,6 +101,7 @@ def test_compile_package(
     mock_mkdtemp: mock.MagicMock,
     mock_fetch: mock.MagicMock,
     tmp_path: Path,
+    cli_runner: RunnerFunc,
     config: Config,
     pp_filter: bool,
     package_ns: Optional[str],
@@ -125,7 +126,7 @@ def test_compile_package(
 
     config.local = local
     pkg_path = _setup_package(tmp_path, package_ns)
-    _prepare_component(compile_dir)
+    _prepare_component(compile_dir, cli_runner)
     if pp_filter:
         _add_postprocessing_filter(compile_dir)
 

--- a/tests/test_package_sync.py
+++ b/tests/test_package_sync.py
@@ -21,7 +21,6 @@ from commodore.config import Config
 from commodore.gitrepo import GitRepo
 from commodore.package import Package
 from commodore.package import sync
-from commodore.package.template import PackageTemplater
 
 DATA_DIR = Path(__file__).parent.absolute() / "testdata" / "github"
 
@@ -291,29 +290,6 @@ def test_sync_packages_package_list_parsing(
         )
 
 
-def make_mock_package_templater(remote_url: str):
-    """Create a Mock package templater class which overrides property `repo_url` with
-    the provided remote_url string.
-
-    Use as follows:
-
-        with patch(
-            "commodore.package.template.PackageTemplater",
-            new_callable=lambda: make_mock_package_templater("file://path/to/remote.git",
-        ):
-            function_under_test()
-    """
-
-    class MockPkgTemplater(PackageTemplater):
-        fake_url = remote_url
-
-        @property
-        def repo_url(self) -> str:
-            return self.fake_url
-
-    return MockPkgTemplater
-
-
 @pytest.mark.parametrize(
     "dry_run,second_pkg,needs_update",
     [
@@ -385,8 +361,8 @@ def test_sync_packages(
     pkg_list = create_pkg_list(tmp_path, additional_packages=add_pkgs)
 
     with patch(
-        "commodore.package.template.PackageTemplater",
-        new_callable=lambda: make_mock_package_templater(remote_url),
+        "commodore.dependency_templater.Templater.repo_url",
+        new_callable=lambda: remote_url,
     ):
         sync.sync_packages(
             config, pkg_list, dry_run, "template-sync", ["template-sync"]

--- a/tests/test_postprocess.py
+++ b/tests/test_postprocess.py
@@ -202,9 +202,9 @@ def _expected_ns(enabled):
     ],
 )
 def test_postprocess_components(
-    tmp_path, capsys, enabled, jsonnet, alias, create_namespace
+    tmp_path, cli_runner, capsys, enabled, jsonnet, alias, create_namespace
 ):
-    call_component_new(tmp_path=tmp_path)
+    call_component_new(tmp_path, cli_runner)
 
     f = _make_ns_filter(
         tmp_path,
@@ -274,9 +274,9 @@ def test_postprocess_components(
     ],
 )
 def test_postprocess_invalid_jsonnet_filter(
-    capsys, tmp_path, error: str, expected: str
+    capsys, tmp_path, cli_runner, error: str, expected: str
 ):
-    call_component_new(tmp_path=tmp_path)
+    call_component_new(tmp_path, cli_runner)
 
     f = _make_jsonnet_filter(tmp_path, "override")
     filtername = f["filters"][0]["filter"]
@@ -331,9 +331,9 @@ def test_postprocess_invalid_jsonnet_filter(
     ],
 )
 def test_postprocess_invalid_builtin_filter(
-    capsys, tmp_path, filtername: str, error: str, expected: str
+    capsys, tmp_path, cli_runner, filtername: str, error: str, expected: str
 ):
-    call_component_new(tmp_path=tmp_path)
+    call_component_new(tmp_path, cli_runner)
 
     f = _make_builtin_filter("myns")
     f["filters"][0]["filter"] = filtername


### PR DESCRIPTION
Currently the command supports enabling or disabling golden tests, matrix tests, the component library and component postprocessing filters.

We'll add support for managing test cases in a follow-up change.

The PR also reorganizes a lot of the template rendering code, moving code which is now useful for both components and packages to the `Templater` base class.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
