### PR TITLE
Add support for adding and removing test cases to `component update`

### DIFF
--- a/commodore/cli.py
+++ b/commodore/cli.py
@@ -440,6 +440,24 @@ def component_new(
     show_default=True,
     help="Add or remove the postprocessing filter configuration.",
 )
+@click.option(
+    "--additional-test-case",
+    "-t",
+    metavar="CASE",
+    default=[],
+    show_default=True,
+    multiple=True,
+    help="Additional test cases to add to the component. Can be repeated. "
+    + "Commodore will deduplicate test cases by name.",
+)
+@click.option(
+    "--remove-test-case",
+    metavar="CASE",
+    default=[],
+    show_default=True,
+    multiple=True,
+    help="Test cases to remove from the package. Can be repeated.",
+)
 @verbosity
 @pass_config
 def component_update(
@@ -452,6 +470,8 @@ def component_update(
     lib: Optional[bool],
     pp: Optional[bool],
     update_copyright_year: bool,
+    additional_test_case: Iterable[str],
+    remove_test_case: Iterable[str],
 ):
     """This command updates the component at COMPONENT_PATH to the latest version of the
     template which was originally used to create it, if the template version is given as
@@ -475,6 +495,10 @@ def component_update(
         t.library = lib
     if pp is not None:
         t.post_process = pp
+
+    test_cases = t.test_cases
+    test_cases.extend(additional_test_case)
+    t.test_cases = [tc for tc in test_cases if tc not in remove_test_case]
 
     t.update()
 

--- a/commodore/dependency_templater.py
+++ b/commodore/dependency_templater.py
@@ -136,6 +136,10 @@ class Templater(ABC):
         self.github_owner = cookiecutter_args["github_owner"]
         self.copyright_holder = cookiecutter_args["copyright_holder"]
         self.copyright_year = cookiecutter_args["copyright_year"]
+        if "test_cases" in cookiecutter_args:
+            self.test_cases = cookiecutter_args["test_cases"].split(" ")
+        else:
+            self.test_cases = ["defaults"]
 
     def _validate_slug(self, value: str) -> str:
         if value.startswith(f"{self.deptype}-"):

--- a/commodore/dependency_templater.py
+++ b/commodore/dependency_templater.py
@@ -246,6 +246,10 @@ class Templater(ABC):
         )
 
     def update(self, print_completion_message: bool = True) -> bool:
+        if len(self.test_cases) == 0:
+            raise click.ClickException(
+                f"{self.deptype.capitalize()} template doesn't support removing all test cases."
+            )
         cruft_update(
             self.target_dir,
             cookiecutter_input=False,

--- a/commodore/package/template.py
+++ b/commodore/package/template.py
@@ -18,11 +18,6 @@ class PackageTemplater(Templater):
     def from_existing(cls, config: Config, path: Path):
         return cls._base_from_existing(config, path, "package")
 
-    def _initialize_from_cookiecutter_args(self, cookiecutter_args: dict[str, str]):
-        super()._initialize_from_cookiecutter_args(cookiecutter_args)
-        if "test_cases" in cookiecutter_args:
-            self.test_cases = cookiecutter_args["test_cases"].split(" ")
-
     def _validate_slug(self, value: str):
         # First perform default slug checks
         slug = super()._validate_slug(value)

--- a/docs/modules/ROOT/pages/reference/cli.adoc
+++ b/docs/modules/ROOT/pages/reference/cli.adoc
@@ -218,6 +218,15 @@ This command doesn't have any command line options.
   Update the year in the copyright notice to the current year.
   Defaults to _false_.
 
+*--additional-test-case, -t* CASE::
+  Additional test cases to add to the component.
+  Can be repeated.
+  Commodore will deduplicate the provided test cases.
+
+*--remove-test-case* CASE::
+  Test cases to remove from the component.
+  Can be repeated.
+
 *--help*::
   Show component new usage and options then exit.
 

--- a/docs/modules/ROOT/pages/reference/commands.adoc
+++ b/docs/modules/ROOT/pages/reference/commands.adoc
@@ -45,6 +45,10 @@ The component repository is created using a Cookiecutter template which provides
 The command requires the argument `SLUG` to match the regular expression `^[a-z][a-z0-9-]+[a-z0-9]$`.
 Optionally, the template can be used to add a component library and postprocessing filter configuration.
 
+The command allows users to define additional test cases to add to the component.
+Test case `defaults` is always generated.
+If multiple test cases are requested, matrix tests are rendered regardless of whether they were requested or not.
+
 If argument `--output-dir` isn't given, the command expects to run in a directory which already holds a Commodore directory structure.
 
 The template also provides many meta-files in the component repository, such as the readme and changelog, standardized license, contributing and code of conduct files, a documentation template, and GitHub issue templates and actions configuration.

--- a/docs/modules/ROOT/pages/reference/commands.adoc
+++ b/docs/modules/ROOT/pages/reference/commands.adoc
@@ -57,6 +57,9 @@ This command updates an existing component repository stored in `PATH`.
 The command will always update the component to the latest version of the template which was originally used to create the component.
 The command has a number of command line options to enable or disable component features, such as golden tests.
 
+Additionally, the command allows users to add or remove test cases.
+Commodore will raise an error if the command would end up removing all test cases from the component, since the template currently doesn't render cleanly with no test cases specified.
+
 
 == Component Delete
 

--- a/docs/modules/ROOT/pages/reference/commands.adoc
+++ b/docs/modules/ROOT/pages/reference/commands.adoc
@@ -192,6 +192,8 @@ This command updates an existing config package repository stored in `PATH`.
 The command will always update the package to the latest version of the template which was originally used to create the package.
 The command has a number of command line options to modify the package's test cases and selected meta-information.
 
+Commodore will raise an error if the command would end up removing all test cases from the package, since the template currently doesn't render cleanly with no test cases specified.
+
 == Package Compile
 
   package compile PATH TEST_CLASS


### PR DESCRIPTION
This PR adds new flags to `component update` which allow users to add or remove test cases.

The PR also makes removing all test cases with `component update` or `package update` an error, since the templates currently don't cleanly support having no test cases at all.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
