### PR TITLE
Only print a message when the OIDC login URL can't be opened automatically

### DIFF
--- a/commodore/login.py
+++ b/commodore/login.py
@@ -294,11 +294,12 @@ def login(config: Config):
         redirect_uri="http://localhost:18000",
         scope=["openid", "email", "profile"],
     )
-    print(
-        f"Follow this link if it doesn't open automatically \n\n{request_uri}\n",
-        file=sys.stderr,
-    )
-    webbrowser.open(request_uri)
+    opened = webbrowser.open(request_uri)
+    if not opened:
+        print(
+            f"Failed to open browser, follow this link to login\n\n{request_uri}\n",
+            file=sys.stderr,
+        )
 
     server.join()
 


### PR DESCRIPTION
Until now, we unconditionally printed a message containing the OIDC login URL whenever Commodore needed to fetch a new OIDC token. The `webbrowser.open()` function returns a boolean which indicates whether the URL was opened successfully.

This commit checks the return value from `webbrowser.open()` and only prints a message if the URL couldn't be opened. This reduces the chances of this message messing up the terminal output when autocompletion is used (cf. #722), and reduces noise in general.

Follow-up for #722 

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
