### PR TITLE
 Add command line flags for configuring automerging of minor updates for selected dependencies

### DIFF
--- a/commodore/cli/component.py
+++ b/commodore/cli/component.py
@@ -65,6 +65,14 @@ def _generate_automerge_pattern_help(level: str, remove: bool = False) -> str:
             + f"See '--{op}-automerge-patch-v0-allow-depname' for a variant of "
             + "this flag which allows specifying dependency names."
         )
+    if level == "minor":
+        return (
+            f"{opc} regex pattern for dependencies for which minor updates should be "
+            + "automerged. Can be repeated. Commodore will deduplicate patterns. "
+            + removenote
+            + f"See '--{op}-automerge-minor-allow-depname' for a variant of "
+            + "this flag which allows specifying dependency names."
+        )
 
     raise ValueError(
         f"Expected 'level' to be one of ['patch', 'patch_v0', 'minor'], got {level}"
@@ -105,6 +113,15 @@ def _generate_automerge_depname_help(level: str, remove: bool = False) -> str:
             + "flag which allows specifying regex patterns. "
             + implnote
         )
+    if level == "minor":
+        return (
+            f"{opc} dependency name for which minor updates should be automerged. "
+            + "Can be repeated. Commodore will deduplicate dependency names. "
+            + removenote
+            + f"See '--{op}-automerge-minor-allow-pattern' for a variant of "
+            + "this flag which allows specifying regex patterns. "
+            + implnote
+        )
 
     raise ValueError(
         f"Expected 'level' to be one of ['patch', 'patch_v0', 'minor'], got {level}"
@@ -124,6 +141,22 @@ def new_update_options(new_cmd: bool):
     add_text, test_case_help = _generate_option_text_snippets(new_cmd)
 
     def decorator(cmd):
+        click.option(
+            "--add-automerge-minor-allow-pattern",
+            metavar="PATTERN",
+            default=[],
+            show_default=True,
+            multiple=True,
+            help=_generate_automerge_pattern_help(level="minor"),
+        )(cmd)
+        click.option(
+            "--add-automerge-minor-allow-depname",
+            metavar="NAME",
+            default=[],
+            show_default=True,
+            multiple=True,
+            help=_generate_automerge_depname_help(level="minor"),
+        )(cmd)
         click.option(
             "--add-automerge-patch-v0-allow-pattern",
             metavar="PATTERN",
@@ -281,6 +314,8 @@ def component_new(
     add_automerge_patch_block_pattern: Iterable[str],
     add_automerge_patch_v0_allow_depname: Iterable[str],
     add_automerge_patch_v0_allow_pattern: Iterable[str],
+    add_automerge_minor_allow_depname: Iterable[str],
+    add_automerge_minor_allow_pattern: Iterable[str],
 ):
     config.update_verbosity(verbose)
     t = ComponentTemplater(
@@ -303,6 +338,10 @@ def component_new(
         t.add_automerge_patch_v0_allow_depname(name)
     for pattern in add_automerge_patch_v0_allow_pattern:
         t.add_automerge_patch_v0_allow_pattern(pattern)
+    for name in add_automerge_minor_allow_depname:
+        t.add_automerge_minor_allow_depname(name)
+    for pattern in add_automerge_minor_allow_pattern:
+        t.add_automerge_minor_allow_pattern(pattern)
     t.create()
 
 
@@ -360,6 +399,22 @@ def component_new(
     help=_generate_automerge_pattern_help(level="patch_v0", remove=True),
 )
 @click.option(
+    "--remove-automerge-minor-allow-depname",
+    metavar="NAME",
+    default=[],
+    show_default=True,
+    multiple=True,
+    help=_generate_automerge_depname_help(level="minor", remove=True),
+)
+@click.option(
+    "--remove-automerge-minor-allow-pattern",
+    metavar="PATTERN",
+    default=[],
+    show_default=True,
+    multiple=True,
+    help=_generate_automerge_pattern_help(level="minor", remove=True),
+)
+@click.option(
     "--commit / --no-commit",
     is_flag=True,
     default=True,
@@ -386,10 +441,14 @@ def component_update(
     add_automerge_patch_block_pattern: Iterable[str],
     add_automerge_patch_v0_allow_depname: Iterable[str],
     add_automerge_patch_v0_allow_pattern: Iterable[str],
+    add_automerge_minor_allow_depname: Iterable[str],
+    add_automerge_minor_allow_pattern: Iterable[str],
     remove_automerge_patch_block_depname: Iterable[str],
     remove_automerge_patch_block_pattern: Iterable[str],
     remove_automerge_patch_v0_allow_depname: Iterable[str],
     remove_automerge_patch_v0_allow_pattern: Iterable[str],
+    remove_automerge_minor_allow_depname: Iterable[str],
+    remove_automerge_minor_allow_pattern: Iterable[str],
 ):
     """This command updates the component at COMPONENT_PATH to the latest version of the
     template which was originally used to create it, if the template version is given as
@@ -433,6 +492,10 @@ def component_update(
         t.add_automerge_patch_v0_allow_depname(name)
     for pattern in add_automerge_patch_v0_allow_pattern:
         t.add_automerge_patch_v0_allow_pattern(pattern)
+    for name in add_automerge_minor_allow_depname:
+        t.add_automerge_minor_allow_depname(name)
+    for pattern in add_automerge_minor_allow_pattern:
+        t.add_automerge_minor_allow_pattern(pattern)
 
     for name in remove_automerge_patch_block_depname:
         t.remove_automerge_patch_block_depname(name)
@@ -442,6 +505,10 @@ def component_update(
         t.remove_automerge_patch_v0_allow_depname(name)
     for pattern in remove_automerge_patch_v0_allow_pattern:
         t.remove_automerge_patch_v0_allow_pattern(pattern)
+    for name in remove_automerge_minor_allow_depname:
+        t.remove_automerge_minor_allow_depname(name)
+    for pattern in remove_automerge_minor_allow_pattern:
+        t.remove_automerge_minor_allow_pattern(pattern)
 
     t.update(commit=commit)
 

--- a/commodore/component/template.py
+++ b/commodore/component/template.py
@@ -108,6 +108,16 @@ class ComponentTemplater(Templater):
         self.matrix_tests = cookiecutter_args["add_matrix"] == "y"
         self.automerge_patch = cookiecutter_args["automerge_patch"] == "y"
         self.automerge_patch_v0 = cookiecutter_args["automerge_patch_v0"] == "y"
+
+        self._initialize_automerge_pattern_lists_from_cookiecutter_args(
+            cookiecutter_args
+        )
+
+        return update_cruft_json
+
+    def _initialize_automerge_pattern_lists_from_cookiecutter_args(
+        self, cookiecutter_args: dict[str, str]
+    ):
         args_patch_blocklist = cookiecutter_args.get(
             "automerge_patch_regexp_blocklist", ""
         )
@@ -129,8 +139,6 @@ class ComponentTemplater(Templater):
             self._automerge_minor_allowlist = set(args_minor_allowlist.split(";"))
         else:
             self._automerge_minor_allowlist = set()
-
-        return update_cruft_json
 
     @property
     def cookiecutter_args(self) -> dict[str, str]:

--- a/docs/modules/ROOT/pages/reference/cli.adoc
+++ b/docs/modules/ROOT/pages/reference/cli.adoc
@@ -244,6 +244,19 @@ NOTE: Enabling automerging of patch-level dependency PRs for v0.x dependencies i
   Commodore will deduplicate patterns.
   See `--add-automerge-patch-v0-allow- depname` for a variant of this flag which allows specifying dependency names.
 
+*--add-automerge-minor-allow-depname* NAME::
+  Add dependency name for which minor updates should be automerged.
+  Can be repeated.
+  Commodore will deduplicate dependency names.
+  See `--add-automerge-minor-allow-pattern` for a variant of this flag which allows specifying regex patterns.
+  Commodore will convert the provided dependency names into a list of anchored regex patterns.
+
+*--add-automerge-minor-allow-pattern* PATTERN::
+  Add regex pattern for dependencies for which minor updates should be automerged.
+  Can be repeated.
+  Commodore will deduplicate patterns.
+  See `--add-automerge-minor-allow-depname` for a variant of this flag which allows specifying dependency names.
+
 *--help*::
   Show component new usage and options then exit.
 
@@ -356,6 +369,34 @@ NOTE: Enabling automerging of patch-level dependency PRs for v0.x dependencies i
   Commodore will deduplicate patterns.
   This flag has no effect if the provided pattern isn't part of the currently configured patterns.
   See `--remove-automerge-patch-v0-allow-depname` for a variant of this flag which allows specifying dependency names.
+
+*--add-automerge-minor-allow-depname* NAME::
+  Add dependency name for which minor updates should be automerged.
+  Can be repeated.
+  Commodore will deduplicate dependency names.
+  See `--add-automerge-minor-allow-pattern` for a variant of this flag which allows specifying regex patterns.
+  Commodore will convert the provided dependency names into a list of anchored regex patterns.
+
+*--add-automerge-minor-allow-pattern* PATTERN::
+  Add regex pattern for dependencies for which minor updates should be automerged.
+  Can be repeated.
+  Commodore will deduplicate patterns.
+  See `--add-automerge-minor-allow-depname` for a variant of this flag which allows specifying dependency names.
+
+*--remove-automerge-minor-allow-depname* NAME::
+  Remove dependency name for which minor updates should be automerged.
+  Can be repeated.
+  Commodore will deduplicate dependency names.
+  This flag has no effect if the provided name isn't part of the currently configured dependency names.
+  See `-- remove-automerge-minor-allow-pattern` for a variant of this flag which allows specifying regex patterns.
+  Commodore will convert the provided dependency names into a list of anchored regex patterns.
+
+*--remove-automerge-minor-allow-pattern* PATTERN::
+  Remove regex pattern for dependencies for which minor updates should be automerged.
+  Can be repeated.
+  Commodore will deduplicate patterns.
+  This flag has no effect if the provided pattern isn't part of the currently configured patterns.
+  See `--remove-automerge-minor-allow-depname` for a variant of this flag which allows specifying dependency names.
 
 *--help*::
   Show component new usage and options then exit.


### PR DESCRIPTION
This PR introduces command line flags which allow users to configure an allowlist for automerging of minor updates for dependencies. We add command line flags that allow specifying regex patterns directly as well as flags that take a full dependency name and generate an anchored pattern from it.

Split out from #978 

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
