### PR TITLE
Fix component ordering in `jsonnetfile.json` and catalog commit message

### DIFF
--- a/commodore/catalog.py
+++ b/commodore/catalog.py
@@ -51,7 +51,8 @@ def _render_catalog_commit_msg(cfg) -> str:
     now = datetime.datetime.now().isoformat(timespec="milliseconds")
 
     component_commits = [
-        _pretty_print_component_commit(cn, c) for cn, c in cfg.get_components().items()
+        _pretty_print_component_commit(cn, c)
+        for cn, c in sorted(cfg.get_components().items())
     ]
     component_commits_str = "\n".join(component_commits)
 

--- a/commodore/dependency_mgmt/jsonnet_bundler.py
+++ b/commodore/dependency_mgmt/jsonnet_bundler.py
@@ -18,7 +18,7 @@ def jsonnet_dependencies(config: Config) -> Iterable:
     """
     dependencies = []
 
-    for component in config.get_components().values():
+    for (_, component) in sorted(config.get_components().items()):
         dependencies.append(
             {
                 "source": {


### PR DESCRIPTION
We want to sort the components ascii-betically by name when generating the jsonnetfile.json and the catalog commit message. This ensures that the order remains the same across Commodore runs with parallel dependency fetching.

This also ensures that the behavior remains the same as it was before we introduced parallel dependency fetching, since the list of applications returned by Reclass is sorted ascii-betically.

Follow-up to #844

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
