### PR TITLE
Fix entrypoint script in case the `.ssh` folder already exists

### DIFF
--- a/tools/entrypoint.sh
+++ b/tools/entrypoint.sh
@@ -23,7 +23,9 @@ if ! whoami &> /dev/null; then
 fi
 
 if [ ! -z "${SSH_PRIVATE_KEY}" ]; then
-  mkdir /app/.ssh
+  if [ ! -d "/app/.ssh" ]; then
+    mkdir /app/.ssh
+  fi
   echo "${SSH_PRIVATE_KEY}" > /app/.ssh/id
   chmod 0400 /app/.ssh/id
 fi


### PR DESCRIPTION
On Kubernetes runners, we already create the `.ssh` folder prior to
running the entrypoint script. This leads to an error in the script, as
it can't create the `.ssh` folder.

Signed-off-by: Nicolas Bigler <nicolas.bigler@vshn.ch>

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [ ] Update the documentation.
- [ ] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
