### PR TITLE
Add new command line flag `--force` for `catalog compile`

### DIFF
--- a/commodore/cli/catalog.py
+++ b/commodore/cli/catalog.py
@@ -129,8 +129,11 @@ def clean(config: Config, verbose):
     "--force/--no-force",
     default=False,
     show_default=True,
-    help="Discard local changes in tenant or global repo. "
-    + "Has no effect if `--local` is given.",
+    help="With `--force` local changes in tenant, global, or dependency repos are discarded. "
+    + "In the global and tenant repo, untracked files, uncommitted changes in tracked files, "
+    + "local commits and local branches count as local changes. In dependency repos only "
+    + "uncommitted changes in tracked files count as local changes."
+    + "The parameter has no effect if `--local` is given.",
 )
 @options.verbosity
 @options.pass_config

--- a/commodore/cli/catalog.py
+++ b/commodore/cli/catalog.py
@@ -125,6 +125,13 @@ def clean(config: Config, verbose):
         + "prefixed with `json:` isn't valid JSON, it will be skipped."
     ),
 )
+@click.option(
+    "--force/--no-force",
+    default=False,
+    show_default=True,
+    help="Discard local changes in tenant or global repo. "
+    + "Has no effect if `--local` is given.",
+)
 @options.verbosity
 @options.pass_config
 # pylint: disable=too-many-arguments
@@ -147,6 +154,7 @@ def compile_catalog(
     fetch_dependencies,
     migration,
     dynamic_fact: str,
+    force: bool,
 ):
     config.update_verbosity(verbose)
     config.api_url = api_url
@@ -163,6 +171,7 @@ def compile_catalog(
     config.oidc_discovery_url = oidc_discovery_url
     config.fetch_dependencies = fetch_dependencies
     config.dynamic_facts = parse_dynamic_facts_from_cli(dynamic_fact)
+    config.force = not config.local and force
 
     if config.push and (
         config.global_repo_revision_override or config.tenant_repo_revision_override

--- a/commodore/compile.py
+++ b/commodore/compile.py
@@ -94,12 +94,7 @@ def _fetch_customer_config(cfg: Config, cluster: Cluster):
     cfg.register_config("customer", repo)
 
 
-def _regular_setup(config: Config, cluster_id):
-    try:
-        cluster = load_cluster_from_api(config, cluster_id)
-    except ApiError as e:
-        raise click.ClickException(f"While fetching cluster specification: {e}") from e
-
+def _regular_setup(config: Config, cluster: Cluster):
     update_target(config, config.inventory.bootstrap_target)
     update_params(config.inventory, cluster)
 
@@ -246,8 +241,14 @@ def compile(config, cluster_id):
     if config.local:
         catalog_repo = _local_setup(config, cluster_id)
     else:
+        try:
+            cluster = load_cluster_from_api(config, cluster_id)
+        except ApiError as e:
+            raise click.ClickException(
+                f"While fetching cluster specification: {e}"
+            ) from e
         clean_working_tree(config)
-        catalog_repo = _regular_setup(config, cluster_id)
+        catalog_repo = _regular_setup(config, cluster)
 
     inventory, targets = setup_compile_environment(config)
 

--- a/commodore/component/__init__.py
+++ b/commodore/component/__init__.py
@@ -171,6 +171,25 @@ class Component:
             )
         self._dependency.checkout_component(self.name, self.version)
 
+    def checkout_is_dirty(self) -> bool:
+        if self._dependency:
+            dep_repo = self._dependency.bare_repo
+            author_name = dep_repo.author.name
+            author_email = dep_repo.author.email
+            worktree = self._dependency.get_component(self.name)
+        else:
+            author_name = None
+            author_email = None
+            worktree = self.target_dir
+
+        if worktree and worktree.is_dir():
+            r = GitRepo(
+                None, worktree, author_name=author_name, author_email=author_email
+            )
+            return r.repo.is_dirty()
+        else:
+            return False
+
     def render_jsonnetfile_json(self, component_params):
         """
         Render jsonnetfile.json from jsonnetfile.jsonnet

--- a/commodore/dependency_mgmt/__init__.py
+++ b/commodore/dependency_mgmt/__init__.py
@@ -81,6 +81,11 @@ def fetch_components(cfg: Config):
             version=cspec.version,
             sub_path=cspec.path,
         )
+        if c.checkout_is_dirty() and not cfg.force:
+            raise click.ClickException(
+                f"Component {cn} has uncommitted changes. "
+                + "Please specify `--force` to discard them"
+            )
         c.checkout()
         cfg.register_component(c)
         create_component_symlinks(cfg, c)
@@ -157,6 +162,11 @@ def fetch_packages(cfg: Config):
             version=pspec.version,
             sub_path=pspec.path,
         )
+        if pkg.checkout_is_dirty() and not cfg.force:
+            raise click.ClickException(
+                f"Package {p} has uncommitted changes. "
+                + "Please specify `--force` to discard them"
+            )
         pkg.checkout()
         cfg.register_package(p, pkg)
         create_package_symlink(cfg, p, pkg)

--- a/commodore/gitrepo.py
+++ b/commodore/gitrepo.py
@@ -331,6 +331,10 @@ class GitRepo:
         return self._repo.remote(remote).fetch(tags=tags, prune=prune)
 
     def has_local_branches(self) -> bool:
+        if len(self.repo.remotes) == 0:
+            # If we don't have a remote, the fact that we have local branches is
+            # useless to determine whether to abort or continue a compile.
+            return False
         local_heads = set(h.name for h in self.repo.heads)
         remote_prefix = self._remote_prefix()
         remote_heads = set(h.name.replace(remote_prefix, "", 1) for h in self.fetch())

--- a/commodore/gitrepo.py
+++ b/commodore/gitrepo.py
@@ -343,6 +343,22 @@ class GitRepo:
     def has_local_changes(self) -> bool:
         return self._repo.is_dirty() or len(self._repo.untracked_files) > 0
 
+    def is_ahead_of_remote(self) -> bool:
+        if self.repo.head.is_detached:
+            # Always return False for repo which has a detached head checked out.
+            return False
+
+        active_branch = self.repo.active_branch
+        tracking_branch = active_branch.tracking_branch()
+        if not tracking_branch:
+            # If there's no tracking branch there's no point in reporting that we're
+            # ahead of anything.
+            return False
+
+        return (
+            len(list(self.repo.iter_commits(f"{tracking_branch}..{active_branch}"))) > 0
+        )
+
     def _create_worktree(self, worktree: Path, version: str):
         """Create worktree.
 

--- a/commodore/gitrepo/__init__.py
+++ b/commodore/gitrepo/__init__.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import difflib
 import hashlib
 import re
 import shutil
@@ -8,7 +7,7 @@ import shutil
 from collections import namedtuple
 from collections.abc import Iterable, Sequence
 from pathlib import Path
-from typing import Optional, Protocol
+from typing import Optional
 
 import click
 
@@ -17,6 +16,8 @@ from git.objects import Tree
 
 from url_normalize import url_normalize
 from url_normalize.tools import deconstruct_url, reconstruct_url
+
+from .diff import DiffFunc, default_difffunc, process_diff
 
 
 class RefError(ValueError):
@@ -28,13 +29,6 @@ class MergeConflict(ValueError):
 
 
 CommitInfo = namedtuple("CommitInfo", ["commit", "branch", "tag"])
-
-
-class DiffFunc(Protocol):
-    def __call__(
-        self, before_text: str, after_text: str, fromfile: str = "", tofile: str = ""
-    ) -> tuple[Iterable[str], bool]:
-        ...
 
 
 def _normalize_git_ssh(url: str) -> str:
@@ -73,73 +67,6 @@ def normalize_git_url(url: str) -> str:
     elif url.startswith("http://") or url.startswith("https://"):
         url = url_normalize(url)
     return url
-
-
-def _colorize_diff(line: str) -> str:
-    if line.startswith("--- ") or line.startswith("+++ ") or line.startswith("@@ "):
-        return click.style(line, fg="yellow")
-    if line.startswith("+"):
-        return click.style(line, fg="green")
-    if line.startswith("-"):
-        return click.style(line, fg="red")
-    return line
-
-
-def _compute_similarity(change):
-    before = change.b_blob.data_stream.read().decode("utf-8").split("\n")
-    after = change.a_blob.data_stream.read().decode("utf-8").split("\n")
-    r = difflib.SequenceMatcher(a=before, b=after).ratio()
-    similarity_diff = []
-    similarity_diff.append(click.style(f"--- {change.b_path}", fg="yellow"))
-    similarity_diff.append(click.style(f"+++ {change.a_path}", fg="yellow"))
-    similarity_diff.append(f"Renamed file, similarity index {r * 100:.2f}%")
-    return similarity_diff
-
-
-def default_difffunc(
-    before_text: str, after_text: str, fromfile: str = "", tofile: str = ""
-) -> tuple[Iterable[str], bool]:
-    before_lines = before_text.split("\n")
-    after_lines = after_text.split("\n")
-    diff_lines = difflib.unified_diff(
-        before_lines, after_lines, lineterm="", fromfile=fromfile, tofile=tofile
-    )
-    # never suppress diffs in default difffunc
-    return diff_lines, False
-
-
-def _process_diff(change_type: str, change, diff_func: DiffFunc) -> Iterable[str]:
-    difftext = []
-    # Because we're diffing the staged changes, the diff objects
-    # are backwards, and "added" files are actually being deleted
-    # and vice versa for "deleted" files.
-    if change_type == "A":
-        difftext.append(click.style(f"Deleted file {change.b_path}", fg="red"))
-    elif change_type == "D":
-        difftext.append(click.style(f"Added file {change.b_path}", fg="green"))
-    elif change_type == "R":
-        difftext.append(
-            click.style(f"Renamed file {change.b_path} => {change.a_path}", fg="yellow")
-        )
-    else:
-        # Other changes should produce a usable diff
-        # The diff objects are backwards, so use b_blob as before
-        # and a_blob as after.
-        before = change.b_blob.data_stream.read().decode("utf-8")
-        after = change.a_blob.data_stream.read().decode("utf-8")
-        diff_lines, suppress_diff = diff_func(
-            before, after, fromfile=change.b_path, tofile=change.a_path
-        )
-        if not suppress_diff:
-            if change.renamed_file:
-                # Just compute similarity ratio for renamed files
-                # similar to git's diffing
-                difftext.append("\n".join(_compute_similarity(change)).strip())
-            else:
-                diff_lines = [_colorize_diff(line) for line in diff_lines]
-                difftext.append("\n".join(diff_lines).strip())
-
-    return difftext
 
 
 class GitRepo:
@@ -630,7 +557,7 @@ class GitRepo:
                 # of type `Lit_change_type` in iter_change_type() but returns plain
                 # strings in `diff.change_type`.
                 for c in diff.iter_change_type(ct):  # type: ignore[arg-type]
-                    difftext.extend(_process_diff(ct, c, diff_func))
+                    difftext.extend(process_diff(ct, c, diff_func))
 
         return "\n".join(difftext), changed
 

--- a/commodore/gitrepo/diff.py
+++ b/commodore/gitrepo/diff.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import difflib
+
+from collections.abc import Iterable
+from typing import Protocol
+
+import click
+
+
+class DiffFunc(Protocol):
+    def __call__(
+        self, before_text: str, after_text: str, fromfile: str = "", tofile: str = ""
+    ) -> tuple[Iterable[str], bool]:
+        ...
+
+
+def _colorize_diff(line: str) -> str:
+    if line.startswith("--- ") or line.startswith("+++ ") or line.startswith("@@ "):
+        return click.style(line, fg="yellow")
+    if line.startswith("+"):
+        return click.style(line, fg="green")
+    if line.startswith("-"):
+        return click.style(line, fg="red")
+    return line
+
+
+def _compute_similarity(change):
+    before = change.b_blob.data_stream.read().decode("utf-8").split("\n")
+    after = change.a_blob.data_stream.read().decode("utf-8").split("\n")
+    r = difflib.SequenceMatcher(a=before, b=after).ratio()
+    similarity_diff = []
+    similarity_diff.append(click.style(f"--- {change.b_path}", fg="yellow"))
+    similarity_diff.append(click.style(f"+++ {change.a_path}", fg="yellow"))
+    similarity_diff.append(f"Renamed file, similarity index {r * 100:.2f}%")
+    return similarity_diff
+
+
+def default_difffunc(
+    before_text: str, after_text: str, fromfile: str = "", tofile: str = ""
+) -> tuple[Iterable[str], bool]:
+    before_lines = before_text.split("\n")
+    after_lines = after_text.split("\n")
+    diff_lines = difflib.unified_diff(
+        before_lines, after_lines, lineterm="", fromfile=fromfile, tofile=tofile
+    )
+    # never suppress diffs in default difffunc
+    return diff_lines, False
+
+
+def process_diff(change_type: str, change, diff_func: DiffFunc) -> Iterable[str]:
+    difftext = []
+    # Because we're diffing the staged changes, the diff objects
+    # are backwards, and "added" files are actually being deleted
+    # and vice versa for "deleted" files.
+    if change_type == "A":
+        difftext.append(click.style(f"Deleted file {change.b_path}", fg="red"))
+    elif change_type == "D":
+        difftext.append(click.style(f"Added file {change.b_path}", fg="green"))
+    elif change_type == "R":
+        difftext.append(
+            click.style(f"Renamed file {change.b_path} => {change.a_path}", fg="yellow")
+        )
+    else:
+        # Other changes should produce a usable diff
+        # The diff objects are backwards, so use b_blob as before
+        # and a_blob as after.
+        before = change.b_blob.data_stream.read().decode("utf-8")
+        after = change.a_blob.data_stream.read().decode("utf-8")
+        diff_lines, suppress_diff = diff_func(
+            before, after, fromfile=change.b_path, tofile=change.a_path
+        )
+        if not suppress_diff:
+            if change.renamed_file:
+                # Just compute similarity ratio for renamed files
+                # similar to git's diffing
+                difftext.append("\n".join(_compute_similarity(change)).strip())
+            else:
+                diff_lines = [_colorize_diff(line) for line in diff_lines]
+                difftext.append("\n".join(diff_lines).strip())
+
+    return difftext

--- a/commodore/package/__init__.py
+++ b/commodore/package/__init__.py
@@ -88,6 +88,20 @@ class Package:
     def checkout(self):
         self._dependency.checkout_package(self._name, self._version)
 
+    def checkout_is_dirty(self) -> bool:
+        dep_repo = self._dependency.bare_repo
+        author_name = dep_repo.author.name
+        author_email = dep_repo.author.email
+        worktree = self._dependency.get_package(self._name)
+
+        if worktree and worktree.is_dir():
+            r = GitRepo(
+                None, worktree, author_name=author_name, author_email=author_email
+            )
+            return r.repo.is_dirty()
+        else:
+            return False
+
 
 def package_dependency_dir(work_dir: Path, pname: str) -> Path:
     return work_dir / "dependencies" / f"pkg.{pname}"

--- a/docs/modules/ROOT/pages/reference/cli.adoc
+++ b/docs/modules/ROOT/pages/reference/cli.adoc
@@ -117,6 +117,14 @@ After that, all the symlinks and dependencies which are required to compile the 
   Nested keys are ignored if any non-leaf level of the requested key already contains a non-dictionary value.
   If a value prefixed with `json:` isn't valid JSON, it will be skipped.
 
+*--force / --no-force*::
+  With `--force` local changes (uncommitted changes, untracked files, or commits or branches which haven't been pushed) in the global and tenant repo checkouts are discarded.
+  Additionally, uncommitted changes in tracked files in dependency repos (components or packages) are discarded.
++
+With `--no-force`, local changes in global, tenant, or dependency checkouts are preserved, and the catalog compilation will abort with an error if there's local changes present.
+Specifying `--force` has no effect if `--local` is given, and is silently ignored.
+Defaults to `--no-force`.
+
 *--help*::
   Show catalog clean usage and options then exit.
 

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -519,3 +519,14 @@ def test_component_clone(tmp_path: P, config: Config):
     assert c.target_directory == tmp_path / "dependencies" / "test-component"
     assert c.target_directory == c.target_dir
     assert c.dependency == config.register_dependency_repo(clone_url)
+
+
+def test_checkout_is_dirty(tmp_path: P, config: Config):
+    rem = _setup_existing_component(tmp_path, worktree=False)
+    clone_url = f"file://{rem.common_dir}"
+
+    c = Component.clone(config, clone_url, "test-component")
+    c.checkout()
+    c._dependency = None
+
+    assert not c.checkout_is_dirty()

--- a/tests/test_gitrepo_diff.py
+++ b/tests/test_gitrepo_diff.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+import git
+
+from commodore.gitrepo import diff
+
+
+class MockDataStream:
+    _data: str
+
+    def __init__(self, data):
+        self._data = data
+
+    @property
+    def data_stream(self):
+        return self
+
+    def read(self) -> bytes:
+        return self._data.encode("utf-8")
+
+
+class MockDiff:
+    def __init__(self, a_path, b_path, a_blob, b_blob):
+        self.a_path = a_path
+        self.b_path = b_path
+        self.a_blob = MockDataStream(a_blob)
+        self.b_blob = MockDataStream(b_blob)
+
+
+def test_compute_similarity(tmp_path: Path):
+    change = MockDiff("foo.txt", "bar.txt", "foo\nbar\nbaz\n", "foo\nbar\nbar\n")
+
+    similarity = diff._compute_similarity(change)
+    expected = [
+        click.style("--- bar.txt", fg="yellow"),
+        click.style("+++ foo.txt", fg="yellow"),
+        "Renamed file, similarity index 75.00%",
+    ]
+    assert similarity == expected
+
+
+def test_process_diff_renamed(tmp_path: Path):
+    r = git.Repo.init(tmp_path / "repo")
+
+    with open(Path(r.working_tree_dir) / "foo.txt", "w", encoding="utf-8") as f:
+        f.write("foo\nbar\nbaz\n")
+
+    r.index.add(["foo.txt"])
+    r.index.commit("Initial")
+
+    # "Move" foo.txt to bar.txt
+    (Path(r.working_tree_dir) / "foo.txt").unlink()
+    with open(Path(r.working_tree_dir) / "bar.txt", "w", encoding="utf-8") as f:
+        f.write("foo\nbar\nbar\n")
+
+    r.index.remove(["foo.txt"])
+    r.index.add(["bar.txt"])
+
+    difftext: list[str] = []
+    d = r.index.diff(r.head.commit)
+    for ct in d.change_type:
+        for c in d.iter_change_type(ct):
+            print(c)
+            difftext.extend(diff.process_diff(ct, c, diff.default_difffunc))
+
+    expected = [
+        click.style("Renamed file foo.txt => bar.txt", fg="yellow"),
+        "\n".join(
+            [
+                click.style("--- foo.txt", fg="yellow"),
+                click.style("+++ bar.txt", fg="yellow"),
+                "Renamed file, similarity index 75.00%",
+            ]
+        ),
+    ]
+    assert difftext == expected

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import git
 import yaml
 
+from commodore.config import Config
 from commodore.multi_dependency import MultiDependency
 
 from commodore import package
@@ -58,3 +59,13 @@ def test_package_checkout(tmp_path: Path):
         params = fcontents["parameters"]
         assert "test" in params
         assert params["test"] == "testing"
+
+
+def test_package_checkout_is_dirty(tmp_path: Path, config: Config):
+    _setup_package_remote("test", tmp_path / "pkg.git")
+    clone_url = f"file://{tmp_path}/pkg.git"
+
+    p = package.Package.clone(config, clone_url, "test-component")
+    p.checkout()
+
+    assert not p.checkout_is_dirty()


### PR DESCRIPTION
If the `--force` flag isn't given, catalog compile won't discard local changes (uncommitted, or unpushed changes, as well as local branches) in the global and tenant repo checkouts. Additionally, without `--force`, the catalog compilation won't discard uncommitted changes in tracked files in dependency repos. The `--force` flag has no effect in local mode.

Fixes #591

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
