### PR TITLE
Label Renovate lockFileMaintenance PRs with `ignore`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,8 @@
     "enabled": true
   },
   "lockFileMaintenance": {
-    "enabled": true
+    "enabled": true,
+    "labels": ["ignore"]
   },
   "ignoreDeps": [
     "gitpython",


### PR DESCRIPTION
We don't really need the "Lock file maintenance" PRs to show up in the Commodore release notes. This commit sets label `ignore` to explicitly mark those PRs as not relevant for the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog


<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
