### PR TITLE
 Change `sync_dependencies()` to omit PRs which only update the template commit id

### DIFF
--- a/commodore/dependency_syncer.py
+++ b/commodore/dependency_syncer.py
@@ -68,7 +68,11 @@ def sync_dependencies(
 
         # Update the dependency
         t = templater.from_existing(config, d.target_dir)
-        changed = t.update(print_completion_message=False, commit=not dry_run)
+        changed = t.update(
+            print_completion_message=False,
+            commit=not dry_run,
+            ignore_template_commit=True,
+        )
 
         # Create or update PR if there were updates
         create_or_update_pr(d, dn, gr, changed, pr_branch, pr_label, dry_run)

--- a/commodore/dependency_templater.py
+++ b/commodore/dependency_templater.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime
+import difflib
 import json
 import re
 import tempfile
@@ -15,10 +16,46 @@ import click
 
 from commodore.config import Config
 from commodore.cruft import create as cruft_create, update as cruft_update
-from commodore.gitrepo import GitRepo, MergeConflict
+from commodore.gitrepo import GitRepo, MergeConflict, default_difffunc
 from commodore.multi_dependency import MultiDependency
 
 SLUG_REGEX = re.compile("^[a-z][a-z0-9-]+[a-z0-9]$")
+
+
+def _ignore_cruft_json_commit_id(
+    before_text: str, after_text: str, fromfile: str = "", tofile: str = ""
+):
+    """Custom diff function which omits `.cruft.json` diffs which only differ in the
+    template commit id."""
+    before_lines = before_text.split("\n")
+    after_lines = after_text.split("\n")
+    diff_lines = difflib.unified_diff(
+        before_lines, after_lines, lineterm="", fromfile=fromfile, tofile=tofile
+    )
+    omit = False
+    if fromfile == ".cruft.json" and tofile == ".cruft.json":
+        # Compute diff without context lines for `.cruft.json` (n=0) and drop the
+        # unified diff header (first 3 lines).
+        minimal_diff = list(
+            difflib.unified_diff(
+                before_lines,
+                after_lines,
+                lineterm="",
+                fromfile=fromfile,
+                tofile=tofile,
+                n=0,
+            )
+        )[3:]
+        # If the context-less diff has exactly 2 lines and both of them start with
+        # '[-+] "commit":', we omit the diff
+        if (
+            len(minimal_diff) == 2
+            and minimal_diff[0].startswith('-  "commit":')
+            and minimal_diff[1].startswith('+  "commit":')
+        ):
+            omit = True
+    # never suppress diffs in default difffunc
+    return diff_lines, omit
 
 
 class Templater(ABC):
@@ -297,7 +334,10 @@ class Templater(ABC):
         )
 
     def update(
-        self, print_completion_message: bool = True, commit: bool = True
+        self,
+        print_completion_message: bool = True,
+        commit: bool = True,
+        ignore_template_commit: bool = False,
     ) -> bool:
         if len(self.test_cases) == 0:
             raise click.ClickException(
@@ -313,7 +353,9 @@ class Templater(ABC):
             raise click.ClickException("Update from template failed")
 
         if not commit:
-            diff_text, updated = self.diff()
+            diff_text, updated = self.diff(
+                ignore_template_commit=ignore_template_commit
+            )
             if updated:
                 indented = textwrap.indent(diff_text, "     ")
                 message = f" > Changes:\n{indented}"
@@ -327,10 +369,12 @@ class Templater(ABC):
             if self.template_commit:
                 commit_msg += f" ({self.template_commit[:7]})"
 
-            updated = self.commit(commit_msg, init=False)
+            updated = self.commit(
+                commit_msg, init=False, ignore_template_commit=ignore_template_commit
+            )
 
         if print_completion_message:
-            if not commit:
+            if not commit and updated:
                 click.secho(
                     " > User requested to skip committing the rendered changes."
                 )
@@ -348,24 +392,52 @@ class Templater(ABC):
 
         return updated
 
-    def diff(self) -> tuple[str, bool]:
+    def _stage_all(self, ignore_template_commit: bool = False) -> tuple[str, bool]:
+        """Wrapper for GitRepo.stage_all() which stages all changes for a dependency."""
         repo = GitRepo(self.repo_url, self.target_dir, force_init=False)
+
+        diff_func = default_difffunc
+        if ignore_template_commit:
+            diff_func = _ignore_cruft_json_commit_id
+        # stage_all() returns the full diff compared to the last commit. Therefore, we
+        # do stage_files() first and then stage_all(), to ensure we get the complete
+        # diff.
         repo.stage_files(self.additional_files)
-        diff_text, changed = repo.stage_all()
+        diff_text, changed = repo.stage_all(diff_func=diff_func)
+
+        if ignore_template_commit:
+            # If we want to ignore updates which only modify the template commit id, we
+            # don't use the returned `changed` but instead singal whether there was a
+            # change by checking if the diff_text has any contents.
+            changed = len(diff_text) > 0
+
+        return diff_text, changed
+
+    def diff(self, ignore_template_commit: bool = False) -> tuple[str, bool]:
+        repo = GitRepo(self.repo_url, self.target_dir, force_init=False)
+        diff_text, changed = self._stage_all(
+            ignore_template_commit=ignore_template_commit
+        )
+
+        # When only computing the diff, we reset all staged changes
         repo.reset(working_tree=False)
         return diff_text, changed
 
-    def commit(self, msg: str, amend=False, init=True) -> bool:
+    def commit(
+        self,
+        msg: str,
+        amend: bool = False,
+        init: bool = True,
+        ignore_template_commit: bool = False,
+    ) -> bool:
         # If we're amending an existing commit, we don't want to force initialize the
         # repo.
         repo = GitRepo(self.repo_url, self.target_dir, force_init=not amend and init)
 
-        # stage_all() returns the full diff compared to the last commit. Therefore, we
-        # do stage_files() first and then stage_all(), to ensure we get the complete
-        # diff.
         try:
-            repo.stage_files(self.additional_files)
-            diff_text, changed = repo.stage_all()
+            diff_text, changed = self._stage_all(
+                ignore_template_commit=ignore_template_commit
+            )
         except MergeConflict as e:
             raise click.ClickException(
                 f"Can't commit template changes: merge error in '{e}'. "

--- a/commodore/dependency_templater.py
+++ b/commodore/dependency_templater.py
@@ -352,6 +352,32 @@ class Templater(ABC):
         if not cruft_updated:
             raise click.ClickException("Update from template failed")
 
+        updated = self._commit_or_print_changes(commit, ignore_template_commit)
+
+        if print_completion_message:
+            if not commit and updated:
+                click.secho(
+                    " > User requested to skip committing the rendered changes."
+                )
+
+            if updated:
+                click.secho(
+                    f"{self.deptype.capitalize()} {self.name} successfully updated 🎉",
+                    bold=True,
+                )
+            else:
+                click.secho(
+                    f"{self.deptype.capitalize()} {self.name} already up-to-date 🎉",
+                    bold=True,
+                )
+
+        return updated
+
+    def _commit_or_print_changes(
+        self, commit: bool, ignore_template_commit: bool
+    ) -> bool:
+        """Helper for update() which either prints or commits the changes in the
+        dependency repo"""
         if not commit:
             diff_text, updated = self.diff(
                 ignore_template_commit=ignore_template_commit
@@ -372,23 +398,6 @@ class Templater(ABC):
             updated = self.commit(
                 commit_msg, init=False, ignore_template_commit=ignore_template_commit
             )
-
-        if print_completion_message:
-            if not commit and updated:
-                click.secho(
-                    " > User requested to skip committing the rendered changes."
-                )
-
-            if updated:
-                click.secho(
-                    f"{self.deptype.capitalize()} {self.name} successfully updated 🎉",
-                    bold=True,
-                )
-            else:
-                click.secho(
-                    f"{self.deptype.capitalize()} {self.name} already up-to-date 🎉",
-                    bold=True,
-                )
 
         return updated
 

--- a/commodore/gitrepo.py
+++ b/commodore/gitrepo.py
@@ -95,7 +95,7 @@ def _compute_similarity(change):
     return similarity_diff
 
 
-def _default_difffunc(
+def default_difffunc(
     before_text: str, after_text: str, fromfile: str = "", tofile: str = ""
 ) -> tuple[Iterable[str], bool]:
     before_lines = before_text.split("\n")
@@ -561,7 +561,7 @@ class GitRepo:
 
         return to_add, to_remove
 
-    def stage_all(self, diff_func: DiffFunc = _default_difffunc) -> tuple[str, bool]:
+    def stage_all(self, diff_func: DiffFunc = default_difffunc) -> tuple[str, bool]:
         """Stage all changes.
         This method currently doesn't handle hidden files correctly.
 


### PR DESCRIPTION
This PR adds an optional argument for `Templater.update()` which configures a custom diff function which suppresses `.cruft.json` diffs which only contain a changed template commit id.

This allows us to change `sync_dependencies()` to call `update()` with `ignore_template_commit=True` to ensure the sync doesn't create PRs for updates which only modify the template commit id for template updates which make changes in a part of the template which only applies to a few dependencies.

Fixes #632 

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
