### PR TITLE
Fix mounting of GPG agent to Commodore docker container on Linux

### DIFF
--- a/docs/modules/ROOT/pages/explanation/running-commodore.adoc
+++ b/docs/modules/ROOT/pages/explanation/running-commodore.adoc
@@ -115,7 +115,7 @@ On Linux it's possible to use SSH agent and mounting the agents socket into the 
 commodore() {
   local pubring="${HOME}/.gnupg/pubring.kbx"
   if command -v gpgconf &>/dev/null && test -f "${pubring}"; then
-    gpg_opts=--volume="${pubring}:/app/.gnupg/pubring.kbx:ro"\ --volume="$(gpgconf --list-dir agent-extra-socket):/app/.gnupg/S.gpg-agent:ro"
+    gpg_opts=(--volume "${pubring}:/app/.gnupg/pubring.kbx:ro" --volume "$(gpgconf --list-dir agent-extra-socket):/app/.gnupg/S.gpg-agent:ro")
   else
     gpg_opts=
   fi
@@ -134,7 +134,7 @@ commodore() {
     --volume "${HOME}/.ssh/known_hosts:/app/.ssh/known_hosts:ro" \
     --volume "${HOME}/.gitconfig:/app/.gitconfig:ro" \
     --volume "${HOME}/.cache:/app/.cache" \
-    ${gpg_opts} \
+    ${gpg_opts[@]} \
     --volume "${PWD}:${PWD}" \
     --workdir "${PWD}" \
     projectsyn/commodore:${COMMODORE_VERSION:=latest} \


### PR DESCRIPTION
without the change the gpg opts would be passed to `docker run` as a single argument instead of two separate arguments.

Not sure if there is a better option to do this or in which shell/version combination this should've worked :) 

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [ ] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog
- [ ] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
