### PR TITLE
Remove broken `python.enabled=false` config in `renovate.json`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,9 +4,6 @@
     ":gitSignOff",
     ":disableDependencyDashboard"
   ],
-  "python": {
-    "enabled": false
-  },
   "poetry": {
     "enabled": true
   },


### PR DESCRIPTION
From what I can see, Renovate changed the semantics of `python.enabled=false` to disable all Python package upgrades around 2023-07-09.

This commit removes the broken config to hopefully re-enable Python dependency updates.

Original investigation in #814 

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
