### PR TITLE
Add support for selective dependency syncing

### DIFF
--- a/commodore/cli/component.py
+++ b/commodore/cli/component.py
@@ -347,6 +347,7 @@ def component_compile(
 @options.pr_label
 @options.pr_batch_size
 @options.github_pause
+@options.dependency_filter
 def component_sync(
     config: Config,
     verbose: int,
@@ -357,6 +358,7 @@ def component_sync(
     pr_label: Iterable[str],
     pr_batch_size: int,
     github_pause: int,
+    filter: str,
 ):
     """This command processes all components listed in the provided `COMPONENT_LIST`
     YAML file.
@@ -364,6 +366,10 @@ def component_sync(
     Currently, the command only supports updating components hosted on GitHub. The
     command expects that the YAML file contains a single document with a list of GitHub
     repositories in form `organization/repository-name`.
+
+    The command supports selectively updating components through parameter `--filter`.
+    This parameter enables callers to filter the list provided in the YAML file by an
+    arbitrary regex.
 
     The command clones each component and runs `component update` on the local copy. If
     there are any changes, the command creates a PR for the changes. For each component,
@@ -388,4 +394,5 @@ def component_sync(
         ComponentTemplater,
         pr_batch_size,
         timedelta(seconds=github_pause),
+        filter,
     )

--- a/commodore/cli/options.py
+++ b/commodore/cli/options.py
@@ -119,7 +119,8 @@ dependency_filter = click.option(
     type=str,
     show_default=False,
     help="Regex to select which dependencies to sync. "
-    + "By default all dependencies listed in the provided YAML are synced.",
+    + "If the option isn't given, all dependencies listed in the provided YAML "
+    + "are synced.",
 )
 
 

--- a/commodore/cli/options.py
+++ b/commodore/cli/options.py
@@ -112,6 +112,16 @@ github_pause = click.option(
     + "Tune this parameter if your sync job hits the GitHub secondary rate limit.",
 )
 
+dependency_filter = click.option(
+    "--filter",
+    metavar="REGEX",
+    default="",
+    type=str,
+    show_default=False,
+    help="Regex to select which dependencies to sync. "
+    + "By default all dependencies listed in the provided YAML are synced.",
+)
+
 
 def local(help: str):
     return click.option(

--- a/commodore/cli/package.py
+++ b/commodore/cli/package.py
@@ -276,6 +276,7 @@ def package_compile(
 @options.pr_label
 @options.pr_batch_size
 @options.github_pause
+@options.dependency_filter
 def package_sync(
     config: Config,
     verbose: int,
@@ -286,12 +287,17 @@ def package_sync(
     pr_label: Iterable[str],
     pr_batch_size: int,
     github_pause: int,
+    filter: str,
 ):
     """This command processes all packages listed in the provided `PACKAGE_LIST` YAML file.
 
     Currently, the command only supports updating packages hosted on GitHub. The command
     expects that the YAML file contains a single document with a list of GitHub
     repositories in form `organization/repository-name`.
+
+    The command supports selectively updating components through parameter `--filter`.
+    This parameter enables callers to filter the list provided in the YAML file by an
+    arbitrary regex.
 
     The command clones each package and runs `package update` on the local copy. If
     there are any changes, the command creates a PR for the changes. For each package,
@@ -316,4 +322,5 @@ def package_sync(
         PackageTemplater,
         pr_batch_size,
         timedelta(seconds=github_pause),
+        filter,
     )

--- a/commodore/dependency_syncer.py
+++ b/commodore/dependency_syncer.py
@@ -2,14 +2,16 @@ from __future__ import annotations
 
 import time
 
+from collections.abc import Iterable
 from datetime import timedelta
 from pathlib import Path
-from typing import Iterable, Union, Type
+from typing import Union, Type
 
 import click
 import git
 import github
 import yaml.parser
+import yaml.scanner
 
 from github.Repository import Repository
 

--- a/docs/modules/ROOT/pages/reference/cli.adoc
+++ b/docs/modules/ROOT/pages/reference/cli.adoc
@@ -263,6 +263,10 @@ However, labels added by previous runs can't be removed since we've got no easy 
   The duration for which to pause (in seconds) after creating a number of PRs according to `--pr-batch-size`.
   Tune this parameter if your sync job hits the GitHub secondary rate limit.
 
+*--filter* REGEX::
+    Regex to select which dependencies to sync.
+    If the option isn't given, all dependencies listed in the provided YAML are synced.
+
 == Inventory Components / Packages / Show
 
 *-f, --values*::
@@ -457,3 +461,7 @@ However, labels added by previous runs can't be removed since we've got no easy 
 *--github-pause* SECONDS::
   The duration for which to pause (in seconds) after creating a number of PRs according to `--pr-batch-size`.
   Tune this parameter if your sync job hits the GitHub secondary rate limit.
+
+*--filter* REGEX::
+    Regex to select which dependencies to sync.
+    If the option isn't given, all dependencies listed in the provided YAML are synced.

--- a/docs/modules/ROOT/pages/reference/commands.adoc
+++ b/docs/modules/ROOT/pages/reference/commands.adoc
@@ -112,6 +112,9 @@ This command processes all components listed in the provided `COMPONENT_LIST` YA
 Currently, the command only supports updating components hosted on GitHub.
 The command expects that the YAML file contains a single document with a list of GitHub repositories in form `organization/repository-name`.
 
+The command supports selectively updating components through parameter `--filter`.
+This parameter enables callers to filter the list provided in the YAML file by an arbitrary regex.
+
 The command clones each component and runs `component update` on the local copy. If there are any changes, the command creates a PR for the changes.
 For each component, the command parses the component's `.cruft.json` to determine the template repository and template version for the component.
 The command bases each PR on the default branch of the corresponding component repository as reported by the GitHub API.
@@ -251,6 +254,9 @@ This command processes all packages listed in the provided `PACKAGE_LIST` YAML f
 
 Currently, the command only supports updating packages hosted on GitHub.
 The command expects that the YAML file contains a single document with a list of GitHub repositories in form `organization/repository-name`.
+
+The command supports selectively updating packages through parameter `--filter`.
+This parameter enables callers to filter the list provided in the YAML file by an arbitrary regex.
 
 The command clones each package and runs `package update` on the local copy.
 If there are any changes, the command creates a PR for the changes.

--- a/tests/test_cli_component.py
+++ b/tests/test_cli_component.py
@@ -73,6 +73,7 @@ def test_component_sync_cli(
         templater: Type,
         pr_batch_size: int,
         github_pause: int,
+        filter: str,
     ):
         assert config.github_token == ghtoken
         assert deplist.absolute() == dep_list.absolute()
@@ -83,6 +84,7 @@ def test_component_sync_cli(
         assert templater == ComponentTemplater
         assert pr_batch_size == 10
         assert github_pause == timedelta(seconds=120)
+        assert filter == ""
 
     mock_sync_dependencies.side_effect = sync_deps
     result = cli_runner(["component", "sync", "deps.yaml"])

--- a/tests/test_cli_package.py
+++ b/tests/test_cli_package.py
@@ -41,6 +41,7 @@ def test_package_sync_cli(
         templater: Type,
         pr_batch_size: int,
         github_pause: int,
+        filter: str,
     ):
         assert config.github_token == ghtoken
         assert pkglist.absolute() == pkg_list.absolute()
@@ -51,6 +52,7 @@ def test_package_sync_cli(
         assert templater == PackageTemplater
         assert pr_batch_size == 10
         assert github_pause == timedelta(seconds=120)
+        assert filter == ""
 
     mock_sync_packages.side_effect = sync_pkgs
     result = cli_runner(["package", "sync", "pkgs.yaml"])

--- a/tests/test_dependency_sync.py
+++ b/tests/test_dependency_sync.py
@@ -655,3 +655,28 @@ def test_render_pr_comment(tmp_path: Path, config: Config):
         + " a\n"
         + "```\n"
     )
+
+
+@pytest.mark.parametrize(
+    "deps,filter,expected",
+    [
+        ([], "", []),
+        ([], "foo", []),
+        (["org/bar"], "foo", []),
+        (["org/foo"], "foo", ["org/foo"]),
+        (["org/foo", "org/bar"], "foo", ["org/foo"]),
+        (["org/foo", "org/bar"], "org", ["org/foo", "org/bar"]),
+        (["org/foo", "org/bar", "org2/foo"], "foo$", ["org/foo", "org2/foo"]),
+        (["org1/foo", "org2/bar", "org3/org1"], "^org1", ["org1/foo"]),
+    ],
+)
+def test_read_dependency_list(
+    tmp_path: Path, deps: list[str], filter: str, expected: list[str]
+):
+    listf = tmp_path / "deps.yaml"
+    with open(listf, "w", encoding="utf-8") as f:
+        yaml.safe_dump(deps, f)
+
+    computed = dependency_syncer.read_dependency_list(listf, filter)
+
+    assert computed == expected


### PR DESCRIPTION
This PR implements a new option `--filter REGEX` for `component sync` and `package sync`. This option allows callers to selectively sync only dependencies which match the provided regex. The base set of dependencies is still always loaded from the given YAML file.

In the dependency syncer implementation, the PR moves loading and filtering of the dependency file into a separate function.

Resolves #615 

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
