### PR TITLE
Add options to configure dependency patch automerge behavior in components via `component new` and `component update`

### DIFF
--- a/commodore/cli/component.py
+++ b/commodore/cli/component.py
@@ -41,6 +41,19 @@ def new_update_options(new_cmd: bool):
                 + "Commodore will deduplicate test cases by name."
             )
         click.option(
+            "--automerge-patch-v0 / --no-automerge-patch-v0",
+            is_flag=True,
+            default=False if new_cmd else None,
+            help="Enable automerging of patch-level dependency PRs "
+            + "for v0.x dependencies.",
+        )(cmd)
+        click.option(
+            "--automerge-patch / --no-automerge-patch",
+            is_flag=True,
+            default=True if new_cmd else None,
+            help="Enable automerging of patch-level dependency PRs.",
+        )(cmd)
+        click.option(
             "--additional-test-case",
             "-t",
             metavar="CASE",
@@ -147,6 +160,8 @@ def component_new(
     template_url: str,
     template_version: str,
     additional_test_case: Iterable[str],
+    automerge_patch: bool,
+    automerge_patch_v0: bool,
 ):
     config.update_verbosity(verbose)
     t = ComponentTemplater(
@@ -159,6 +174,8 @@ def component_new(
     t.golden_tests = golden_tests
     t.matrix_tests = matrix_tests
     t.test_cases = ["defaults"] + list(additional_test_case)
+    t.automerge_patch = automerge_patch
+    t.automerge_patch_v0 = automerge_patch_v0
     t.create()
 
 
@@ -204,6 +221,8 @@ def component_update(
     additional_test_case: Iterable[str],
     remove_test_case: Iterable[str],
     commit: bool,
+    automerge_patch: Optional[bool],
+    automerge_patch_v0: Optional[bool],
 ):
     """This command updates the component at COMPONENT_PATH to the latest version of the
     template which was originally used to create it, if the template version is given as
@@ -230,6 +249,10 @@ def component_update(
         t.library = lib
     if pp is not None:
         t.post_process = pp
+    if automerge_patch is not None:
+        t.automerge_patch = automerge_patch
+    if automerge_patch_v0 is not None:
+        t.automerge_patch_v0 = automerge_patch_v0
 
     test_cases = t.test_cases
     test_cases.extend(additional_test_case)

--- a/commodore/cli/component.py
+++ b/commodore/cli/component.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 from datetime import timedelta
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Tuple
 
 import click
 
@@ -18,6 +18,23 @@ from commodore.dependency_syncer import sync_dependencies
 import commodore.cli.options as options
 
 
+def _generate_option_text_snippets(new_cmd: bool) -> Tuple[str, str]:
+    if new_cmd:
+        test_case_help = (
+            "Additional test cases to generate in the new component. "
+            + "Can be repeated. Test case `defaults` will always be generated. "
+            + "Commodore will deduplicate test cases by name."
+        )
+    else:
+        test_case_help = (
+            "Additional test cases to add to the component. Can be repeated. "
+            + "Commodore will deduplicate test cases by name."
+        )
+    add_text = "Add" if new_cmd else "Add or remove"
+
+    return add_text, test_case_help
+
+
 def new_update_options(new_cmd: bool):
     """Shared command options for component new and component update.
 
@@ -28,18 +45,9 @@ def new_update_options(new_cmd: bool):
     unchanged by default by `component update`.
     """
 
+    add_text, test_case_help = _generate_option_text_snippets(new_cmd)
+
     def decorator(cmd):
-        if new_cmd:
-            test_case_help = (
-                "Additional test cases to generate in the new component. "
-                + "Can be repeated. Test case `defaults` will always be generated. "
-                + "Commodore will deduplicate test cases by name."
-            )
-        else:
-            test_case_help = (
-                "Additional test cases to add to the component. Can be repeated. "
-                + "Commodore will deduplicate test cases by name."
-            )
         click.option(
             "--automerge-patch-v0 / --no-automerge-patch-v0",
             is_flag=True,
@@ -62,7 +70,6 @@ def new_update_options(new_cmd: bool):
             multiple=True,
             help=test_case_help,
         )(cmd)
-        add_text = "Add" if new_cmd else "Add or remove"
         click.option(
             "--matrix-tests/--no-matrix-tests",
             default=True if new_cmd else None,

--- a/commodore/component/template.py
+++ b/commodore/component/template.py
@@ -16,6 +16,8 @@ from commodore.multi_dependency import MultiDependency
 class ComponentTemplater(Templater):
     library: bool
     post_process: bool
+    _automerge_patch: bool
+    automerge_patch_v0: bool
     _matrix_tests: bool
 
     @classmethod
@@ -79,6 +81,8 @@ class ComponentTemplater(Templater):
         self.library = cookiecutter_args["add_lib"] == "y"
         self.post_process = cookiecutter_args["add_pp"] == "y"
         self.matrix_tests = cookiecutter_args["add_matrix"] == "y"
+        self.automerge_patch = cookiecutter_args["automerge_patch"] == "y"
+        self.automerge_patch_v0 = cookiecutter_args["automerge_patch_v0"] == "y"
 
         return update_cruft_json
 
@@ -88,7 +92,23 @@ class ComponentTemplater(Templater):
         args["add_lib"] = "y" if self.library else "n"
         args["add_pp"] = "y" if self.post_process else "n"
         args["add_matrix"] = "y" if self.matrix_tests else "n"
+        args["automerge_patch"] = "y" if self.automerge_patch else "n"
+        args["automerge_patch_v0"] = "y" if self.automerge_patch_v0 else "n"
         return args
+
+    @property
+    def automerge_patch(self) -> bool:
+        if self.automerge_patch_v0:
+            click.echo(
+                " > Forcing automerging of patch dependencies to be enabled "
+                + "when automerging of v0.x patch dependencies is requested"
+            )
+            return True
+        return self._automerge_patch
+
+    @automerge_patch.setter
+    def automerge_patch(self, automerge_patch: bool) -> None:
+        self._automerge_patch = automerge_patch
 
     @property
     def matrix_tests(self) -> bool:

--- a/docs/modules/ROOT/pages/reference/cli.adoc
+++ b/docs/modules/ROOT/pages/reference/cli.adoc
@@ -208,6 +208,14 @@ Defaults to `--no-force`.
   Test case `defaults` will always be generated.
   Commodore will deduplicate the provided test cases.
 
+*--automerge-patch / --no-automerge-patch*::
+  Enable automerging of patch-level dependency PRs.
+
+*--automerge-patch-v0 / --no-automerge-patch-v0*::
+  Enable automerging of patch-level dependency PRs for v0.x dependencies.
++
+NOTE: Enabling automerging of patch-level dependency PRs for v0.x dependencies implicitly enables automerging of all patch-level dependency PRs.
+
 *--help*::
   Show component new usage and options then exit.
 
@@ -253,6 +261,14 @@ Defaults to `--no-force`.
 
 *--commit / --no-commit*::
   Whether to commit the rendered template changes.
+
+*--automerge-patch / --no-automerge-patch*::
+  Enable automerging of patch-level dependency PRs.
+
+*--automerge-patch-v0 / --no-automerge-patch-v0*::
+  Enable automerging of patch-level dependency PRs for v0.x dependencies.
++
+NOTE: Enabling automerging of patch-level dependency PRs for v0.x dependencies implicitly enables automerging of all patch-level dependency PRs.
 
 *--help*::
   Show component new usage and options then exit.

--- a/tests/test_component_template.py
+++ b/tests/test_component_template.py
@@ -687,6 +687,8 @@ def test_cookiecutter_args_no_cruft_json(tmp_path: P, config: Config):
     t.post_process = False
     t.copyright_holder = ""
     t.github_owner = "projectsyn"
+    t.automerge_patch = True
+    t.automerge_patch_v0 = False
 
     templater_cookiecutter_args = t.cookiecutter_args
 


### PR DESCRIPTION
Follow-up for https://github.com/projectsyn/commodore-component-template/pull/101
## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
