### PR TITLE
Make non-dictionary key `parameters` a linting error

### DIFF
--- a/commodore/inventory/lint.py
+++ b/commodore/inventory/lint.py
@@ -76,11 +76,6 @@ def _lint_file(cfg: Config, file: Path, lintfunc: LintFunc) -> int:
                 click.echo(
                     f"> Skipping file {file}: Expected top-level dictionary in YAML document"
                 )
-        elif not isinstance(filecontents[0].get("parameters", {}), dict):
-            if cfg.debug:
-                click.echo(
-                    f"> Skipping file {file}: Expected key 'parameters' to be a dict"
-                )
         else:
             errcount = lintfunc(file, filecontents[0])
 

--- a/commodore/inventory/lint_dependency_specification.py
+++ b/commodore/inventory/lint_dependency_specification.py
@@ -11,7 +11,15 @@ def lint_dependency_specification(
     deptype: DepType, file: Path, filecontents: dict[str, Any]
 ) -> int:
     errcount = 0
-    components = filecontents.get("parameters", {}).get(deptype.value, {})
+    params = filecontents.get("parameters", {})
+    if not isinstance(params, dict):
+        click.secho(
+            f"> Key 'parameters' isn't a dictionary in {file}",
+            fg="red",
+        )
+        return 1
+
+    components = params.get(deptype.value, {})
     deptype_str = deptype.name.capitalize()
     for d, dspec in components.items():
         if "version" not in dspec:

--- a/tests/test_inventory_lint_components.py
+++ b/tests/test_inventory_lint_components.py
@@ -16,6 +16,7 @@ from commodore.inventory import lint
 LINT_FILECONTENTS = [
     ({}, 0),
     ({"a": "b"}, 0),
+    ({"parameters": ["foo", "bar"]}, 1),
     (
         {
             "parameters": {
@@ -103,7 +104,6 @@ SKIP_FILECONTENTS = [
     ("\tTest", "Unable to load as YAML"),
     ([{"a": 1}, {"b": 2}], "Linting multi-document YAML streams is not supported"),
     ([[1, 2, 3]], "Expected top-level dictionary in YAML document"),
-    ([{"parameters": ["foo", "bar"]}], "Expected key 'parameters' to be a dict"),
 ]
 
 
@@ -195,6 +195,7 @@ def _setup_directory(tmp_path: Path):
         tmp_path / "d2" / "test3.yml",
         tmp_path / "d2" / "subd" / "test4.yml",
         tmp_path / "d3" / "test5.yml",
+        tmp_path / "test6.yml",
     ]
     assert len(lint_direntries) == len(LINT_FILECONTENTS)
     skip_direntries = [
@@ -202,7 +203,6 @@ def _setup_directory(tmp_path: Path):
         tmp_path / "d3" / "tab.txt",
         tmp_path / "d3" / "stream.yaml",
         tmp_path / "d3" / "top-level.yaml",
-        tmp_path / "test6.yml",
     ]
     assert len(skip_direntries) == len(SKIP_FILECONTENTS)
 


### PR DESCRIPTION
We can now ignore files which shouldn't be linted (cf. #665), so we can make a non-dictionary key `parameters` in a Commodore inventory file a lint error instead of skipping such files.

Fixes #659

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
