### PR TITLE
Implement ignore patterns for `inventory lint`

### DIFF
--- a/commodore/cli.py
+++ b/commodore/cli.py
@@ -1239,9 +1239,9 @@ def package_versions(
 def inventory_lint(
     config: Config,
     verbose: int,
-    target: tuple[str],
-    linter: tuple[str],
-    ignore_patterns: tuple[str],
+    target: tuple[str, ...],
+    linter: tuple[str, ...],
+    ignore_patterns: tuple[str, ...],
 ):
     """Lint YAML files in the provided paths.
 

--- a/commodore/inventory/lint.py
+++ b/commodore/inventory/lint.py
@@ -26,28 +26,28 @@ class LintFunc(Protocol):
 class Linter:
     @abc.abstractmethod
     def __call__(
-        self, config: Config, path: Path, ignore_patterns: tuple[str] = ()
+        self, config: Config, path: Path, ignore_patterns: tuple[str, ...] = ()
     ) -> int:
         ...
 
 
 class ComponentSpecLinter(Linter):
     def __call__(
-        self, config: Config, path: Path, ignore_patterns: tuple[str] = ()
+        self, config: Config, path: Path, ignore_patterns: tuple[str, ...] = ()
     ) -> int:
         return run_linter(config, path, ignore_patterns, lint_components)
 
 
 class DeprecatedParameterLinter(Linter):
     def __call__(
-        self, config: Config, path: Path, ignore_patterns: tuple[str] = ()
+        self, config: Config, path: Path, ignore_patterns: tuple[str, ...] = ()
     ) -> int:
         return run_linter(config, path, ignore_patterns, lint_deprecated_parameters)
 
 
 class PackageSpecLinter(Linter):
     def __call__(
-        self, config: Config, path: Path, ignore_patterns: tuple[str] = ()
+        self, config: Config, path: Path, ignore_patterns: tuple[str, ...] = ()
     ) -> int:
         return run_linter(config, path, ignore_patterns, lint_packages)
 
@@ -124,7 +124,9 @@ def _read_ignore_patterns_from_file(path: Path) -> set[str]:
     return ignore_patterns
 
 
-def _render_ignore_patterns(base_dir: Path, ignore_patterns: tuple[str]) -> set[Path]:
+def _render_ignore_patterns(
+    base_dir: Path, ignore_patterns: tuple[str, ...]
+) -> set[Path]:
     """Use `glob.glob()` to render the paths to ignore from `ignore_patterns`.
     All patterns are rooted at `base_dir`.
 
@@ -149,7 +151,7 @@ def _render_ignore_patterns(base_dir: Path, ignore_patterns: tuple[str]) -> set[
 
 
 def run_linter(
-    cfg: Config, path: Path, ignore_patterns: tuple[str], lintfunc: LintFunc
+    cfg: Config, path: Path, ignore_patterns: tuple[str, ...], lintfunc: LintFunc
 ) -> int:
     """Run lint function `lintfunc` in `path`.
 

--- a/commodore/inventory/lint.py
+++ b/commodore/inventory/lint.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import abc
+import glob
 
 from collections.abc import Iterable
 from pathlib import Path
@@ -24,23 +25,31 @@ class LintFunc(Protocol):
 
 class Linter:
     @abc.abstractmethod
-    def __call__(self, config: Config, path: Path) -> int:
+    def __call__(
+        self, config: Config, path: Path, ignore_patterns: tuple[str] = ()
+    ) -> int:
         ...
 
 
 class ComponentSpecLinter(Linter):
-    def __call__(self, config: Config, path: Path) -> int:
-        return run_linter(config, path, lint_components)
+    def __call__(
+        self, config: Config, path: Path, ignore_patterns: tuple[str] = ()
+    ) -> int:
+        return run_linter(config, path, ignore_patterns, lint_components)
 
 
 class DeprecatedParameterLinter(Linter):
-    def __call__(self, config: Config, path: Path) -> int:
-        return run_linter(config, path, lint_deprecated_parameters)
+    def __call__(
+        self, config: Config, path: Path, ignore_patterns: tuple[str] = ()
+    ) -> int:
+        return run_linter(config, path, ignore_patterns, lint_deprecated_parameters)
 
 
 class PackageSpecLinter(Linter):
-    def __call__(self, config: Config, path: Path) -> int:
-        return run_linter(config, path, lint_packages)
+    def __call__(
+        self, config: Config, path: Path, ignore_patterns: tuple[str] = ()
+    ) -> int:
+        return run_linter(config, path, ignore_patterns, lint_packages)
 
 
 LINTERS = {
@@ -82,7 +91,9 @@ def _lint_file(cfg: Config, file: Path, lintfunc: LintFunc) -> int:
     return errcount
 
 
-def _lint_directory(cfg: Config, path: Path, lintfunc: LintFunc) -> int:
+def _lint_directory(
+    cfg: Config, path: Path, ignore_paths: set[Path], lintfunc: LintFunc
+) -> int:
     if not path.is_dir():
         raise ValueError("Unexpected path argument: expected to be a directory")
 
@@ -92,14 +103,54 @@ def _lint_directory(cfg: Config, path: Path, lintfunc: LintFunc) -> int:
             if cfg.debug:
                 click.echo(f"> Skipping hidden directory entry {dentry}")
             continue
+        if dentry.absolute() in ignore_paths:
+            if cfg.debug:
+                click.echo(f"> Skipping ignored directory entry {dentry}")
+            continue
         if dentry.is_dir():
-            errcount += _lint_directory(cfg, dentry, lintfunc)
+            errcount += _lint_directory(cfg, dentry, ignore_paths, lintfunc)
         else:
             errcount += _lint_file(cfg, dentry, lintfunc)
     return errcount
 
 
-def run_linter(cfg: Config, path: Path, lintfunc: LintFunc) -> int:
+def _read_ignore_patterns_from_file(path: Path) -> set[str]:
+    ignore_patterns = set()
+    if path.is_file():
+        with open(path, "r", encoding="utf-8") as ifile:
+            for p in ifile.readlines():
+                ignore_patterns.add(p.strip())
+
+    return ignore_patterns
+
+
+def _render_ignore_patterns(base_dir: Path, ignore_patterns: tuple[str]) -> set[Path]:
+    """Use `glob.glob()` to render the paths to ignore from `ignore_patterns`.
+    All patterns are rooted at `base_dir`.
+
+    If pattern doesn't start with /, we will treat it as matching any prefix in
+    `base_dir`."""
+
+    # Read additional ignore patterns from `<base_dir>/.commodoreignore`, if the file
+    # exists
+    _ignore_patterns = set(ignore_patterns)
+    # Extend ignore patterns set with ignore patterns from `.commodoreignore`
+    _ignore_patterns |= _read_ignore_patterns_from_file(base_dir / ".commodoreignore")
+
+    ignore_paths: set[str] = set()
+    for pat in _ignore_patterns:
+        if pat.startswith("/"):
+            pat = f"{base_dir.absolute()}{pat}"
+        else:
+            pat = f"{base_dir.absolute()}/**/{pat}"
+        ignore_paths |= set(glob.glob(pat, recursive=True))
+
+    return {Path(p) for p in ignore_paths}
+
+
+def run_linter(
+    cfg: Config, path: Path, ignore_patterns: tuple[str], lintfunc: LintFunc
+) -> int:
     """Run lint function `lintfunc` in `path`.
 
     If `path` is a directory, run the function in all `.ya?ml` files in the directory
@@ -109,8 +160,18 @@ def run_linter(cfg: Config, path: Path, lintfunc: LintFunc) -> int:
     Returns a value that can be used as exit code to indicate whether there were linting
     errors.
     """
+    base_dir = path.absolute()
+    if not base_dir.is_dir():
+        base_dir = path.parent
+    ignore_paths = _render_ignore_patterns(base_dir, ignore_patterns)
+
+    if path.absolute() in ignore_paths:
+        if cfg.debug:
+            click.echo(f" > Skipping ignored path {path}")
+        return 0
+
     if path.is_dir():
-        return _lint_directory(cfg, path, lintfunc)
+        return _lint_directory(cfg, path, ignore_paths, lintfunc)
 
     return _lint_file(cfg, path, lintfunc)
 

--- a/docs/modules/ROOT/pages/reference/cli.adoc
+++ b/docs/modules/ROOT/pages/reference/cli.adoc
@@ -282,6 +282,10 @@ However, labels added by previous runs can't be removed since we've got no easy 
   Can be repeated.
   If this parameter isn't specified, all known linters are enabled.
 
+*--ignore-patterns=GLOB*::
+  Glob pattern(s) indicating path(s) to ignore.
+  Can be repeated.
+
 == Login
 
 *--oidc-discovery-url* URL::

--- a/docs/modules/ROOT/pages/reference/commands.adoc
+++ b/docs/modules/ROOT/pages/reference/commands.adoc
@@ -165,6 +165,18 @@ The command takes zero or more paths to files or directories to lint as command 
 It silently skips files which aren't valid YAML, as well as empty files and files containing multi-document YAML streams.
 All other files are assumed to be Commodore inventory classes.
 
+Individual files or whole directory trees can be ignored by providing glob patterns.
+Glob patterns can be provided in command line argument `--ignore-patterns` or in `.commodoreignore` in the provided path.
+Patterns provided in `--ignore-patterns` are applied in each target path.
+In contrast, `.commodoreignore` files are only applied to the target path in which they're saved.
+
+The provided patterns are expanded recursively using Python's `glob` library.
+You can use `*`, `?`, and character ranges expressed as `[]` with the usual semantics of shell globbing.
+Additionally, you can use `**` to indicate an arbitrary amount of subdirectories.
+Patterns which start with `/` are treated as anchored in the target path.
+All other patterns are treated as matching any subpath in the target path.
+
+
 When linting directories, any hidden files (prefixed with a dot) are ignored.
 Directories are linted recursively and the same skipping logic as for individual files is applied.
 


### PR DESCRIPTION
Patterns can be provided either on the command line in `--ignore-patterns` or in a `.commodoreignore` file in the linting
target path. Patterns given on the command line apply for each target path, while `.commodoreignore` applies only for the target path in which the file is present.

Patterns are expanded recursively using Python's `glob` library.  You can use `*`, `?`, and character ranges expressed as `[]` with the usual semantics of shell globbing, and `**` to indicate an arbitrary amount of subdirectories. Patterns which start with `/` are treated as anchored in the target path, while other patterns are treated as matching any subpath in the target path.

Part of #659 

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
