### PR TITLE
Correctly merge instance parameters in `component compile`

### DIFF
--- a/commodore/component/compile.py
+++ b/commodore/component/compile.py
@@ -223,7 +223,7 @@ def _prepare_kapitan_inventory(
                 },
                 "components": {
                     component.name: {
-                        "url": "https://example.com/{component.name}.git",
+                        "url": f"https://example.com/{component.name}.git",
                         "version": "master",
                     }
                 },

--- a/commodore/component/compile.py
+++ b/commodore/component/compile.py
@@ -12,7 +12,7 @@ import click
 import git
 from kapitan.resources import inventory_reclass
 
-from commodore import __kustomize_wrapper__
+from commodore.cluster import generate_target
 from commodore.config import Config
 from commodore.component import Component
 from commodore.dependency_mgmt.component_library import (
@@ -240,20 +240,15 @@ def _prepare_kapitan_inventory(
 
     # Create test target
     value_classes = [f"{c.stem}" for c in value_files]
+    classes = [
+        f"params.{inv.bootstrap_target}",
+        f"defaults.{component.name}",
+        f"components.{component.name}",
+    ] + value_classes
     yaml_dump(
-        {
-            "classes": [
-                f"params.{inv.bootstrap_target}",
-                f"defaults.{component.name}",
-                f"components.{component.name}",
-            ]
-            + value_classes,
-            "parameters": {
-                "_instance": instance_name,
-                "_base_directory": str(component.target_directory),
-                "_kustomize_wrapper": str(__kustomize_wrapper__),
-            },
-        },
+        generate_target(
+            inv, instance_name, {component.name: component}, classes, component.name
+        ),
         inv.target_file(instance_name),
     )
 


### PR DESCRIPTION
Until now, `commodore component compile` didn't correctly merge parameters provided in the instance's parameters key when compiling a multi-instance-enabled component in it's instantiated form (using the `--alias` flag of `component compile`).

The root cause for this error was that we didn't use the same logic to generate the Kapitan target in `component compile` and `catalog compile` until now. The PR refactors `render_target()` to pull out the instance logic into a separate function `generate_target()` which we can use for `component compile` as well.

The new `generate_target()` function expects a list of classes to use for field `classes` in the resulting Kapitan target, but contains all the logic to render the contents of field `parameters` which is identical for `component compile` and `catalog compile`.

We do this refactoring, in order to not make `render_target()` more complex by introducing a new parameter to allow callers to provide additional classes to include. Instead we keep the interface of `render_target()` unchanged, but call `generate_target()` after constructing the list of classes required for `catalog compile`.

In `component compile`, we replace the hand-crafted target contents with a call to `generate_target()` using the same list of classes that we previously had in the hand-crafted target.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog


<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
