### PR TITLE
Add command line flags for disabling automerging of patch updates for selected dependencies

### DIFF
--- a/commodore/cli/component.py
+++ b/commodore/cli/component.py
@@ -35,6 +35,60 @@ def _generate_option_text_snippets(new_cmd: bool) -> Tuple[str, str]:
     return add_text, test_case_help
 
 
+def _generate_automerge_pattern_help(level: str, remove: bool = False) -> str:
+    op = "remove" if remove else "add"
+    opc = op.capitalize()
+    if remove:
+        removenote = (
+            "This flag has no effect if the provided pattern isn't part of the "
+            + "currently configured patterns. "
+        )
+    else:
+        removenote = ""
+    if level == "patch":
+        return (
+            f"{opc} regex pattern for dependencies that should be excluded from "
+            + "automerging of patch updates. Can be repeated. Commodore will "
+            + "deduplicate patterns. "
+            + removenote
+            + f"See '--{op}-automerge-patch-block-depname' for a variant of this flag "
+            + "which allows specifying dependency names."
+        )
+
+    raise ValueError(
+        f"Expected 'level' to be one of ['patch', 'patch_v0', 'minor'], got {level}"
+    )
+
+
+def _generate_automerge_depname_help(level: str, remove: bool = False) -> str:
+    implnote = (
+        "Commodore will convert the provided dependency names into a list of anchored "
+        + "regex patterns."
+    )
+    op = "remove" if remove else "add"
+    opc = op.capitalize()
+    if remove:
+        removenote = (
+            "This flag has no effect if the provided name isn't part of the "
+            + "currently configured dependency names. "
+        )
+    else:
+        removenote = ""
+    if level == "patch":
+        return (
+            f"{opc} dependency name that should be excluded from automerging of patch "
+            + "updates. Can be repeated. Commodore will deduplicate dependency names. "
+            + removenote
+            + f"See '--{op}-automerge-patch-block-pattern' for a variant of this flag "
+            + "which allows specifying regex patterns. "
+            + implnote
+        )
+
+    raise ValueError(
+        f"Expected 'level' to be one of ['patch', 'patch_v0', 'minor'], got {level}"
+    )
+
+
 def new_update_options(new_cmd: bool):
     """Shared command options for component new and component update.
 
@@ -48,6 +102,22 @@ def new_update_options(new_cmd: bool):
     add_text, test_case_help = _generate_option_text_snippets(new_cmd)
 
     def decorator(cmd):
+        click.option(
+            "--add-automerge-patch-block-pattern",
+            metavar="PATTERN",
+            default=[],
+            show_default=True,
+            multiple=True,
+            help=_generate_automerge_pattern_help(level="patch"),
+        )(cmd)
+        click.option(
+            "--add-automerge-patch-block-depname",
+            metavar="NAME",
+            default=[],
+            show_default=True,
+            multiple=True,
+            help=_generate_automerge_depname_help(level="patch"),
+        )(cmd)
         click.option(
             "--automerge-patch-v0 / --no-automerge-patch-v0",
             is_flag=True,
@@ -169,6 +239,8 @@ def component_new(
     additional_test_case: Iterable[str],
     automerge_patch: bool,
     automerge_patch_v0: bool,
+    add_automerge_patch_block_depname: Iterable[str],
+    add_automerge_patch_block_pattern: Iterable[str],
 ):
     config.update_verbosity(verbose)
     t = ComponentTemplater(
@@ -183,6 +255,10 @@ def component_new(
     t.test_cases = ["defaults"] + list(additional_test_case)
     t.automerge_patch = automerge_patch
     t.automerge_patch_v0 = automerge_patch_v0
+    for name in add_automerge_patch_block_depname:
+        t.add_automerge_patch_block_depname(name)
+    for pattern in add_automerge_patch_block_pattern:
+        t.add_automerge_patch_block_pattern(pattern)
     t.create()
 
 
@@ -208,6 +284,22 @@ def component_new(
     help="Test cases to remove from the component. Can be repeated.",
 )
 @click.option(
+    "--remove-automerge-patch-block-depname",
+    metavar="NAME",
+    default=[],
+    show_default=True,
+    multiple=True,
+    help=_generate_automerge_depname_help(level="patch", remove=True),
+)
+@click.option(
+    "--remove-automerge-patch-block-pattern",
+    metavar="PATTERN",
+    default=[],
+    show_default=True,
+    multiple=True,
+    help=_generate_automerge_pattern_help(level="patch", remove=True),
+)
+@click.option(
     "--commit / --no-commit",
     is_flag=True,
     default=True,
@@ -230,6 +322,10 @@ def component_update(
     commit: bool,
     automerge_patch: Optional[bool],
     automerge_patch_v0: Optional[bool],
+    add_automerge_patch_block_depname: Iterable[str],
+    add_automerge_patch_block_pattern: Iterable[str],
+    remove_automerge_patch_block_depname: Iterable[str],
+    remove_automerge_patch_block_pattern: Iterable[str],
 ):
     """This command updates the component at COMPONENT_PATH to the latest version of the
     template which was originally used to create it, if the template version is given as
@@ -264,6 +360,16 @@ def component_update(
     test_cases = t.test_cases
     test_cases.extend(additional_test_case)
     t.test_cases = [tc for tc in test_cases if tc not in remove_test_case]
+
+    for name in add_automerge_patch_block_depname:
+        t.add_automerge_patch_block_depname(name)
+    for pattern in add_automerge_patch_block_pattern:
+        t.add_automerge_patch_block_pattern(pattern)
+
+    for name in remove_automerge_patch_block_depname:
+        t.remove_automerge_patch_block_depname(name)
+    for pattern in remove_automerge_patch_block_pattern:
+        t.remove_automerge_patch_block_pattern(pattern)
 
     t.update(commit=commit)
 

--- a/docs/modules/ROOT/pages/reference/cli.adoc
+++ b/docs/modules/ROOT/pages/reference/cli.adoc
@@ -216,6 +216,19 @@ Defaults to `--no-force`.
 +
 NOTE: Enabling automerging of patch-level dependency PRs for v0.x dependencies implicitly enables automerging of all patch-level dependency PRs.
 
+*--add-automerge-patch-block-depname* NAME::
+  Add dependency name that should be excluded from automerging of patch updates.
+  Can be repeated.
+  Commodore will deduplicate dependency names.
+  See `--add-automerge-patch-block-pattern` for a variant of this flag which allows specifying regex patterns.
+  Commodore will convert the provided dependency names into a list of anchored regex patterns.
+
+*--add-automerge-patch-block-pattern* PATTERN::
+  Add regex pattern for dependencies that should be excluded from automerging of patch updates.
+  Can be repeated.
+  Commodore will deduplicate patterns.
+  See `--add-automerge-patch-block-depname` for a variant of this flag which allows specifying dependency names.
+
 *--help*::
   Show component new usage and options then exit.
 
@@ -269,6 +282,34 @@ NOTE: Enabling automerging of patch-level dependency PRs for v0.x dependencies i
   Enable automerging of patch-level dependency PRs for v0.x dependencies.
 +
 NOTE: Enabling automerging of patch-level dependency PRs for v0.x dependencies implicitly enables automerging of all patch-level dependency PRs.
+
+*--add-automerge-patch-block-depname* NAME::
+  Add dependency name that should be excluded from automerging of patch updates.
+  Can be repeated.
+  Commodore will deduplicate dependency names.
+  See `--add-automerge-patch-block-pattern` for a variant of this flag which allows specifying regex patterns.
+  Commodore will convert the provided dependency names into a list of anchored regex patterns.
+
+*--add-automerge-patch-block-pattern* PATTERN::
+  Add regex pattern for dependencies that should be excluded from automerging of patch updates.
+  Can be repeated.
+  Commodore will deduplicate patterns.
+  See `--add-automerge-patch-block-depname` for a variant of this flag which allows specifying dependency names.
+
+*--remove-automerge-patch-block-depname* NAME::
+  Remove dependency name that should be excluded from automerging of patch updates.
+  Can be repeated.
+  Commodore will deduplicate dependency names.
+  This flag has no effect if the provided name isn't part of the currently configured dependency names.
+  See `--remove-automerge-patch-block-pattern` for a variant of this flag which allows specifying regex patterns.
+  Commodore will convert the provided dependency names into a list of anchored regex patterns.
+
+*--remove-automerge-patch-block-pattern* PATTERN::
+  Remove regex pattern for dependencies that should be excluded from automerging of patch updates.
+  Can be repeated.
+  Commodore will deduplicate patterns.
+  This flag has no effect if the provided pattern isn't part of the currently configured patterns.
+  See '--remove-automerge-patch-block-depname' for a variant of this flag which allows specifying dependency names.
 
 *--help*::
   Show component new usage and options then exit.

--- a/tests/test_component_template.py
+++ b/tests/test_component_template.py
@@ -214,7 +214,7 @@ def _validate_rendered_component(
             assert patch_rule["matchUpdateTypes"] == ["patch"]
             assert patch_rule["automerge"] is True
             assert patch_rule["platformAutomerge"] is False
-            assert patch_rule["labels"] == ["dependency", "automerge"]
+            assert patch_rule["labels"] == ["dependency", "automerge", "bump:patch"]
             if "matchCurrentVersion" in patch_rule:
                 assert patch_rule["matchCurrentVersion"] == "!/^v?0\\./"
 


### PR DESCRIPTION
This PR adds command line flags and internal logic to allow users to configure the component template's patch automerging blocklist. We add command line flags that allow specifying regex patterns directly as well as flags that take a full dependency name and generate an anchored pattern from it.

Split out from #978.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
