### PR TITLE
Provide cluster and tenant display names in `component compile` and `package compile`

### DIFF
--- a/commodore/component/compile.py
+++ b/commodore/component/compile.py
@@ -211,7 +211,9 @@ def _prepare_kapitan_inventory(
                 "cluster": {
                     "catalog_url": "ssh://git@git.example.com/org/repo.git",
                     "name": "c-green-test-1234",
+                    "display_name": "Test Cluster 1234",
                     "tenant": "t-silent-test-1234",
+                    "tenant_display_name": "Test Tenant 1234",
                 },
                 "facts": {
                     "distribution": "test-distribution",

--- a/commodore/package/compile.py
+++ b/commodore/package/compile.py
@@ -155,7 +155,9 @@ def _setup_inventory(
                 "cluster": {
                     "catalog_url": "ssh://git@git.example.com/org/repo.git",
                     "name": "c-green-test-1234",
+                    "display_name": "Test Cluster 1234",
                     "tenant": "t-silent-test-1234",
+                    "tenant_display_name": "Test Tenant 1234",
                 },
                 "facts": {
                     "distribution": "x-fake-distribution",

--- a/tests/test_component_compile.py
+++ b/tests/test_component_compile.py
@@ -51,6 +51,12 @@ def _prepare_component(
                   annotations: {
                     foo: std.get(params, "foo", "default"),
                   },
+                  labels+: {
+                    cluster_id: inv.parameters.cluster.name,
+                    cluster_name: inv.parameters.cluster.display_name,
+                    tenant_id: inv.parameters.cluster.tenant,
+                    tenant_name: inv.parameters.cluster.tenant_display_name,
+                  },
                 },
               },
             }"""
@@ -149,6 +155,11 @@ def test_run_component_compile_command(tmp_path: P, cli_runner: RunnerFunc):
         target = yaml.safe_load(file)
         assert target["kind"] == "ServiceAccount"
         assert target["metadata"]["namespace"] == f"syn-{component_name}"
+        # Verify that cluster metadata is provided correctly to `component compile`
+        assert target["metadata"]["labels"]["cluster_id"] == "c-green-test-1234"
+        assert target["metadata"]["labels"]["cluster_name"] == "Test Cluster 1234"
+        assert target["metadata"]["labels"]["tenant_id"] == "t-silent-test-1234"
+        assert target["metadata"]["labels"]["tenant_name"] == "Test Tenant 1234"
 
     assert list(component_repo.remote().urls) == orig_remote_urls
 


### PR DESCRIPTION
We manually generate a `cluster/params.yml` in `component compile` and `package compile`. This logic hasn't been updated to provide values for `${cluster:display_name}` and `${cluster:tenant_display_name}` in #311.

This PR updates `component compile` and `package compile` to provide dummy values for those variables and adjusts the component compilation tests to verify that these variables are provided.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
