### PR TITLE
Avoid crash in `inventory lint` when top-level `parameters` is not an object

### DIFF
--- a/commodore/inventory/lint.py
+++ b/commodore/inventory/lint.py
@@ -67,6 +67,11 @@ def _lint_file(cfg: Config, file: Path, lintfunc: LintFunc) -> int:
                 click.echo(
                     f"> Skipping file {file}: Expected top-level dictionary in YAML document"
                 )
+        elif not isinstance(filecontents[0].get("parameters", {}), dict):
+            if cfg.debug:
+                click.echo(
+                    f"> Skipping file {file}: Expected key 'parameters' to be a dict"
+                )
         else:
             errcount = lintfunc(file, filecontents[0])
 

--- a/tests/test_inventory_lint_components.py
+++ b/tests/test_inventory_lint_components.py
@@ -103,6 +103,7 @@ SKIP_FILECONTENTS = [
     ("\tTest", "Unable to load as YAML"),
     ([{"a": 1}, {"b": 2}], "Linting multi-document YAML streams is not supported"),
     ([[1, 2, 3]], "Expected top-level dictionary in YAML document"),
+    ([{"parameters": ["foo", "bar"]}], "Expected key 'parameters' to be a dict"),
 ]
 
 
@@ -201,6 +202,7 @@ def _setup_directory(tmp_path: Path):
         tmp_path / "d3" / "tab.txt",
         tmp_path / "d3" / "stream.yaml",
         tmp_path / "d3" / "top-level.yaml",
+        tmp_path / "test6.yml",
     ]
     assert len(skip_direntries) == len(SKIP_FILECONTENTS)
 


### PR DESCRIPTION
Until now, we didn't check whether a top-level key `parameters` is actually a dict, which caused a crash in the linter when a non-inventory file (e.g.  an OpenShift template) has such a top-level key.

This commit simply skips files which have a top-level key `parameters` which isn't a dict.

Part of #659

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
