### PR TITLE
Remove `Templater.additional_files` which is not needed anymore

### DIFF
--- a/commodore/dependency_templater.py
+++ b/commodore/dependency_templater.py
@@ -10,7 +10,7 @@ import textwrap
 
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Optional, Sequence
+from typing import Optional
 
 import click
 
@@ -277,16 +277,6 @@ class Templater(ABC):
         self._test_cases = test_cases
 
     @property
-    def additional_files(self) -> Sequence[str]:
-        return [
-            ".github",
-            ".gitignore",
-            ".*.yml",
-            ".editorconfig",
-            ".cruft.json",
-        ]
-
-    @property
     def template_commit(self) -> Optional[str]:
         cruft_json = self.target_dir / ".cruft.json"
         if not cruft_json.is_file():
@@ -408,10 +398,6 @@ class Templater(ABC):
         diff_func = default_difffunc
         if ignore_template_commit:
             diff_func = _ignore_cruft_json_commit_id
-        # stage_all() returns the full diff compared to the last commit. Therefore, we
-        # do stage_files() first and then stage_all(), to ensure we get the complete
-        # diff.
-        repo.stage_files(self.additional_files)
         diff_text, changed = repo.stage_all(diff_func=diff_func)
 
         if ignore_template_commit:


### PR DESCRIPTION
With the updated `GitRepo.stage_all()` implementation (cf. #633), we no longer need to explicitly stage hidden files as the new `stage_all()` implementation will ensure that new hidden files are staged.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
