### PR TITLE
Add fallback to extract copyright info from modulesync config

### DIFF
--- a/commodore/component/template.py
+++ b/commodore/component/template.py
@@ -57,6 +57,25 @@ class ComponentTemplater(Templater):
             cookiecutter_args["add_pp"] = "y" if self._has_pp else "n"
             update_cruft_json = True
 
+        if (self.target_dir / ".sync.yml").is_file():
+            # Migrate copyright information from modulesync config, if it's present and
+            # the information is missing in the cookiecutter args.
+            with open(self.target_dir / ".sync.yml", "r", encoding="utf-8") as f:
+                sync_yml = yaml.safe_load(f)
+            license_data = sync_yml.get("LICENSE", {})
+            if "copyright_holder" not in cookiecutter_args:
+                cookiecutter_args["copyright_holder"] = license_data.get(
+                    "holder", "VSHN AG <info@vshn.ch>"
+                )
+                update_cruft_json = True
+            self.copyright_holder = cookiecutter_args["copyright_holder"]
+            if "copyright_year" not in cookiecutter_args:
+                cookiecutter_args["copyright_year"] = str(
+                    license_data.get("year", 2021)
+                )
+                update_cruft_json = True
+            self.copyright_year = cookiecutter_args["copyright_year"]
+
         self.library = cookiecutter_args["add_lib"] == "y"
         self.post_process = cookiecutter_args["add_pp"] == "y"
         self.matrix_tests = cookiecutter_args["add_matrix"] == "y"

--- a/commodore/dependency_templater.py
+++ b/commodore/dependency_templater.py
@@ -179,8 +179,12 @@ class Templater(ABC):
         should ensure that the updated args dict is written back to `.cruft.json`."""
         self.golden_tests = cookiecutter_args["add_golden"] == "y"
         self.github_owner = cookiecutter_args["github_owner"]
-        self.copyright_holder = cookiecutter_args["copyright_holder"]
-        self.copyright_year = cookiecutter_args["copyright_year"]
+        # Allow copyright holder and copyright year to be missing in the cookiecutter
+        # args. Fallback to VSHN AG <info@vshn.ch> and the current year here.
+        self.copyright_holder = cookiecutter_args.get(
+            "copyright_holder", "VSHN AG <info@vshn.ch>"
+        )
+        self.copyright_year = cookiecutter_args.get("copyright_year")
         if "test_cases" in cookiecutter_args:
             self.test_cases = cookiecutter_args["test_cases"].split(" ")
         else:


### PR DESCRIPTION
If we don't have the copyright info for a component in the Cruft cookiecutter args, fall back to reading it from the component's
modulesync config (`.sync.yml`) or use the default values used by modulesync, if the component's `.sync.yml` doesn't have the information either.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
