### PR TITLE
Add new label `internal` for PRs which make purely internal changes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,7 +14,7 @@ Remove items that do not apply. For completed items, change [ ] to [x].
 - [ ] Update the documentation.
 - [ ] Update tests.
 - [ ] Categorize the PR by setting a good title and adding one of the labels:
-      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
+      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
       as they show up in the changelog
 - [ ] Link this PR to related issues.
 

--- a/.github/changelog-configuration.json
+++ b/.github/changelog-configuration.json
@@ -2,6 +2,10 @@
     "pr_template": "- ${{TITLE}} (#${{NUMBER}})",
     "categories": [
         {
+            "title": "## 🔎 Breaking Changes",
+            "labels": ["breaking"]
+        },
+        {
             "title": "## 🚀 Features",
             "labels": ["enhancement", "feature"]
         },
@@ -10,8 +14,8 @@
             "labels": ["change"]
         },
         {
-            "title": "## 🔎 Breaking Changes",
-            "labels": ["breaking"]
+            "title": "## 🪛 Internal Changes",
+            "labels": ["internal"]
         },
         {
             "title": "## 🐛 Fixes",


### PR DESCRIPTION
This allows us to separate changes which impact the user from changes that are purely internal to the Commodore code base in the changelog.

Additionally, the commit ensures that breaking changes will appear at the top of the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
