### PR TITLE
Provide more output for Git errors on push

### DIFF
--- a/commodore/catalog.py
+++ b/commodore/catalog.py
@@ -114,6 +114,7 @@ def _push_catalog(cfg: Config, repo: GitRepo, commit_message: str):
             raise click.ClickException(
                 "Failed to push to the catalog repository: "
                 + f"Git exited with status code {e.status}"
+                + f"\nThe error reported was: {e.stderr}"
             ) from e
         for pi in pushinfos:
             # Any error has pi.ERROR set in the `flags` bitmask


### PR DESCRIPTION
This provides Git's stderr output when errors occur trying to push catalogs. Previously, only the exit code was returned, which usually is simply 1 and not very specific. 

## Background

The default branch in most Git hosting environments is called `main` now, but Commodore seems to expect the remote HEAD to be `master`. Trying a `commodore catalog compile --push` on a catalog repository with `main` as default branch will fail with "error: src refspec master does not match any...".

It would be cleverer to make Commodore read the default branch name from the remote repo and use that instead. But in the meantime, having more error output at least makes it possible to narrow down the cause of a push problem.

## Problems

The stderr output seems to be truncated (by the GitRepo module?). I couldn't figure out how to get the whole output without the truncated first line. Subsequent lines seem OK?

Update: Actually, this may also be a new issue in Git itself. When pushing from the command-line, it also truncates after "does not match any" for me.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
