### PR TITLE
Fix reference parsing for strings which contain multiple references

### DIFF
--- a/tests/test_refs.py
+++ b/tests/test_refs.py
@@ -41,6 +41,7 @@ def inventory():
                 "enabled": True,
                 "thesecret": "?{vaultkv:t-tenant/c-cluster/other-component/thesecret}",
                 "users": ["user1", "user2"],
+                "multiref": "?{vaultkv:t-tenant/c-cluster/foo/bar}-?{vaultkv:t-tenant/c-cluster/foo/baz}",
             },
             "kapitan": {
                 "secrets": {
@@ -89,6 +90,8 @@ def test_update_refs(tmp_path: Path, config: Config, inventory):
         Path("test/test-b-accesskey"),
         Path("test/test-b-secretkey"),
         Path("global/password"),
+        Path("foo/bar"),
+        Path("foo/baz"),
     ]
     for ref in expected_refs:
         refpath = ref_prefix / ref


### PR DESCRIPTION
Until now, Commodore only parsed the first Kapitan secret reference in each string value. This can lead to compilation errors for cluster configurations which have fields whose values contain multiple secret references.

This commit updates the internal secret reference parsing in Commodore to find all non-overlapping secret references in strings instead of just the first one.

We also update the reference parsing test case to include an example string which contains two references.
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
