### PR TITLE
Correctly pass Git author name and email in `catalog compile`

### DIFF
--- a/commodore/compile.py
+++ b/commodore/compile.py
@@ -63,7 +63,12 @@ def check_removed_reclass_variables_components(config: Config):
 
 def _fetch_global_config(cfg: Config, cluster: Cluster):
     click.secho("Updating global config...", bold=True)
-    repo = GitRepo(cluster.global_git_repo_url, cfg.inventory.global_config_dir)
+    repo = GitRepo(
+        cluster.global_git_repo_url,
+        cfg.inventory.global_config_dir,
+        author_name=cfg.username,
+        author_email=cfg.usermail,
+    )
     rev = cluster.global_git_repo_revision
     if cfg.global_repo_revision_override:
         rev = cfg.global_repo_revision_override
@@ -76,7 +81,12 @@ def _fetch_customer_config(cfg: Config, cluster: Cluster):
     repo_url = cluster.config_repo_url
     if cfg.debug:
         click.echo(f" > Cloning customer config {repo_url}")
-    repo = GitRepo(repo_url, cfg.inventory.tenant_config_dir(cluster.tenant_id))
+    repo = GitRepo(
+        repo_url,
+        cfg.inventory.tenant_config_dir(cluster.tenant_id),
+        author_name=cfg.username,
+        author_email=cfg.usermail,
+    )
     rev = cluster.config_git_repo_revision
     if cfg.tenant_repo_revision_override:
         rev = cfg.tenant_repo_revision_override
@@ -137,9 +147,23 @@ def _local_setup(config: Config, cluster_id):
         raise click.ClickException(error)
 
     click.secho("Registering config...", bold=True)
-    config.register_config("global", GitRepo(None, config.inventory.global_config_dir))
     config.register_config(
-        "customer", GitRepo(None, config.inventory.tenant_config_dir(tenant))
+        "global",
+        GitRepo(
+            None,
+            config.inventory.global_config_dir,
+            author_name=config.username,
+            author_email=config.usermail,
+        ),
+    )
+    config.register_config(
+        "customer",
+        GitRepo(
+            None,
+            config.inventory.tenant_config_dir(tenant),
+            author_name=config.username,
+            author_email=config.usermail,
+        ),
     )
 
     check_removed_reclass_variables_inventory(config, tenant)
@@ -162,7 +186,12 @@ def _local_setup(config: Config, cluster_id):
     update_target(config, config.inventory.bootstrap_target)
 
     click.secho("Configuring catalog repo...", bold=True)
-    return GitRepo(None, config.catalog_dir)
+    return GitRepo(
+        None,
+        config.catalog_dir,
+        author_name=config.username,
+        author_email=config.usermail,
+    )
 
 
 def check_parameters_component_versions(cluster_parameters):


### PR DESCRIPTION
Previously, we didn't pass the provided Git author name and email when cloning the global and tenant repo in `catalog compile`. This can cause unexpected errors on setups where GitPython can't infer user information from either the Git config file or the UID of the process (e.g. GitLab CI runners in K8s pods).

This change ensures that we pass provided Git author information when creating GitRepo objects for the global and tenant repos. This should ensure that there's no errors if `GIT_AUTHOR_NAME` and `GIT_AUTHOR_MAIL` are set for environments which don't have sufficient information for GitPython's author information fallback mechanism.

Replacement for #597 which got closed accidentally
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
