### PR TITLE
Fix GitRepo initialization for dependencies without backing MultiDependency

### DIFF
--- a/commodore/component/__init__.py
+++ b/commodore/component/__init__.py
@@ -52,13 +52,20 @@ class Component:
 
     @property
     def repo(self) -> GitRepo:
-        dep_repo = self.dependency.bare_repo
         if not self._repo:
+            if self._dependency:
+                dep_repo = self._dependency.bare_repo
+                author_name = dep_repo.author.name
+                author_email = dep_repo.author.email
+            else:
+                # Fall back to author detection if we don't have a dependency
+                author_name = None
+                author_email = None
             self._repo = GitRepo(
                 None,
                 self._dir,
-                author_name=dep_repo.author.name,
-                author_email=dep_repo.author.email,
+                author_name=author_name,
+                author_email=author_email,
             )
         return self._repo
 

--- a/commodore/package/__init__.py
+++ b/commodore/package/__init__.py
@@ -60,13 +60,20 @@ class Package:
 
     @property
     def repo(self) -> Optional[GitRepo]:
-        dep_repo = self._dependency.bare_repo
         if not self._gitrepo and self.target_dir and self.target_dir.is_dir():
+            if self._dependency:
+                dep_repo = self._dependency.bare_repo
+                author_name = dep_repo.author.name
+                author_email = dep_repo.author.email
+            else:
+                # Fall back to author detection if we don't have a dependency
+                author_name = None
+                author_email = None
             self._gitrepo = GitRepo(
                 None,
                 self.target_dir,
-                author_name=dep_repo.author.name,
-                author_email=dep_repo.author.email,
+                author_name=author_name,
+                author_email=author_email,
             )
         return self._gitrepo
 

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -485,3 +485,24 @@ def test_component_update_dependency(tmp_path: P, init_dep: bool, new_dep: bool)
         with pytest.raises(ValueError) as exc:
             _ = c.dependency
         assert str(exc.value) == "Dependency for component tc1 hasn't been initialized"
+
+
+@pytest.mark.parametrize("dep", [True, False])
+def test_component_repo(tmp_path: P, dep: bool):
+    u = Repo.init(tmp_path / "bare.git")
+    (tmp_path / "bare.git" / "x").touch()
+    u.index.add(["x"])
+    u.index.commit("Initial commit")
+
+    if dep:
+        md = MultiDependency(f"file://{tmp_path}/bare.git", tmp_path)
+    else:
+        md = None
+
+    c = Component(
+        "test-component", md, directory=tmp_path / "test-component", version="master"
+    )
+    if md:
+        c.checkout()
+
+    assert c.repo.working_tree_dir == tmp_path / "test-component"


### PR DESCRIPTION
We don't always create a `MultiDependency` for component or package objects, so we need to ensure `Component.repo` works correctly even if `Component._dependency` is `None`.

This commit ensures that we fall back to using `None` for the Git author name and email if we don't have a `MultiDependency` for a component or package.

Follow-up to #598, #602, #603, #604

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
