### PR TITLE
Switch to Kapitan's new `literal` multi-line YAML string style

### DIFF
--- a/commodore/helpers.py
+++ b/commodore/helpers.py
@@ -184,7 +184,7 @@ def kapitan_compile(
     click.secho("Compiling catalog...", bold=True)
     cached.args["compile"] = ArgumentCache(
         inventory_path=config.inventory.inventory_dir,
-        yaml_multiline_string_style="double-quotes",
+        yaml_multiline_string_style="literal",
         yaml_dump_null_as_empty=False,
     )
     kapitan_targets.compile_targets(


### PR DESCRIPTION
This renders multiline YAML strings with literal newlines, for example a field `data` which has three lines of text which contain "foo", "bar", and "baz" respectively will now be rendered as follows by Kapitan.

```yaml
data: |
  foo
  bar
  baz
```

This should improve readability of any manifests in the cluster catalog which contain large amounts of multi-line YAML strings, and should massively improve readability of catalog diffs for such manifests.

Follow-up to #720 

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
