### PR TITLE
Fetch component and package dependencies in parallel

### DIFF
--- a/commodore/cluster.py
+++ b/commodore/cluster.py
@@ -196,7 +196,7 @@ def render_target(
 
     classes = [f"params.{inv.bootstrap_target}"]
 
-    for c in components:
+    for c in sorted(components):
         if inv.defaults_file(c).is_file():
             classes.append(f"defaults.{c}")
         else:

--- a/commodore/dependency_mgmt/__init__.py
+++ b/commodore/dependency_mgmt/__init__.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import itertools
+from concurrent.futures import ThreadPoolExecutor
+
 import click
 
 from commodore.config import Config
@@ -69,6 +72,8 @@ def fetch_components(cfg: Config):
     cfg.register_component_aliases(component_aliases)
     cspecs = _read_components(cfg, component_names)
     click.secho("Fetching components...", bold=True)
+
+    deps: dict[str, list] = {}
     for cn in component_names:
         cspec = cspecs[cn]
         if cfg.debug:
@@ -86,9 +91,26 @@ def fetch_components(cfg: Config):
                 f"Component {cn} has uncommitted changes. "
                 + "Please specify `--force` to discard them"
             )
+        deps.setdefault(cdep.url, []).append(c)
+    fetch_parallel(fetch_component, cfg, deps.values())
+
+
+def fetch_component(cfg, dependencies):
+    """
+    Fetch all components of a MultiDependency object.
+    """
+    for c in dependencies:
         c.checkout()
         cfg.register_component(c)
         create_component_symlinks(cfg, c)
+
+
+def fetch_parallel(fetch_fun, cfg, to_fetch):
+    """
+    Fetch dependencies in parallel threads with ThreadPoolExecutor.
+    """
+    with ThreadPoolExecutor() as exe:
+        exe.map(fetch_fun, itertools.repeat(cfg), to_fetch)
 
 
 def register_components(cfg: Config):

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -53,8 +53,8 @@ def test_render_bootstrap_target(tmp_path: P):
 
     classes = [
         "params.cluster",
-        "defaults.foo",
         "defaults.bar",
+        "defaults.foo",
         "global.commodore",
     ]
     assert target != ""
@@ -83,8 +83,8 @@ def test_render_target(tmp_path: P):
 
     classes = [
         "params.cluster",
-        "defaults.foo",
         "defaults.bar",
+        "defaults.foo",
         "global.commodore",
         "components.foo",
     ]
@@ -115,8 +115,8 @@ def test_render_aliased_target(tmp_path: P):
 
     classes = [
         "params.cluster",
-        "defaults.foo",
         "defaults.bar",
+        "defaults.foo",
         "global.commodore",
         "components.foo",
     ]
@@ -148,8 +148,8 @@ def test_render_aliased_target_with_dash(tmp_path: P):
 
     classes = [
         "params.cluster",
-        "defaults.foo-comp",
         "defaults.bar",
+        "defaults.foo-comp",
         "global.commodore",
         "components.foo-comp",
     ]


### PR DESCRIPTION
Uses `concurrent.futures.ThreadPoolExecutor` to fetch component and package dependencies in parallel.
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [ ] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
