### PR TITLE
Pin black to 22.12.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -59,7 +59,7 @@ commands =
 [testenv:black]
 description = Ensure black formatting is applied
 deps =
-     black
+     black==22.12.0
 commands =
      black --check {toxinidir}
 


### PR DESCRIPTION
We can't currently upgrade to black 23, since there's a dependency conflict with kapitan 0.30. We should remove this once we upgrade to black 23 (#727), which will need to happen after the upgrade to kapitan 0.31 (#720).

We need to pin the black version in `tox.ini` since tox will otherwise install the latest v23 version, which brings some formatting changes compared to v22 (cf. the changelog in #727).
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
