### PR TITLE
Add missing `Optional` to function arguments with default value `None`

### DIFF
--- a/commodore/dependency_mgmt/jsonnet_bundler.py
+++ b/commodore/dependency_mgmt/jsonnet_bundler.py
@@ -5,6 +5,7 @@ import json
 from collections.abc import Iterable
 from pathlib import Path
 from subprocess import call  # nosec
+from typing import Optional
 
 import click
 
@@ -65,7 +66,7 @@ def write_jsonnetfile(file: Path, deps: Iterable):
         f.write("\n")
 
 
-def fetch_jsonnet_libraries(cwd: Path, deps: Iterable = None):
+def fetch_jsonnet_libraries(cwd: Path, deps: Optional[Iterable] = None):
     """
     Download Jsonnet libraries using Jsonnet-Bundler.
     """

--- a/commodore/helpers.py
+++ b/commodore/helpers.py
@@ -147,7 +147,7 @@ def clean_working_tree(config: Config):
 def kapitan_compile(
     config: Config,
     targets: Iterable[str],
-    output_dir: P = None,
+    output_dir: Optional[P] = None,
     search_paths=None,
     fake_refs=False,
     reveal=False,

--- a/commodore/inventory/__init__.py
+++ b/commodore/inventory/__init__.py
@@ -1,6 +1,6 @@
 from os import makedirs
 from pathlib import Path as P
-from typing import Union
+from typing import Optional, Union
 
 from commodore.component import Component
 
@@ -8,7 +8,7 @@ from commodore.component import Component
 class Inventory:
     _work_dir: P
 
-    def __init__(self, work_dir: P = None):
+    def __init__(self, work_dir: Optional[P] = None):
         if work_dir:
             self._work_dir = work_dir
         else:

--- a/commodore/inventory/parameters.py
+++ b/commodore/inventory/parameters.py
@@ -287,7 +287,9 @@ class InventoryFactory:
             )
         )
 
-    def _find_values(self, fact: DefaultsFact, cloud: str = None) -> Iterable[str]:
+    def _find_values(
+        self, fact: DefaultsFact, cloud: Optional[str] = None
+    ) -> Iterable[str]:
         values = []
         value_path = self.global_dir / fact.value
         if fact == DefaultsFact.REGION:


### PR DESCRIPTION
Mypy has started to emit the following error for arguments with default values which don't match the argument's type annotation:

```
error: Incompatible default for argument "cloud" (default has type "None", argument has type "str")  [assignment]
note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True
```

This commit fixes all occurrences of this new error in the Commodore code base.

Discovered in #683 

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
