### PR TITLE
Improve handling of secondary rate limits in `sync_dependencies()`

### DIFF
--- a/commodore/cli.py
+++ b/commodore/cli.py
@@ -636,12 +636,22 @@ def component_compile(
     help="Labels to set on the PR. Can be repeated",
 )
 @click.option(
+    "--pr-batch-size",
+    metavar="COUNT",
+    default=10,
+    type=int,
+    show_default=True,
+    help="Number of PRs to create before pausing"
+    + "Tune this parameter if your sync job hits the GitHub secondary rate limit.",
+)
+@click.option(
     "--github-pause",
     metavar="DURATION",
     default=120,
     type=int,
     show_default=True,
-    help="Duration for which to pause (in seconds) after creating 10 PRs. "
+    help="Duration for which to pause (in seconds) after creating a number PRs "
+    + "(according to --pr-batch-size). "
     + "Tune this parameter if your sync job hits the GitHub secondary rate limit.",
 )
 def component_sync(
@@ -652,6 +662,7 @@ def component_sync(
     dry_run: bool,
     pr_branch: str,
     pr_label: Iterable[str],
+    pr_batch_size: int,
     github_pause: int,
 ):
     """This command processes all components listed in the provided `COMPONENT_LIST`
@@ -682,6 +693,7 @@ def component_sync(
         pr_label,
         Component,
         ComponentTemplater,
+        pr_batch_size,
         timedelta(seconds=github_pause),
     )
 
@@ -959,12 +971,22 @@ def package_compile(
     help="Labels to set on the PR. Can be repeated",
 )
 @click.option(
+    "--pr-batch-size",
+    metavar="COUNT",
+    default=10,
+    type=int,
+    show_default=True,
+    help="Number of PRs to create before pausing"
+    + "Tune this parameter if your sync job hits the GitHub secondary rate limit.",
+)
+@click.option(
     "--github-pause",
     metavar="DURATION",
     default=120,
     type=int,
     show_default=True,
-    help="Duration for which to pause (in seconds) after creating 10 PRs. "
+    help="Duration for which to pause (in seconds) after creating a number PRs "
+    + "(according to --pr-batch-size). "
     + "Tune this parameter if your sync job hits the GitHub secondary rate limit.",
 )
 def package_sync(
@@ -975,6 +997,7 @@ def package_sync(
     dry_run: bool,
     pr_branch: str,
     pr_label: Iterable[str],
+    pr_batch_size: int,
     github_pause: int,
 ):
     """This command processes all packages listed in the provided `PACKAGE_LIST` YAML file.
@@ -1004,6 +1027,7 @@ def package_sync(
         pr_label,
         Package,
         PackageTemplater,
+        pr_batch_size,
         timedelta(seconds=github_pause),
     )
 

--- a/commodore/cli.py
+++ b/commodore/cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import sys
 from collections.abc import Iterable
+from datetime import timedelta
 from pathlib import Path
 from typing import Optional
 
@@ -633,6 +634,15 @@ def component_compile(
     multiple=True,
     help="Labels to set on the PR. Can be repeated",
 )
+@click.option(
+    "--github-pause",
+    metavar="DURATION",
+    default=120,
+    type=int,
+    show_default=True,
+    help="Duration for which to pause (in seconds) after creating 10 PRs. "
+    + "Tune this parameter if your sync job hits the GitHub secondary rate limit.",
+)
 def component_sync(
     config: Config,
     verbose: int,
@@ -641,6 +651,7 @@ def component_sync(
     dry_run: bool,
     pr_branch: str,
     pr_label: Iterable[str],
+    github_pause: int,
 ):
     """This command processes all components listed in the provided `COMPONENT_LIST`
     YAML file.
@@ -670,6 +681,7 @@ def component_sync(
         pr_label,
         Component,
         ComponentTemplater,
+        timedelta(seconds=github_pause),
     )
 
 
@@ -944,6 +956,15 @@ def package_compile(
     multiple=True,
     help="Labels to set on the PR. Can be repeated",
 )
+@click.option(
+    "--github-pause",
+    metavar="DURATION",
+    default=120,
+    type=int,
+    show_default=True,
+    help="Duration for which to pause (in seconds) after creating 10 PRs. "
+    + "Tune this parameter if your sync job hits the GitHub secondary rate limit.",
+)
 def package_sync(
     config: Config,
     verbose: int,
@@ -952,6 +973,7 @@ def package_sync(
     dry_run: bool,
     pr_branch: str,
     pr_label: Iterable[str],
+    github_pause: int,
 ):
     """This command processes all packages listed in the provided `PACKAGE_LIST` YAML file.
 
@@ -980,6 +1002,7 @@ def package_sync(
         pr_label,
         Package,
         PackageTemplater,
+        timedelta(seconds=github_pause),
     )
 
 

--- a/commodore/cli.py
+++ b/commodore/cli.py
@@ -623,6 +623,7 @@ def component_compile(
     "-b",
     metavar="BRANCH",
     default="template-sync",
+    show_default=True,
     type=str,
     help="Branch name to use for updates from template",
 )
@@ -945,6 +946,7 @@ def package_compile(
     "-b",
     metavar="BRANCH",
     default="template-sync",
+    show_default=True,
     type=str,
     help="Branch name to use for updates from template",
 )

--- a/docs/modules/ROOT/pages/reference/cli.adoc
+++ b/docs/modules/ROOT/pages/reference/cli.adoc
@@ -255,6 +255,10 @@ NOTE: Changing this flag will orphan any open update PRs created with a differen
 When changing the set of labels, new labels will be added to open PRs.
 However, labels added by previous runs can't be removed since we've got no easy way to distinguish between old labels and externally added labels.
 
+*--github-pause* SECONDS::
+  The duration for which to pause (in seconds) after creating 10 PRs.
+  Tune this parameter if your sync job hits the GitHub secondary rate limit.
+
 == Inventory Components / Packages / Show
 
 *-f, --values*::
@@ -437,3 +441,7 @@ NOTE: Changing this flag will orphan any open update PRs created with a differen
 +
 When changing the set of labels, new labels will be added to open PRs.
 However, labels added by previous runs can't be removed since we've got no easy way to distinguish between old labels and externally added labels.
+
+*--github-pause* SECONDS::
+  The duration for which to pause (in seconds) after creating 10 PRs.
+  Tune this parameter if your sync job hits the GitHub secondary rate limit.

--- a/docs/modules/ROOT/pages/reference/cli.adoc
+++ b/docs/modules/ROOT/pages/reference/cli.adoc
@@ -255,8 +255,12 @@ NOTE: Changing this flag will orphan any open update PRs created with a differen
 When changing the set of labels, new labels will be added to open PRs.
 However, labels added by previous runs can't be removed since we've got no easy way to distinguish between old labels and externally added labels.
 
+*--pr-batch-size* COUNT::
+    The number of PRs to create before pausing.
+    Tune this parameter if your sync job hits the GitHub secondary rate limit.
+
 *--github-pause* SECONDS::
-  The duration for which to pause (in seconds) after creating 10 PRs.
+  The duration for which to pause (in seconds) after creating a number of PRs according to `--pr-batch-size`.
   Tune this parameter if your sync job hits the GitHub secondary rate limit.
 
 == Inventory Components / Packages / Show
@@ -442,6 +446,10 @@ NOTE: Changing this flag will orphan any open update PRs created with a differen
 When changing the set of labels, new labels will be added to open PRs.
 However, labels added by previous runs can't be removed since we've got no easy way to distinguish between old labels and externally added labels.
 
+*--pr-batch-size* COUNT::
+    The number of PRs to create before pausing.
+    Tune this parameter if your sync job hits the GitHub secondary rate limit.
+
 *--github-pause* SECONDS::
-  The duration for which to pause (in seconds) after creating 10 PRs.
+  The duration for which to pause (in seconds) after creating a number of PRs according to `--pr-batch-size`.
   Tune this parameter if your sync job hits the GitHub secondary rate limit.

--- a/tests/test_cli_functions.py
+++ b/tests/test_cli_functions.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 
+from datetime import timedelta
 from pathlib import Path
 from typing import Any, Iterable, Type
 from unittest import mock
@@ -402,6 +403,7 @@ def test_package_sync_cli(
         pr_labels: Iterable[str],
         deptype: Type,
         templater: Type,
+        github_pause: int,
     ):
         assert config.github_token == ghtoken
         assert pkglist.absolute() == pkg_list.absolute()
@@ -410,6 +412,7 @@ def test_package_sync_cli(
         assert list(pr_labels) == []
         assert deptype == Package
         assert templater == PackageTemplater
+        assert github_pause == timedelta(seconds=120)
 
     mock_sync_packages.side_effect = sync_pkgs
     result = cli_runner(["package", "sync", "pkgs.yaml"])
@@ -469,6 +472,7 @@ def test_component_sync_cli(
         pr_labels: Iterable[str],
         deptype: Type,
         templater: Type,
+        github_pause: int,
     ):
         assert config.github_token == ghtoken
         assert deplist.absolute() == dep_list.absolute()
@@ -477,6 +481,7 @@ def test_component_sync_cli(
         assert list(pr_labels) == []
         assert deptype == Component
         assert templater == ComponentTemplater
+        assert github_pause == timedelta(seconds=120)
 
     mock_sync_dependencies.side_effect = sync_deps
     result = cli_runner(["component", "sync", "deps.yaml"])

--- a/tests/test_cli_functions.py
+++ b/tests/test_cli_functions.py
@@ -403,6 +403,7 @@ def test_package_sync_cli(
         pr_labels: Iterable[str],
         deptype: Type,
         templater: Type,
+        pr_batch_size: int,
         github_pause: int,
     ):
         assert config.github_token == ghtoken
@@ -412,6 +413,7 @@ def test_package_sync_cli(
         assert list(pr_labels) == []
         assert deptype == Package
         assert templater == PackageTemplater
+        assert pr_batch_size == 10
         assert github_pause == timedelta(seconds=120)
 
     mock_sync_packages.side_effect = sync_pkgs
@@ -472,6 +474,7 @@ def test_component_sync_cli(
         pr_labels: Iterable[str],
         deptype: Type,
         templater: Type,
+        pr_batch_size: int,
         github_pause: int,
     ):
         assert config.github_token == ghtoken
@@ -481,6 +484,7 @@ def test_component_sync_cli(
         assert list(pr_labels) == []
         assert deptype == Component
         assert templater == ComponentTemplater
+        assert pr_batch_size == 10
         assert github_pause == timedelta(seconds=120)
 
     mock_sync_dependencies.side_effect = sync_deps


### PR DESCRIPTION
We change `sync_dependencies()` to pause for 2 minutes (120 seconds) after creating batches of 10 PRs. The length of the pause is configurable as a command line option for commands `component sync` and `package sync`.

Fixes #617 

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
