### PR TITLE
Skip GitHub actions which need additional secrets on PRs from forks

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   coverage:
+    # Only run coverage (which includes the integration test) for PRs which don't originate from a fork
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -12,6 +12,8 @@ on:
 
 jobs:
   build-and-publish:
+    # Skip job on forks
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
     name: Build and publish to PyPI
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,6 +111,8 @@ jobs:
     - name: Run benchmarks on Python ${{ matrix.python-version }}
       run: make bench_py${PYVER}
   integration:
+    # Skip integration tests on PRs from forks
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
GitHub doesn't provide repo secrets to actions running for PRs whose head branch is from a fork. We have some actions which don't work without the secrets, see e.g. #686 . This PR disables these actions for PRs from forks.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
