### PR TITLE
Add support for taking over library prefix of deprecated components

### DIFF
--- a/commodore/dependency_mgmt/component_library.py
+++ b/commodore/dependency_mgmt/component_library.py
@@ -121,6 +121,7 @@ def _check_library_alias_collisions(cfg: Config, cluster_params: dict[str, Any])
 
 
 def create_component_library_aliases(cfg: Config, cluster_params: dict[str, Any]):
+    click.secho("Installing component library aliases", bold=True)
     _check_library_alias_collisions(cfg, cluster_params)
 
     components = cfg.get_components()

--- a/commodore/dependency_mgmt/component_library.py
+++ b/commodore/dependency_mgmt/component_library.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import click
 
+from commodore.component import Component
 from commodore.config import Config
 from commodore.helpers import relsymlink
 
@@ -21,13 +22,69 @@ def validate_component_library_name(cname: str, lib: Path) -> Path:
     return lib
 
 
-def _check_library_alias_prefixes(libalias: str, cn: str, component_prefixes: set[str]):
-    for p in component_prefixes - {cn}:
+def _check_library_alias_prefixes(
+    libalias: str,
+    cn: str,
+    component_prefixes: set[str],
+    additional_prefix: str,
+):
+    prefixes = component_prefixes - {cn}
+    if additional_prefix:
+        prefixes = prefixes - {additional_prefix}
+    for p in prefixes:
         if libalias.startswith(p):
             raise click.ClickException(
                 f"Invalid alias prefix '{p}' "
                 + f"for template library alias of component '{cn}'"
             )
+
+
+def _read_additional_prefix(
+    cn: str,
+    cmeta: dict,
+    components: dict[str, Component],
+    cluster_params: dict[str, dict],
+) -> str:
+    """Extract additional allowed library prefixes from component metadata.
+
+    If a component matching the additional prefix is present in the cluster
+    config, we verify that additional prefix is ok by checking that that
+    component is deprecated and has nominated us as their replacement.
+    """
+    additional_cname = cmeta.get("replaces", "")
+    if additional_cname and additional_cname in components:
+        ometa = cluster_params[components[additional_cname].parameters_key].get(
+            "_metadata", {}
+        )
+        odeprecated = ometa.get("deprecated", False)
+        oreplaced_by = ometa.get("replaced_by", "")
+        if not odeprecated:
+            click.secho(
+                f" > Ignoring additional library prefix '{additional_cname}' "
+                + f"requested by '{cn}'. Component '{additional_cname}' is "
+                + "also deployed on the cluster and isn't deprecated.",
+                fg="red",
+            )
+            additional_cname = ""
+        elif oreplaced_by != cn:
+            click.secho(
+                f" > Ignoring additional library prefix '{additional_cname}' "
+                + f"requested by '{cn}'. Component '{additional_cname}' is "
+                + f"also deployed on the cluster and hasn't nominated '{cn}' "
+                + "as its replacement.",
+                fg="red",
+            )
+            additional_cname = ""
+        else:
+            click.secho(
+                f" > Allowing additional library prefix '{additional_cname}' "
+                + f"for component '{cn}'. Component '{additional_cname}' "
+                + f"is marked as deprecated and has nominated component '{cn}' "
+                + "as its replacement.",
+                fg="yellow",
+            )
+
+    return additional_cname
 
 
 def _check_library_alias_collisions(cfg: Config, cluster_params: dict[str, Any]):
@@ -40,8 +97,18 @@ def _check_library_alias_collisions(cfg: Config, cluster_params: dict[str, Any])
     for cn, component in components.items():
         cmeta = cluster_params[component.parameters_key].get("_metadata", {})
         aliases = cmeta.get("library_aliases", {})
+        # If component replaces another component, and wants to use the old component's
+        # library prefix, it should set `_metadata.replaces` to the old component name.
+        # _read_additional_prefix() also sanity-checks the specified additional prefix,
+        # see docstring for details.
+        additional_prefix = _read_additional_prefix(
+            cn, cmeta, components, cluster_params
+        )
+
         for libalias in aliases.keys():
-            _check_library_alias_prefixes(libalias, cn, component_prefixes)
+            _check_library_alias_prefixes(
+                libalias, cn, component_prefixes, additional_prefix
+            )
             collisions.setdefault(libalias, set()).add(cn)
 
     for libalias, cnames in collisions.items():
@@ -56,7 +123,9 @@ def _check_library_alias_collisions(cfg: Config, cluster_params: dict[str, Any])
 def create_component_library_aliases(cfg: Config, cluster_params: dict[str, Any]):
     _check_library_alias_collisions(cfg, cluster_params)
 
-    for _, component in cfg.get_components().items():
+    components = cfg.get_components()
+
+    for cn, component in components.items():
         cmeta = cluster_params[component.parameters_key].get("_metadata", {})
         aliases = cmeta.get("library_aliases", {}).items()
 

--- a/commodore/dependency_mgmt/component_library.py
+++ b/commodore/dependency_mgmt/component_library.py
@@ -41,9 +41,9 @@ def _check_library_alias_prefixes(
 
 def _read_additional_prefix(
     cn: str,
-    cmeta: dict,
+    cmeta: dict[str, Any],
     components: dict[str, Component],
-    cluster_params: dict[str, dict],
+    cluster_params: dict[str, Any],
 ) -> str:
     """Extract additional allowed library prefixes from component metadata.
 

--- a/docs/modules/ROOT/pages/reference/architecture.adoc
+++ b/docs/modules/ROOT/pages/reference/architecture.adoc
@@ -255,7 +255,11 @@ This allows components to provide implementations for generic library interfaces
 For example, cluster monitoring components for different Kubernetes distributions could provide libraries which implement the same interface.
 In this example, the interface would define functions which other components can use to ensure their alerts are picked up correctly by the cluster's monitoring stack.
 
-If multiple components advertise the same component alias or if a component advertises an alias which is prefixed with the name of another known component (the list of known components is extracted from `parameters.components`), Commodore aborts the compilation with an error.
+If multiple components advertise the same component alias or if a component advertises an alias which is prefixed with the name of another component deployed on the cluster (the list of deployed components is extracted from `applications`), Commodore aborts the compilation with an error.
+
+Commodore allows a component `c2` which replaces a deprecated component `c1` to take over its predecessor's library prefix if certain conditions are met:
+In order to be allowed to use its predecessor's prefix, component `c2` needs to explicitly specify that it replaces `c1` by setting `_metadata.replaces: c1`.
+Additionally, component `c1` must either not be deployed on the same cluster, or must be marked as deprecated via `_metadata.deprecated: true` and must nominate `c2` as their replacement by setting `_metadata.replaced_by: c2`.
 
 Below, a hypothetical example showing component `rancher-monitoring` advertising library alias `alerts.libsonnet` is given.
 

--- a/docs/modules/ROOT/pages/reference/component-deprecation.adoc
+++ b/docs/modules/ROOT/pages/reference/component-deprecation.adoc
@@ -1,7 +1,7 @@
 = Component deprecation
 
 Commodore supports components being marked as deprecated.
-Components can be marked as "deprecated" by adding `deprecated: True` to parameter `parameters.<component_name>._metadata`.
+Components can be marked as "deprecated" by adding `deprecated: true` to parameter `parameters.<component_name>._metadata`.
 To avoid allowing the inventory hierarchy to overwrite a component's `_metadata` parameter, it must be labeled as https://github.com/kapicorp/reclass/blob/develop/README-extensions.rst#constant-parameters[constant] by prefixing it with a `=`.
 The component template adds the `_metadata` parameter (with no content) for new components.
 
@@ -11,11 +11,12 @@ The component template adds the `_metadata` parameter (with no content) for new 
 parameters:
   component_name:
     =_metadata:
-      deprecated: True
+      deprecated: true
 ----
 
 If the component is deprecated in favor of a new component, the new component can be indicated by adding `replaced_by: another-component` in the component's `_metadata` parameter.
-The value of `replaced_by` isn't verified to be an existing component.
+In general, the value of `replaced_by` isn't verified to be an existing component.
+The component named in `replaced_by` is allowed to take over the deprecated component's library prefix in order to provide a transitional library to make switching components easy.
 
 .class/defaults.yml
 [source,yaml]
@@ -23,7 +24,7 @@ The value of `replaced_by` isn't verified to be an existing component.
 parameters:
   component_name:
     =_metadata:
-      deprecated: True
+      deprecated: true
       replaced_by: another-component
 ----
 
@@ -37,14 +38,28 @@ This could be a link to a migration guide, if a replacement component exists, or
 parameters:
   component_name:
     =_metadata:
-      deprecated: True
+      deprecated: true
       replaced_by: another-component
       deprecation_notice: >-
         See https://github.com/projectsyn/component-another-component/docs/.../how-tos/migrating-from-component-name.adoc
         for a migration guide.
 ----
 
-Commodore will print a deprecation notice for each component which has `parameters.<component_name>._metadata.deprecated` set to `True`.
+Commodore will print a deprecation notice for each component which has `parameters.<component_name>._metadata.deprecated` set to `true`.
 
 * If field `replaced_by` in the component's `_metadata` parameter isn't empty, the deprecation notice will use the field's value as the name of the replacement component.
 * If field `deprecation_notice` in the component's `_metadata` parameter isn't empty, the value of the field will be appended to the deprecation notice.
+
+Components can indicate that they replace another component by setting `_metadata.replaces`.
+By providing this information, a component is allowed to use its predecessor's library prefix in the following two cases.
+First, the component is allowed to use the additional prefix if its predecessor isn't deployed on the cluster which is being compiled.
+Second, the component is allowed to use the additional prefix if its predecessor has set `_metadata.deprecated: true` and `_metadata.replaced_by` to the component's name.
+
+.class/defaults.yml
+[source,yaml]
+----
+parameters:
+  another-component:
+    =_metadata:
+      replaces: component-name
+----

--- a/tests/test_dependency_mgmt_component_library.py
+++ b/tests/test_dependency_mgmt_component_library.py
@@ -137,6 +137,8 @@ def test_create_component_library_aliases_multiple_component(
     c2 = setup_mock_component(tmp_path, name="tc2")
     c3 = setup_mock_component(tmp_path, name="tc3")
 
+    config.inventory.ensure_dirs()
+
     config.register_component(c1)
     config.register_component(c2)
     config.register_component(c3)
@@ -172,3 +174,6 @@ def test_create_component_library_aliases_multiple_component(
             component_library.create_component_library_aliases(config, cluster_params)
 
         assert err in str(e.value)
+
+    else:
+        component_library.create_component_library_aliases(config, cluster_params)

--- a/tests/test_dependency_mgmt_component_library.py
+++ b/tests/test_dependency_mgmt_component_library.py
@@ -90,35 +90,35 @@ def test_create_component_library_aliases_single_component(
 
 
 @pytest.mark.parametrize(
-    "tc1_libalias,tc2_libalias,tc3_libalias,err",
+    "tc1_meta,tc2_meta,tc3_meta,err",
     [
         ({}, {}, {}, None),
         (
-            {"foo.libsonnet": "tc1.libjsonnet"},
+            {"library_aliases": {"foo.libsonnet": "tc1.libjsonnet"}},
             {},
             {},
             None,
         ),
         (
             {},
-            {"foo.libsonnet": "tc2.libjsonnet"},
+            {"library_aliases": {"foo.libsonnet": "tc2.libjsonnet"}},
             {},
             None,
         ),
         (
-            {"foo.libsonnet": "tc1.libjsonnet"},
-            {"foo.libsonnet": "tc2.libjsonnet"},
+            {"library_aliases": {"foo.libsonnet": "tc1.libjsonnet"}},
+            {"library_aliases": {"foo.libsonnet": "tc2.libjsonnet"}},
             {},
             "Components 'tc1' and 'tc2' both define component library alias 'foo.libsonnet'",
         ),
         (
-            {"foo.libsonnet": "tc1.libjsonnet"},
-            {"foo.libsonnet": "tc2.libjsonnet"},
-            {"foo.libsonnet": "tc3.libjsonnet"},
+            {"library_aliases": {"foo.libsonnet": "tc1.libjsonnet"}},
+            {"library_aliases": {"foo.libsonnet": "tc2.libjsonnet"}},
+            {"library_aliases": {"foo.libsonnet": "tc3.libjsonnet"}},
             "Components 'tc1', 'tc2', and 'tc3' all define component library alias 'foo.libsonnet'",
         ),
         (
-            {"tc2-fake.libsonnet": "tc1.libjsonnet"},
+            {"library_aliases": {"tc2-fake.libsonnet": "tc1.libjsonnet"}},
             {},
             {},
             "Invalid alias prefix 'tc2' for template library alias of component 'tc1'",
@@ -128,9 +128,9 @@ def test_create_component_library_aliases_single_component(
 def test_create_component_library_aliases_multiple_component(
     tmp_path: Path,
     config: Config,
-    tc1_libalias: dict[str, str],
-    tc2_libalias: dict[str, str],
-    tc3_libalias: dict[str, str],
+    tc1_meta: dict[str, str],
+    tc2_meta: dict[str, str],
+    tc3_meta: dict[str, str],
     err: Optional[str],
 ):
     c1 = setup_mock_component(tmp_path, name="tc1")
@@ -145,13 +145,13 @@ def test_create_component_library_aliases_multiple_component(
 
     cluster_params = {
         c1.parameters_key: {
-            "_metadata": {"library_aliases": tc1_libalias},
+            "_metadata": tc1_meta,
         },
         c2.parameters_key: {
-            "_metadata": {"library_aliases": tc2_libalias},
+            "_metadata": tc2_meta,
         },
         c3.parameters_key: {
-            "_metadata": {"library_aliases": tc3_libalias},
+            "_metadata": tc3_meta,
         },
         "components": {
             "tc1": {

--- a/tests/test_dependency_mgmt_component_library.py
+++ b/tests/test_dependency_mgmt_component_library.py
@@ -123,6 +123,36 @@ def test_create_component_library_aliases_single_component(
             {},
             "Invalid alias prefix 'tc2' for template library alias of component 'tc1'",
         ),
+        # NOTE: we don't test the informational messages printed out when additional
+        # library prefixes are allowed or denied, we only test that there is an error
+        # message or not.
+        (
+            {
+                "library_aliases": {"tc2-fake.libsonnet": "tc1.libjsonnet"},
+                "replaces": "tc2",
+            },
+            {"deprecated": True, "replaced_by": "tc1"},
+            {},
+            None,
+        ),
+        (
+            {
+                "library_aliases": {"tc2-fake.libsonnet": "tc1.libjsonnet"},
+                "replaces": "tc2",
+            },
+            {"deprecated": True, "replaced_by": "tc3"},
+            {},
+            "Invalid alias prefix 'tc2' for template library alias of component 'tc1'",
+        ),
+        (
+            {
+                "library_aliases": {"tc2-fake.libsonnet": "tc1.libjsonnet"},
+                "replaces": "tc2",
+            },
+            {"deprecated": False, "replaced_by": "tc2"},
+            {},
+            "Invalid alias prefix 'tc2' for template library alias of component 'tc1'",
+        ),
     ],
 )
 def test_create_component_library_aliases_multiple_component(


### PR DESCRIPTION
Commodore will verify that either the component who's prefix we're trying to take over isn't present in the cluster configuration (in this case the alias is just a regular alias) or that the component is deprecated, and has nominated us as their replacement component. Library prefixes of non-deprecated components, or deprecated components which don't specify a replacement can't be taken over.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
