### PR TITLE
Improve support for `kustomize` in Commodore

### DIFF
--- a/commodore/__init__.py
+++ b/commodore/__init__.py
@@ -10,3 +10,6 @@ __version__ = version("syn-commodore")
 
 # provide Commodore installation dir as variable that can be imported
 __install_dir__ = P(__file__).parent
+
+# Location of Kustomize wrapper script
+__kustomize_wrapper__ = __install_dir__ / "scripts" / "run-kustomize"

--- a/commodore/cluster.py
+++ b/commodore/cluster.py
@@ -6,6 +6,7 @@ from typing import Any, Optional, Union
 
 import click
 
+from . import __kustomize_wrapper__
 from .helpers import (
     lieutenant_query,
     yaml_dump,
@@ -160,6 +161,7 @@ def render_target(
     }
     if not bootstrap:
         parameters["_base_directory"] = str(components[component].target_directory)
+        parameters["_kustomize_wrapper"] = str(__kustomize_wrapper__)
 
     for c in components:
         if inv.defaults_file(c).is_file():

--- a/commodore/component/compile.py
+++ b/commodore/component/compile.py
@@ -12,6 +12,7 @@ import click
 import git
 from kapitan.resources import inventory_reclass
 
+from commodore import __kustomize_wrapper__
 from commodore.config import Config
 from commodore.component import Component
 from commodore.dependency_mgmt.component_library import (
@@ -250,6 +251,7 @@ def _prepare_kapitan_inventory(
             "parameters": {
                 "_instance": instance_name,
                 "_base_directory": str(component.target_directory),
+                "_kustomize_wrapper": str(__kustomize_wrapper__),
             },
         },
         inv.target_file(instance_name),

--- a/commodore/lib/commodore.libjsonnet
+++ b/commodore/lib/commodore.libjsonnet
@@ -408,6 +408,43 @@ local generateResources(resources, resourceFn) =
     ]
   );
 
+/**
+ *
+ * \brief Generate a kustomization overlay
+ *
+ * \arg base_url        The URL of the base kustomization
+ * \arg base_version    The version of the base kustomization
+ * \arg images          An object with keys referring to container image URIs
+ *                      used in the base and values providing `newTag` and
+ *                      `newName` to apply.
+ * \arg kustomize_input User-provided content to merge into the overlay
+ *
+ * \returns an object suitable as a Jsonnet output to generate a
+ *          `kustomization.yaml` to be passed to `kustomize build`
+ */
+local kustomization(base_url, base_version='', images={}, kustomize_input={}) = {
+  // Generate `kustomization.yaml` as output
+  kustomization: {
+    // Configure the provided kustomization as a base for our overlay
+    resources: [
+      if base_version != '' then
+        '%s?ref=%s' % [ base_url, base_version ]
+      else
+        base_url,
+    ],
+    // Render `images` from the provided parameter
+    images: [
+      {
+        name: img,
+        newTag: images[img].newTag,
+        newName: images[img].newName,
+      }
+      for img in std.objectFields(images)
+    ],
+    // Inject the kustomize input provided in the component parameters
+  } + makeMergeable(kustomize_input),
+};
+
 {
   inventory: inventory,
   list_dir: list_dir,
@@ -424,4 +461,5 @@ local generateResources(resources, resourceFn) =
   fixupDir: fixupDir,
   renderArray: renderArray,
   generateResources: generateResources,
+  Kustomization: kustomization,
 }

--- a/commodore/scripts/run-kustomize
+++ b/commodore/scripts/run-kustomize
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# The wrapper always calls `kustomize build`. To use the wrapper provide the
+# directory in which the output should be written as the first argument. We
+# need to pass the output directory as an argument, because otherwise Kapitan
+# won't substitute `${compiled_target_dir}` with the path of the compilation
+# target directory. To avoid having to reimplement kustomize argument parsing,
+# we require that the output directory is the first argument.
+# Further arguments are passed to kustomize as provided. The input directory
+# is expected to be provided in environment variable ${INPUT_DIR}.
+#
+# export INPUT_DIR=/path/to/kustomization
+# run-kustomize <OUTPUT_DIR> [kustomize args...]
+#
+# Wrapper around kustomize which provides some convenience features
+# 1) The wrapper searches for the kustomize binary in ${PATH}
+# 2) The wrapper ensures that the user provides the expected arguments
+# 3) The wrapper ensures that the provided output directory exists
+#
+set -e
+
+# Kapitan provides a fairly standard PATH variable, we add /opt/homebrew/bin for macOS
+export PATH="${PATH}:/opt/homebrew/bin"
+
+kustomize=$(which kustomize) || (>&2 echo "kustomize not found in ${PATH}"; exit 7)
+
+if [ -z "${INPUT_DIR}" ]; then
+  (>&2 echo "INPUT_DIR environment variable not provided"; exit 2)
+fi
+
+# Assumption: output dir provided as first arg
+readonly output_dir="$1"
+if [ -z "${output_dir}" ]; then
+  (>&2 echo "First argument is empty, expected output directory as first argument"; exit 2)
+fi
+mkdir -p "${output_dir}"
+
+exec "$kustomize" build "${INPUT_DIR}" -o "${@}"

--- a/docs/modules/ROOT/pages/reference/commodore-libjsonnet.adoc
+++ b/docs/modules/ROOT/pages/reference/commodore-libjsonnet.adoc
@@ -269,3 +269,82 @@ stringData:
   secret: another
 type: Opaque
 ----
+
+== `Kustomization(base_url, base_version='', images={}, kustomize_input={})`
+
+This function generates a Kustomize overlay which uses the parameter `base_url` as a base resource.
+
+The parameters `base_url` and `base_version` are used to format an entry in the kustomization's https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/resource/[resources] field.
+
+=== Arguments
+
+`base_url`:: The URL of the base kustomization
+`base_version`:: The version of the base kustomization.
+The version can be any Git reference understood by `kustomize`.
+If version is the empty string, the base kustomization is added to `resources` without the `?ref=<version>` suffix
+`images`:: An object with keys referring to container image URIs used in the base and values providing `newTag` and `newName` to apply.
+The contents of parameter `images` are transformed into entries in the kustomization's https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/images/[`images`] field.
+`kustomize_input`:: User-provided content to merge into the overlay
+This variable is merged into the kustomization without further modifications.
+
+=== Return value
+
+An object suitable as a Jsonnet output to generate a `kustomization.yaml` to be passed to `kustomize build`.
+
+=== Example
+
+Let's look at what results from the following configuration, where `defaults.yml` is assumed to be a reclass class and `kustomization.jsonnet` a Commodore component Jsonnet script.
+
+.defaults.yml
+[source,yaml]
+----
+parameters:
+  <component-name>:
+    namespace: syn-example
+    images:
+      example:
+        registry: quay-mirror.syn.tools
+        repository: example
+        tag: v1.0.0
+    kustomize_input:
+      namespace: ${<component_name>:namespace}
+----
+
+.kustomization.jsonnet
+[source,jsonnet]
+----
+// Omitted `local params = ...` which reads the configuration
+// In the example the configuration has field `images` which specifies the
+// container images, and field `kustomize_input` which provides additional
+// kustomization configs.
+//local params = ...;
+
+// Render `kustomization.yaml`
+com.Kustomization(
+  'https://syn.example.com/example//config/default',
+  'v1.0.0',
+  {
+    // Assumes that `params.images.example` is formatted according to Commodore
+    // component best practices
+    'quay.io/syn/example': {
+      newTag: params.images.example.tag,
+      newName: '%(registry)s/%(repository)s' % params.images.example
+    }
+  },
+  params.kustomize_input,
+)
+----
+
+The rendered output will then be a single `kustomization.yaml` as shown below.
+
+.kustomization.yaml
+[source,yaml]
+----
+images:
+  - name: quay.io/syn/example
+    newName: quay-mirror.syn.tools/example
+    newTag: v1.0.0
+namespace: syn-example
+resources:
+  - https://syn.example.com/example//config/default?ref=v1.0.0
+----

--- a/docs/modules/ROOT/pages/reference/parameters.adoc
+++ b/docs/modules/ROOT/pages/reference/parameters.adoc
@@ -6,7 +6,7 @@ This class is created by Commodore in file `inventory/classes/params/cluster.yml
 
 The class is included in each Kapitan target with the lowest precedence of all classes.
 
-== Parameters
+== Global parameters
 
 === `cluster`
 
@@ -68,3 +68,21 @@ parameters:
 ----
 <1> The parameter is overwritten using dynamic facts in the Project Syn installation's global configuration repository.
 ====
+
+== Component-specific parameters
+
+Commodore adds some "meta-parameters" to each component's Kapitan target.
+These are provided to simplify component configurations.
+
+Commodore provides the following component-specific top-level parameters
+
+=== `_base_directory`
+
+This parameter provides the absolute path to the component's base directory.
+This parameter is intended for component authors to use in `kapitan.compile` and `kapitan.dependencies` entries when referencing files in the component directory.
+
+=== `_kustomize_wrapper`
+
+This parameter provides the absolute path to the Kustomize wrapper script bundled with Commodore.
+This parameter is intended for component authors to use to call Kustomize in components.
+See the xref:syn:ROOT:explanations/commodore-components/kustomizations.adoc[Kustomization best practices] for more details.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ packages = [
 include = [
     "commodore/lib/commodore.libjsonnet",
     "commodore/filters/helm_namespace.jsonnet",
+    "commodore/scripts/run-kustomize",
 ]
 
 [tool.poetry.dependencies]

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -9,7 +9,7 @@ import pytest
 from pathlib import Path as P
 from textwrap import dedent
 
-from commodore import cluster
+from commodore import cluster, __kustomize_wrapper__
 from commodore.inventory import Inventory
 from commodore.config import Config
 
@@ -58,7 +58,6 @@ def test_render_bootstrap_target(tmp_path: P):
         "global.commodore",
     ]
     assert target != ""
-    print(target)
     assert len(target["classes"]) == len(
         classes
     ), "rendered target includes different amount of classes"
@@ -66,6 +65,7 @@ def test_render_bootstrap_target(tmp_path: P):
         assert target["classes"][i] == classes[i]
     assert target["parameters"]["_instance"] == "cluster"
     assert "_base_directory" not in target["parameters"]
+    assert "_kustomize_wrapper" not in target["parameters"]
 
 
 def test_render_target(tmp_path: P):
@@ -89,7 +89,6 @@ def test_render_target(tmp_path: P):
         "components.foo",
     ]
     assert target != ""
-    print(target)
     assert len(target["classes"]) == len(
         classes
     ), "rendered target includes different amount of classes"
@@ -98,6 +97,7 @@ def test_render_target(tmp_path: P):
     assert target["parameters"]["kapitan"]["vars"]["target"] == "foo"
     assert target["parameters"]["_instance"] == "foo"
     assert target["parameters"]["_base_directory"] == str(tmp_path / "foo")
+    assert target["parameters"]["_kustomize_wrapper"] == str(__kustomize_wrapper__)
 
 
 def test_render_aliased_target(tmp_path: P):


### PR DESCRIPTION
Provide the absolute path to the script in reclass variable `${_kustomize_wrapper}`, to allow users to make use of Kustomize without having to worry about the binary location being different on different systems.

The PR also provides a new function in `commodore.libjsonnet`, which generates an object which is suitable as a Jsonnet output to render a `kustomization.yaml` which can be processed by `kustomize build`.

See https://github.com/projectsyn/documentation/pull/169 for extended documentation.

Closes #504 

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
