### PR TITLE
Add explicit HTTP request timeouts

### DIFF
--- a/commodore/catalog.py
+++ b/commodore/catalog.py
@@ -269,7 +269,12 @@ def catalog_list(cfg, out: str, sort_by: str = "id", tenant: str = ""):
         params["tenant"] = tenant
     try:
         clusters = lieutenant_query(
-            cfg.api_url, cfg.api_token, "clusters", "", params=params
+            cfg.api_url,
+            cfg.api_token,
+            "clusters",
+            "",
+            params=params,
+            timeout=cfg.request_timeout,
         )
     except ApiError as e:
         raise click.ClickException(f"While listing clusters on Lieutenant: {e}") from e

--- a/commodore/cli/__init__.py
+++ b/commodore/cli/__init__.py
@@ -43,9 +43,19 @@ CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
         "inventory and catalog, and store intermediate outputs"
     ),
 )
+@click.option(
+    "--request-timeout",
+    default=5,
+    show_default=True,
+    type=click.INT,
+    envvar="COMMODORE_REQUEST_TIMEOUT",
+    help="Timeout in seconds for HTTP requests",
+)
 @click.pass_context
-def commodore(ctx, working_dir, verbose):
-    ctx.obj = Config(Path(working_dir), verbose=verbose)
+def commodore(ctx, working_dir, verbose, request_timeout):
+    cfg = Config(Path(working_dir), verbose=verbose)
+    cfg.request_timeout = request_timeout
+    ctx.obj = cfg
 
 
 commodore.add_command(catalog_group)

--- a/commodore/cli/catalog.py
+++ b/commodore/cli/catalog.py
@@ -42,7 +42,13 @@ def _complete_clusters(ctx: click.Context, _, incomplete: str) -> list[str]:
     try:
         if config.api_token is None:
             login(config)
-        clusters = lieutenant_query(config.api_url, config.api_token, "clusters", "")
+        clusters = lieutenant_query(
+            config.api_url,
+            config.api_token,
+            "clusters",
+            "",
+            timeout=config.request_timeout,
+        )
     except (click.ClickException, ApiError):
         # If we encounter any errors, ignore them.
         # We shouldn't print errors during completion

--- a/commodore/cluster.py
+++ b/commodore/cluster.py
@@ -116,12 +116,16 @@ class Cluster:
 
 def load_cluster_from_api(cfg: Config, cluster_id: str) -> Cluster:
     cluster_response = lieutenant_query(
-        cfg.api_url, cfg.api_token, "clusters", cluster_id
+        cfg.api_url, cfg.api_token, "clusters", cluster_id, timeout=cfg.request_timeout
     )
     if "tenant" not in cluster_response:
         raise click.ClickException("cluster does not have a tenant reference")
     tenant_response = lieutenant_query(
-        cfg.api_url, cfg.api_token, "tenants", cluster_response["tenant"]
+        cfg.api_url,
+        cfg.api_token,
+        "tenants",
+        cluster_response["tenant"],
+        timeout=cfg.request_timeout,
     )
     return Cluster(cluster_response, tenant_response, cfg.dynamic_facts)
 

--- a/commodore/config.py
+++ b/commodore/config.py
@@ -39,6 +39,7 @@ class Config:
     _migration: Optional[Migration]
     _dynamic_facts: dict[str, Any]
     _github_token: Optional[str]
+    _request_timeout: int
 
     oidc_client: Optional[str]
     oidc_discovery_url: Optional[str]
@@ -78,6 +79,7 @@ class Config:
         self._migration = None
         self._dynamic_facts = {}
         self._github_token = None
+        self._request_timeout = 5
 
     @property
     def verbose(self):
@@ -214,6 +216,14 @@ class Config:
     @github_token.setter
     def github_token(self, github_token: str):
         self._github_token = github_token
+
+    @property
+    def request_timeout(self) -> int:
+        return self._request_timeout
+
+    @request_timeout.setter
+    def request_timeout(self, timeout: int):
+        self._request_timeout = timeout
 
     @property
     def inventory(self):

--- a/commodore/config.py
+++ b/commodore/config.py
@@ -328,7 +328,9 @@ class Config:
             and self.api_url is not None
         ):
             try:
-                r = requests.get(url_normalize(self.api_url))
+                r = requests.get(
+                    url_normalize(self.api_url), timeout=self.request_timeout
+                )
                 api_cfg = json.loads(r.text)
                 if "oidc" in api_cfg:
                     self.oidc_client = api_cfg["oidc"].get("clientId")

--- a/commodore/helpers.py
+++ b/commodore/helpers.py
@@ -111,12 +111,13 @@ def yaml_dump_all(obj, file):
         yaml.dump_all(obj, outf, Dumper=IndentedListDumper)
 
 
-def lieutenant_query(api_url, api_token, api_endpoint, api_id, params={}):
+def lieutenant_query(api_url, api_token, api_endpoint, api_id, params={}, timeout=5):
     try:
         r = requests.get(
             url_normalize(f"{api_url}/{api_endpoint}/{api_id}"),
             headers={"Authorization": f"Bearer {api_token}"},
             params=params,
+            timeout=timeout,
         )
     except ConnectionError as e:
         raise ApiError(f"Unable to connect to Lieutenant at {api_url}") from e

--- a/docs/modules/ROOT/pages/reference/cli.adoc
+++ b/docs/modules/ROOT/pages/reference/cli.adoc
@@ -10,6 +10,10 @@ provided to any command instead.
   By default, this happens in the current working directory of the environment in which Commodore is executed.
   If this option is provided, Commodore will create its directories and files in the provided location.
 
+*--request-timeout*::
+  Commodore allows users to customize the HTTP request timeout.
+  If this option isn't provided, Commodore uses a request timeout of 5 seconds.
+
 *--version*::
   Show the version and exit.
 

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -10,7 +10,7 @@ from commodore import compile
 from commodore.cluster import Cluster
 
 
-def lieutenant_query(api_url, api_token, api_endpoint, api_id):
+def lieutenant_query(api_url, api_token, api_endpoint, api_id, params={}, timeout=5):
     if api_endpoint == "clusters":
         return {"id": api_id}
 

--- a/tests/test_commodore_libjsonnet.py
+++ b/tests/test_commodore_libjsonnet.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import functools
 import json
-import os
 
 from pathlib import Path
 from typing import Any
@@ -10,7 +9,6 @@ from typing import Any
 from commodore.postprocess.jsonnet import _import_cb, _native_callbacks
 
 import _jsonnet
-import requests
 import pytest
 import yaml
 
@@ -172,12 +170,6 @@ def test_jsonnet(tmp_path: Path, tc: str):
       value: aaa
     """
     inputf, invf, expectedf = tc_files(tc)
-    os.makedirs(tmp_path / "lib")
-    resp = requests.get(
-        "https://raw.githubusercontent.com/bitnami-labs/kube-libsonnet/v1.19.0/kube.libsonnet"
-    )
-    with open(tmp_path / "lib" / "kube.libjsonnet", "w") as f:
-        f.write(resp.text)
     write_testdata(tmp_path)
     result = render_jsonnet(tmp_path, inputf, invf, work_dir=str(tmp_path))
     with open(expectedf) as e:

--- a/tox.ini
+++ b/tox.ini
@@ -74,7 +74,7 @@ commands =
 [bandit]
 exclude = .cache,.git,.tox,build,dist,docs,tests
 targets = .
-skips = B113,B603,B607
+skips = B603,B607
 
 [flake8]
 exclude = *.egg*,.git,.tox,venv


### PR DESCRIPTION
The HTTP request timeout can be configured through a new command line flag (or associated environment variable). If the parameter isn't provided, we use a request timeout of 5 seconds.

Resolves #758 

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
