### PR TITLE
Skip new bandit checks B113, B603, and B607

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -69,6 +69,7 @@ commands =
 [bandit]
 exclude = .cache,.git,.tox,build,dist,docs,tests
 targets = .
+skips = B113,B603,B607
 
 [flake8]
 exclude = *.egg*,.git,.tox,venv


### PR DESCRIPTION
We currently skip the following bandit checks to allow PRs to be merged

* B113: Requests call without timeout
* B603: subprocess call - check for execution of untrusted input.
* B607: Starting a process with a partial executable path

We'll address the lints in #758

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
