### PR TITLE
Explicitly handle Cruft errors and merge conflicts in `Templater.update()`

### DIFF
--- a/tests/test_gitrepo.py
+++ b/tests/test_gitrepo.py
@@ -3,6 +3,7 @@ Unit-tests for git
 """
 from __future__ import annotations
 
+import subprocess
 from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Optional
@@ -559,3 +560,48 @@ def test_gitrepo_commit_amend(tmp_path: Path):
     assert r.repo.head.commit.author.email == "john.doe@example.com"
     assert r.repo.head.commit.committer.name == "John Doe"
     assert r.repo.head.commit.committer.email == "john.doe@example.com"
+
+
+def _setup_merge_conflict(tmp_path: Path):
+    r, _ = setup_repo(tmp_path)
+    test_txt_path = r.working_tree_dir / "test.txt"
+    with open(test_txt_path, "w", encoding="utf-8") as f:
+        f.write("Hello, world!\n")
+    r.stage_all()
+    r.commit("Add content to test.txt")
+    assert not r.repo.is_dirty()
+
+    diff = """diff --git a/test.txt b/test.txt
+new file mode 100644
+index 0000000..d56c457
+--- /dev/null
++++ b/test.txt
+@@ -0,0 +1 @@
++Yo World!
+"""
+
+    result = subprocess.run(
+        ["git", "apply", "-3"], input=diff.encode(), cwd=r.working_tree_dir
+    )
+    # patch should not apply
+    assert result.returncode == 1
+
+    return r
+
+
+def test_gitrepo_stage_all_raises_on_conflict(tmp_path: Path):
+    r = _setup_merge_conflict(tmp_path)
+
+    with pytest.raises(gitrepo.MergeConflict) as e:
+        r.stage_all()
+
+    assert str(e.value) == "test.txt"
+
+
+def test_gitrepo_stage_files_raises_on_conflict(tmp_path: Path):
+    r = _setup_merge_conflict(tmp_path)
+
+    with pytest.raises(gitrepo.MergeConflict) as e:
+        r.stage_files(["test.txt"])
+
+    assert str(e.value) == "test.txt"


### PR DESCRIPTION
This PR aborts `component update` and `package update` if Cruft's `update()` returns `False`. Additionally, we add logic to `GitRepo.stage_all()` and `GitRepo.stage_files()` to raise an exception on merge conflicts in the files to be staged.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
