### PR TITLE
Use multiprocessing start method `spawn` by default

### DIFF
--- a/commodore/cli/__init__.py
+++ b/commodore/cli/__init__.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import multiprocessing
+
 from pathlib import Path
 
 import click
@@ -55,6 +57,8 @@ commodore.add_command(commodore_fetch_token)
 
 
 def main():
+    multiprocessing.set_start_method("spawn")
+
     load_dotenv(dotenv_path=find_dotenv(usecwd=True))
     commodore.main(
         prog_name="commodore", auto_envvar_prefix="COMMODORE", max_content_width=100


### PR DESCRIPTION
This is already the default on macOS, and doesn't break anything on Linux. We'll need this at the latest when we want to switch to gojsonnet, since that library doesn't work correctly with multiprocessing start method `fork`.

Additionally, we reduce the memory usage of Commodore by using start method `spawn` because the multiprocessing child processes are created with smaller initial memory working sets. However, this causes some execution time overhead because more data needs to be copied to the new processes. Locally, we measured an increase in runtime of approximately 4 seconds when using `spawn` compared to `fork`.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
