### PR TITLE
Increase connection timeout for publishing package to PyPI

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -46,9 +46,16 @@ jobs:
         run: poetry build
       - name: Publish to PyPI
         if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          # increase connection timeout to PyPI to 60s
+          # NOTE(sg): This is probably not required
+          POETRY_REQUESTS_TIMEOUT: "60"
         run: poetry publish -u __token__ -p ${{ secrets.PYPI_TOKEN }}
       - name: Publish to TestPyPI
         if: "!startsWith(github.ref, 'refs/tags/v')"
+        env:
+          # increase connection timeout to TestPyPI to 60s
+          POETRY_REQUESTS_TIMEOUT: "60"
         run: |
           poetry config repositories.test-pypi https://test.pypi.org/legacy/
           poetry publish -r test-pypi -u __token__ -p ${{ secrets.TEST_PYPI_TOKEN }}


### PR DESCRIPTION
This should address the recent CI failures for the Test PyPI publishing errors, see e.g. https://github.com/projectsyn/commodore/actions/runs/6844060932/job/18607409336?pr=885

To be on the safe side, we also increase the connection timeout to prod PyPI to 60s.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
