### PR TITLE
Fix mypy error for spurious `return` in `Component.lib_files`

### DIFF
--- a/commodore/component/__init__.py
+++ b/commodore/component/__init__.py
@@ -140,14 +140,16 @@ class Component:
 
     @property
     def lib_files(self) -> Iterable[P]:
+        # NOTE(sg): Usage of yield makes the whole function return a generator.
+        # So if the top-level condition is false, this should immediately raise
+        # a StopIteration exception. Mypy has started to complain about the
+        # `return []` that was previously part of this function.
         lib_dir = self.target_directory / "lib"
         if lib_dir.exists():
             for e in lib_dir.iterdir():
                 # Skip hidden files in lib directory
                 if not e.name.startswith("."):
                     yield e
-
-        return []
 
     def get_library(self, libname: str) -> Optional[P]:
         lib_dir = self.target_directory / "lib"


### PR DESCRIPTION
Mypy has started raising an error for generator functions (i.e. functions which use the `yield` keyword) which also contain a `return` statement.

From what I found in the docs, using yield makes the function return a generator in all cases. If execution hits a flow which doesn't encounter a yield statement (e.g. because the top-level condition is false) that generator will immediately raise a StopIteration exception.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
