### PR TITLE
Propagate exceptions raised while fetching dependencies

### DIFF
--- a/commodore/dependency_mgmt/__init__.py
+++ b/commodore/dependency_mgmt/__init__.py
@@ -110,7 +110,11 @@ def fetch_parallel(fetch_fun, cfg, to_fetch):
     Fetch dependencies in parallel threads with ThreadPoolExecutor.
     """
     with ThreadPoolExecutor() as exe:
-        exe.map(fetch_fun, itertools.repeat(cfg), to_fetch)
+        # We need to collect the results from the iterator produced by exe.map to ensure
+        # that any exceptions raised in `fetch_fun` are propagated, cf.
+        # https://docs.python.org/3/library/concurrent.futures.html#executor-objects. We
+        # do so by simply materializing the iterator into a list.
+        list(exe.map(fetch_fun, itertools.repeat(cfg), to_fetch))
 
 
 def register_components(cfg: Config):

--- a/tests/test_dependency_mgmt.py
+++ b/tests/test_dependency_mgmt.py
@@ -199,6 +199,23 @@ def test_fetch_components_raises(
 
 @patch("commodore.dependency_mgmt._read_components")
 @patch("commodore.dependency_mgmt._discover_components")
+def test_fetch_components_raises_giterror(
+    patch_discover, patch_read, config: Config, tmp_path: Path
+):
+    components = ["foo"]
+    patch_discover.return_value = (components, {})
+    read_retval = setup_components_upstream(tmp_path, components)
+    read_retval["foo"].version = "nonexistent"
+    patch_read.return_value = read_retval
+
+    with pytest.raises(Exception) as excinfo:
+        dependency_mgmt.fetch_components(config)
+
+    assert "Failed to checkout revision 'nonexistent'" in str(excinfo.value)
+
+
+@patch("commodore.dependency_mgmt._read_components")
+@patch("commodore.dependency_mgmt._discover_components")
 def test_fetch_components_is_minimal(
     patch_discover, patch_urls, config: Config, tmp_path: Path
 ):


### PR DESCRIPTION
We need to collect the results from the iterator which is produced by `ThreadPool.map()` to ensure that exceptions raised in the worker threads are propagated to the main thread.

This PR collects the iterator by calling `list()` on it, which ensures that any exceptions raised in a worker thread are propagated to the main thread.

The PR also adds a test case which verifies that `fetch_components()` properly raises exceptions (e.g. when a requested component version doesn't exist).

Follow-up to #844 
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
