### PR TITLE
Add option to create additional test cases for `component new`

### DIFF
--- a/commodore/cli.py
+++ b/commodore/cli.py
@@ -354,35 +354,48 @@ def component(config: Config, verbose):
     show_default=True,
     help="The component template version (Git tree-ish) to use.",
 )
+@click.option(
+    "--additional-test-case",
+    "-t",
+    metavar="CASE",
+    default=[],
+    show_default=True,
+    multiple=True,
+    help="Additional test cases to generate in the new component. Can be repeated. "
+    + "Test case `defaults` will always be generated."
+    + "Commodore will deduplicate test cases by name.",
+)
 @verbosity
 @pass_config
 # pylint: disable=too-many-arguments
 def component_new(
     config: Config,
-    slug,
-    name,
-    lib,
-    pp,
-    owner,
-    copyright_holder,
-    golden_tests,
-    matrix_tests,
-    verbose,
-    output_dir,
-    template_url,
-    template_version,
+    slug: str,
+    name: str,
+    lib: bool,
+    pp: bool,
+    owner: str,
+    copyright_holder: str,
+    golden_tests: bool,
+    matrix_tests: bool,
+    verbose: int,
+    output_dir: str,
+    template_url: str,
+    template_version: str,
+    additional_test_case: Iterable[str],
 ):
     config.update_verbosity(verbose)
-    f = ComponentTemplater(
+    t = ComponentTemplater(
         config, template_url, template_version, slug, name=name, output_dir=output_dir
     )
-    f.library = lib
-    f.post_process = pp
-    f.github_owner = owner
-    f.copyright_holder = copyright_holder
-    f.golden_tests = golden_tests
-    f.matrix_tests = matrix_tests
-    f.create()
+    t.library = lib
+    t.post_process = pp
+    t.github_owner = owner
+    t.copyright_holder = copyright_holder
+    t.golden_tests = golden_tests
+    t.matrix_tests = matrix_tests
+    t.test_cases = ["defaults"] + list(additional_test_case)
+    t.create()
 
 
 @component.command(

--- a/commodore/component/template.py
+++ b/commodore/component/template.py
@@ -15,7 +15,7 @@ from commodore.multi_dependency import MultiDependency
 class ComponentTemplater(Templater):
     library: bool
     post_process: bool
-    matrix_tests: bool
+    _matrix_tests: bool
 
     @classmethod
     def from_existing(cls, config: Config, path: Path):
@@ -34,6 +34,18 @@ class ComponentTemplater(Templater):
         args["add_pp"] = "y" if self.post_process else "n"
         args["add_matrix"] = "y" if self.matrix_tests else "n"
         return args
+
+    @property
+    def matrix_tests(self) -> bool:
+        if len(self.test_cases) > 1:
+            if not self._matrix_tests:
+                click.echo(" > Forcing matrix tests when multiple test cases requested")
+            return True
+        return self._matrix_tests
+
+    @matrix_tests.setter
+    def matrix_tests(self, matrix_tests: bool) -> None:
+        self._matrix_tests = matrix_tests
 
     @property
     def deptype(self) -> str:

--- a/commodore/dependency_templater.py
+++ b/commodore/dependency_templater.py
@@ -34,6 +34,7 @@ class Templater(ABC):
     _target_dir: Optional[Path] = None
     template_url: str
     template_version: Optional[str] = None
+    _test_cases: list[str] = ["defaults"]
 
     def __init__(
         self,
@@ -125,6 +126,9 @@ class Templater(ABC):
             "github_owner": self.github_owner,
             "name": self.name,
             "slug": self.slug,
+            # The template expects the test cases in a single string separated by
+            # spaces.
+            "test_cases": " ".join(self.test_cases),
         }
 
     def _initialize_from_cookiecutter_args(self, cookiecutter_args: dict[str, str]):
@@ -161,6 +165,24 @@ class Templater(ABC):
     @property
     def repo_url(self) -> str:
         return f"git@github.com:{self.github_owner}/{self.deptype}-{self.slug}.git"
+
+    @property
+    def test_cases(self) -> list[str]:
+        """Return list of test cases.
+
+        The getter deduplicates the stored list before returning it.
+
+        Don't use `append()` on the returned list to add test cases to the package, as
+        the getter returns a copy of the list stored in the object."""
+        cases = []
+        for t in self._test_cases:
+            if t not in cases:
+                cases.append(t)
+        return cases
+
+    @test_cases.setter
+    def test_cases(self, test_cases: list[str]):
+        self._test_cases = test_cases
 
     @property
     def additional_files(self) -> Sequence[str]:

--- a/commodore/package/template.py
+++ b/commodore/package/template.py
@@ -14,8 +14,6 @@ from commodore.package import package_dependency_dir
 
 
 class PackageTemplater(Templater):
-    _test_cases: list[str] = ["defaults"]
-
     @classmethod
     def from_existing(cls, config: Config, path: Path):
         return cls._base_from_existing(config, path, "package")
@@ -24,24 +22,6 @@ class PackageTemplater(Templater):
         super()._initialize_from_cookiecutter_args(cookiecutter_args)
         if "test_cases" in cookiecutter_args:
             self.test_cases = cookiecutter_args["test_cases"].split(" ")
-
-    @property
-    def test_cases(self) -> list[str]:
-        """Return list of test cases.
-
-        The getter deduplicates the stored list before returning it.
-
-        Don't use `append()` on the returned list to add test cases to the package, as
-        the getter returns a copy of the list stored in the object."""
-        cases = []
-        for t in self._test_cases:
-            if t not in cases:
-                cases.append(t)
-        return cases
-
-    @test_cases.setter
-    def test_cases(self, test_cases: list[str]):
-        self._test_cases = test_cases
 
     def _validate_slug(self, value: str):
         # First perform default slug checks
@@ -54,13 +34,6 @@ class PackageTemplater(Templater):
                 "Package slug can't use reserved tenant prefix 't-'"
             )
         return slug
-
-    @property
-    def cookiecutter_args(self) -> dict[str, str]:
-        args = super().cookiecutter_args
-        # The template expects the test cases in a single string separated by spaces.
-        args["test_cases"] = " ".join(self.test_cases)
-        return args
 
     @property
     def deptype(self) -> str:

--- a/docs/modules/ROOT/pages/reference/cli.adoc
+++ b/docs/modules/ROOT/pages/reference/cli.adoc
@@ -178,6 +178,12 @@ This command doesn't have any command line options.
   The component template version (Git tree-ish) to use.
   Defaults to `main`.
 
+*--additional-test-case, -t* CASE::
+  Additional test cases to generate in the new component.
+  Can be repeated.
+  Test case `defaults` will always be generated.
+  Commodore will deduplicate the provided test cases.
+
 *--help*::
   Show component new usage and options then exit.
 


### PR DESCRIPTION
This PR adds support for generating additional test cases to `component new`. Commodore will ensure that components are always created with matrix tests enabled if more than one test case is requested. This feature requires https://github.com/projectsyn/commodore-component-template/pull/6.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
