### PR TITLE
Update Poetry to v1.3.1 in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       curl \
       libffi-dev \
  && rm -rf /var/lib/apt/lists/* \
- && curl -sSL https://install.python-poetry.org | python - --version 1.1.13 \
+ && curl -sSL https://install.python-poetry.org | python - --version 1.3.1 \
  && mkdir -p /app/.config
 
 COPY pyproject.toml poetry.lock ./

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Commodore also supports additional processing on the output of Kapitan, such as 
 
 ### Additional System Requirements
 
-* [Poetry](https://github.com/python-poetry/poetry) 1.1.0+
+* [Poetry](https://github.com/python-poetry/poetry) 1.3.0+
 * Docker
 
 


### PR DESCRIPTION
We were still using Poetry 1.1.13 in the build stage of the Dockerfile. With the latest changes to Poetry (cf. #706 ), the `poetry.lock` format has changed in an incompatible way. Since we can't control the Poetry version used by Renovate, we simply update to the latest Poetry version in the Dockerfile.

See also https://python-poetry.org/blog/announcing-poetry-1.3.0/

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
