### PR TITLE
Add auto-completion for catalog compilation

### DIFF
--- a/commodore/cli/catalog.py
+++ b/commodore/cli/catalog.py
@@ -47,7 +47,7 @@ def _complete_clusters(ctx: click.Context, _, incomplete: str) -> list[str]:
         # If we encounter any errors, ignore them.
         # We shouldn't print errors during completion
         return []
-    return [c["id"] for c in clusters if c["id"].startswith(incomplete)]
+    return [c["id"] for c in clusters if "id" in c and c["id"].startswith(incomplete)]
 
 
 @catalog_group.command(name="compile", short_help="Compile the catalog.")

--- a/commodore/cli/catalog.py
+++ b/commodore/cli/catalog.py
@@ -1,4 +1,6 @@
 """Commands which interact with cluster catalogs"""
+from __future__ import annotations
+
 import click
 
 from pathlib import Path
@@ -30,7 +32,7 @@ def clean(config: Config, verbose):
     clean_working_tree(config)
 
 
-def _complete_clusters(ctx, param, incomplete):
+def _complete_clusters(ctx: click.Context, _, incomplete: str) -> list[str]:
     config = Config(Path("."))
     config.api_url = ctx.params["api_url"]
     config.api_token = ctx.params["api_token"]

--- a/docs/modules/ROOT/pages/explanation/running-commodore.adoc
+++ b/docs/modules/ROOT/pages/explanation/running-commodore.adoc
@@ -83,7 +83,30 @@ commodore --version
 
 === Usage
 
-If you've installed Commodore into a virtualenv, you need to activate the virtualenv whenever you want to run Commodore.
+If you've installed Commodore into a virtualenv, you either need to activate the virtualenv whenever you want to run Commodore, or you can create a symlink to the `commodore` entrypoint script in a directory which is part of your `$PATH`.
+
+==== Creating a symlink
+
+This section assumes that you've added `~/.local/bin` to your `$PATH`.
+If you use another directory, you can adjust the commands in this section as needed.
+
+Create a symlink to the `commodore` entrypoint script in `~/.local/bin`.
+
+[source,bash]
+----
+ln -s ~/.local/commodore-venv/bin/commodore ~/.local/bin/
+----
+
+After that, you can run Commodore with
+
+[source,bash]
+----
+commodore --help
+----
+
+TIP: We recommend this approach, especially if you're interested in xref:how-to/shell-completion.adoc[using shell completion] for Commodore.
+
+==== Activating the virtualenv
 
 [source,bash]
 ----

--- a/docs/modules/ROOT/pages/how-to/shell-completion.adoc
+++ b/docs/modules/ROOT/pages/how-to/shell-completion.adoc
@@ -1,0 +1,47 @@
+= Shell autocompletion
+
+Commodore supports command and cluster autocompletion.
+Command autocompletion shows possible completion for partially typed Commodore subcommands and command-line flags.
+Command autocompletion is provided by the Click Python library.
+Cluster autocompletion is enabled for `commodore catalog compile`.
+This relies on a custom completion implementation in Commodore which fetches the list of known clusters from the provided Lieutenant API to show possible completions.
+
+This only works when Commodore is installed locally due to limitations on how shell completion is implemented in the Click Python library.
+See xref:explanation/running-commodore.adoc#_pypi[Running Commodore] for details on how to install Commodore locally.
+
+Click supports autocompletion for the `bash`, `zsh` and `fish` shells.
+
+To enable autocompletion for your local Commodore installation, follow the steps below.
+
+. Add the following snippet in your shell's configuration
++
+.*bash* (`~/.bashrc`)
+[%collapsible]
+====
+[source,bash]
+----
+source <(_COMMODORE_COMPLETE=bash_source commodore)
+----
+====
++
+.*zsh* (`~/.zshrc`)
+[%collapsible]
+====
+[source,zsh]
+----
+source <(_COMMODORE_COMPLETE=zsh_source commodore)
+----
+====
++
+.*fish* (`~/.config/fish/completions/commodore.fish`)
+[%collapsible]
+====
+[source,fish]
+----
+source <(_COMMODORE_COMPLETE=fish_source commodore)
+----
+====
+
+. Reload your shell's configuration or start a new shell in order for the changes to be loaded
+
+See https://click.palletsprojects.com/en/8.1.x/shell-completion/#enabling-completion[the Click documentation] for more details on how-to setup autocompletion.

--- a/docs/modules/ROOT/partials/nav-howtos.adoc
+++ b/docs/modules/ROOT/partials/nav-howtos.adoc
@@ -1,1 +1,2 @@
 * xref:commodore:ROOT:how-to/local-mode-component.adoc[]
+* xref:commodore:ROOT:how-to/shell-completion.adoc[]


### PR DESCRIPTION
This PR introduces auto-completion when compiling catalogs. This means

```
commodore catalog compile c-my-clu<TAB>
```

Will complete to
```
commodore catalog compile c-my-cluster
```

When lieutenant knows a cluster with id `c-my-cluster` (and the prefix `c-my-clu` is unique

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
