### PR TITLE
Ensure that cluster catalog is initialized with branch `master`

### DIFF
--- a/commodore/gitrepo/__init__.py
+++ b/commodore/gitrepo/__init__.py
@@ -115,7 +115,7 @@ class GitRepo:
         if not force_init and targetdir.exists():
             self._repo = Repo(targetdir)
         else:
-            self._repo = Repo.init(targetdir, bare=bare)
+            self._repo = Repo.init(targetdir, bare=bare, initial_branch="master")
 
         if remote:
             self.remote = remote

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,8 @@ https://docs.pytest.org/en/latest/how-to/fixtures.html#scope-sharing-fixtures-ac
 """
 from __future__ import annotations
 
+import os
+
 from pathlib import Path
 from typing import Protocol
 
@@ -21,6 +23,23 @@ from commodore.gitrepo import GitRepo
 class RunnerFunc(Protocol):
     def __call__(self, args: list[str]) -> Result:
         ...
+
+
+@pytest.fixture(autouse=True)
+def gitconfig(tmp_path: Path) -> Path:
+    """Ensure that tests have a predictable empty gitconfig.
+
+    We set autouse=True, so that the fixture is automatically used for all
+    tests.  Tests that want to access the mock gitconfig can explicitly specify
+    the fixutre, so they get the path to the mock gitconfig.
+    """
+    os.environ["GIT_CONFIG_NOSYSTEM"] = "true"
+    os.environ["HOME"] = str(tmp_path)
+    os.environ["XDG_CONFIG_HOME"] = str(tmp_path / ".config")
+    gitconfig = tmp_path / ".config" / "git" / "config"
+    os.makedirs(gitconfig.parent, exist_ok=True)
+
+    return gitconfig
 
 
 @pytest.fixture

--- a/tests/test_gitrepo.py
+++ b/tests/test_gitrepo.py
@@ -752,3 +752,14 @@ def test_gitrepo_is_ahead_of_remote_local_branch(tmp_path: Path):
     # verify that our local branch is ahead of both local and remote tracking master
     assert len(list(r.repo.iter_commits("master..local"))) == 1
     assert len(list(r.repo.iter_commits("origin/master..local"))) == 1
+
+
+def test_gitrepo_init_always_master(gitconfig: Path, tmp_path: Path):
+    cfg = git.config.GitConfigParser(file_or_files=gitconfig, read_only=False)
+    cfg.add_value("init", "defaultBranch", "main").write()
+
+    r = gitrepo.GitRepo(None, tmp_path / "repo.git")
+    r.commit("Initial commit")
+
+    assert len(r._repo.heads) == 1
+    assert r._repo.heads[0].name == "master"


### PR DESCRIPTION
Until now, Commodore could fail to push the initial catalog for a cluster if the user's Git config sets `init.defaultBranch`. The
observed error is:

```
 > Commiting changes...
 > Pushing catalog to remote...
Error: Failed to push to the catalog repository: Git exited with status code 1
The error reported was:
  stderr: 'error: src refspec master does not match any
error: failed to push some refs to 'ssh://<catalog repo>''
```

This error is caused because GitPython falls back to `init.defaultBranch` when creating the catalog repo unless `initial_branch` is specified.

However, since Commodore unconditionally falls back to trying to push `master` when no default branch can be identified in the remote repo (e.g. empty catalog repo), the push then fails because we're trying to push branch `master` which doesn't exist locally.

This isn't an issue for `commodore component new` and `commodore package new` since we explicitly fall back to creating a `master` branch when initializing the worktree for the new dependency.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog


<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
