### PR TITLE
Correctly pass Git author name and email to dependency repos

### DIFF
--- a/commodore/config.py
+++ b/commodore/config.py
@@ -249,7 +249,10 @@ class Config:
         depkey = dependency_key(repo_url)
         if depkey not in self._dependency_repos:
             self._dependency_repos[depkey] = MultiDependency(
-                repo_url, self.inventory.dependencies_dir
+                repo_url,
+                self.inventory.dependencies_dir,
+                author_name=self.username,
+                author_email=self.usermail,
             )
 
         dep = self._dependency_repos[depkey]

--- a/commodore/multi_dependency.py
+++ b/commodore/multi_dependency.py
@@ -13,9 +13,21 @@ class MultiDependency:
     _components: dict[str, Path]
     _packages: dict[str, Path]
 
-    def __init__(self, repo_url: str, dependencies_dir: Path):
+    def __init__(
+        self,
+        repo_url: str,
+        dependencies_dir: Path,
+        author_name: Optional[str] = None,
+        author_email: Optional[str] = None,
+    ):
         repo_dir = dependency_dir(dependencies_dir, repo_url)
-        self._repo = GitRepo(repo_url, repo_dir, bare=True)
+        self._repo = GitRepo(
+            repo_url,
+            repo_dir,
+            bare=True,
+            author_name=author_name,
+            author_email=author_email,
+        )
         self._components = {}
         self._packages = {}
 


### PR DESCRIPTION
Follow-up to https://github.com/projectsyn/commodore/pull/598.

We also need to pass through the provided Git author name and email when registering dependency repositories to ensure `catalog compile` works correctly in environments which don't support GitPython's fallback mechanism to determine author information.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
