### PR TITLE
Use pytest-xdist's new `worksteal` distribution mode

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ deps =
 commands = \
     pytest {toxinidir}/tests \
     bench: -m bench \
-    !bench: -m "not bench and not integration" -n auto \
+    !bench: -m "not bench and not integration" -n auto --dist worksteal \
     {posargs}
 passenv = SSH_AUTH_SOCK
 


### PR DESCRIPTION
Switching test scheduling from `load` to `worksteal` cuts down test runtime on my 6 core/12 thread Ryzen 5 5600x from 51s wall 
time to 40s wall time for `make test_py3.11`:

With `-n auto --dist=worksteal`:

```
$ time make test_py3.11
poetry run tox -e py311
[ ... snipped ... ]
scheduling tests via WorkStealingScheduling

[ ... snipped ... ]
___________________________________________________________________________________ summary ___________________________________________________________________________________
  py311: commands succeeded
  congratulations :)

real	0m38.080s
user	1m6.428s
sys	0m13.098s
```

With `-n auto`:
```
$ time make test_py3.11
poetry run tox -e py311
[ ... snipped ... ]
scheduling tests via LoadScheduling

[ ... snipped ... ]
___________________________________________________________________________________ summary ___________________________________________________________________________________
  py311: commands succeeded
  congratulations :)

real	0m52.752s
user	1m11.667s
sys	0m13.218s
```

Follow-up to #735 

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
