### PR TITLE
Configure Renovate auto-merge for lock file maintenance

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,10 @@
   },
   "lockFileMaintenance": {
     "enabled": true,
-    "labels": ["ignore"]
+    "labels": ["ignore"],
+    "automerge": true,
+    "automergeType": "pr",
+    "platformAutomerge": true
   },
   "ignoreDeps": [
     "gitpython",


### PR DESCRIPTION
If this works, we'll also setup auto-merge for minor and patch updates of development dependencies.

I've granted the renovate GitHub app user permissions to merge PRs without approval in the branch protection rules of the Commodore GitHub repo.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
