### PR TITLE
Adjust component template tests to allow additional Cookiecutter context keys

### DIFF
--- a/tests/test_component_template.py
+++ b/tests/test_component_template.py
@@ -171,7 +171,7 @@ def _validate_rendered_component(
             "_template",
         }
 
-        assert set(cookiecutter_context.keys()) == context_keys
+        assert len(context_keys - set(cookiecutter_context.keys())) == 0
 
         assert cookiecutter_context["add_matrix"] == "y" if has_matrix else "n"
         assert cookiecutter_context["name"] == component_name


### PR DESCRIPTION
This allows us to add new Cookiecutter context keys to the template without breaking the tests. The adjusted test just checks that all the known context keys are present, but doesn't fail if there are any additional context keys.

Discovered after https://github.com/projectsyn/commodore-component-template/pull/101 got merged.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
