### PR TITLE
Disable explicit Renovate PRs for boto3/botocore

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,10 @@
   "labels": [
     "dependency"
   ],
+  "ignoreDeps": [
+    "boto3",
+    "botocore"
+  ],
   "regexManagers": [
     {
       "fileMatch": ["^Dockerfile$"],


### PR DESCRIPTION
We don't need to get explicit PRs for boto3/botocore, since we only specify those packages as top-level dependencies to help Poetry's dependency resolver.

We add the packages to `ignoreDeps` in `renovate.json`. With this config, the two packages should still get updated once a week in the lockfile maintenance.

Follow-up for #810 
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
