### PR TITLE
Add CLI flag to control autorelease config in `component new` and `component update`

### DIFF
--- a/commodore/cli/component.py
+++ b/commodore/cli/component.py
@@ -190,6 +190,14 @@ def new_update_options(new_cmd: bool):
             help=_generate_automerge_depname_help(level="patch"),
         )(cmd)
         click.option(
+            "--autorelease / --no-autorelease",
+            is_flag=True,
+            default=True if new_cmd else None,
+            help="Enable autorelease GitHub action. "
+            + "When autorelease is enabled, new releases will be generated "
+            + "for automerged dependency PRs.",
+        )(cmd)
+        click.option(
             "--automerge-patch-v0 / --no-automerge-patch-v0",
             is_flag=True,
             default=False if new_cmd else None,
@@ -310,6 +318,7 @@ def component_new(
     additional_test_case: Iterable[str],
     automerge_patch: bool,
     automerge_patch_v0: bool,
+    autorelease: bool,
     add_automerge_patch_block_depname: Iterable[str],
     add_automerge_patch_block_pattern: Iterable[str],
     add_automerge_patch_v0_allow_depname: Iterable[str],
@@ -330,6 +339,7 @@ def component_new(
     t.test_cases = ["defaults"] + list(additional_test_case)
     t.automerge_patch = automerge_patch
     t.automerge_patch_v0 = automerge_patch_v0
+    t.autorelease = autorelease
     for name in add_automerge_patch_block_depname:
         t.add_automerge_patch_block_depname(name)
     for pattern in add_automerge_patch_block_pattern:
@@ -437,6 +447,7 @@ def component_update(
     commit: bool,
     automerge_patch: Optional[bool],
     automerge_patch_v0: Optional[bool],
+    autorelease: Optional[bool],
     add_automerge_patch_block_depname: Iterable[str],
     add_automerge_patch_block_pattern: Iterable[str],
     add_automerge_patch_v0_allow_depname: Iterable[str],
@@ -479,6 +490,8 @@ def component_update(
         t.automerge_patch = automerge_patch
     if automerge_patch_v0 is not None:
         t.automerge_patch_v0 = automerge_patch_v0
+    if autorelease is not None:
+        t.autorelease = autorelease
 
     test_cases = t.test_cases
     test_cases.extend(additional_test_case)

--- a/commodore/component/template.py
+++ b/commodore/component/template.py
@@ -19,6 +19,7 @@ class ComponentTemplater(Templater):
     post_process: bool
     _automerge_patch: bool
     automerge_patch_v0: bool
+    autorelease: bool
     _matrix_tests: bool
     _automerge_patch_blocklist: set[str]
     _automerge_patch_v0_allowlist: set[str]
@@ -108,6 +109,7 @@ class ComponentTemplater(Templater):
         self.matrix_tests = cookiecutter_args["add_matrix"] == "y"
         self.automerge_patch = cookiecutter_args["automerge_patch"] == "y"
         self.automerge_patch_v0 = cookiecutter_args["automerge_patch_v0"] == "y"
+        self.autorelease = cookiecutter_args["auto_release"] == "y"
 
         self._initialize_automerge_pattern_lists_from_cookiecutter_args(
             cookiecutter_args
@@ -148,6 +150,7 @@ class ComponentTemplater(Templater):
         args["add_matrix"] = "y" if self.matrix_tests else "n"
         args["automerge_patch"] = "y" if self.automerge_patch else "n"
         args["automerge_patch_v0"] = "y" if self.automerge_patch_v0 else "n"
+        args["auto_release"] = "y" if self.autorelease else "n"
         args["automerge_patch_regexp_blocklist"] = ";".join(
             sorted(self._automerge_patch_blocklist)
         )

--- a/docs/modules/ROOT/pages/reference/cli.adoc
+++ b/docs/modules/ROOT/pages/reference/cli.adoc
@@ -216,6 +216,11 @@ Defaults to `--no-force`.
 +
 NOTE: Enabling automerging of patch-level dependency PRs for v0.x dependencies implicitly enables automerging of all patch-level dependency PRs.
 
+*--autorelease / --no-autorelease*::
+  Enable autorelease GitHub action
++
+NOTE: If autorelease is enabled, new releases will be generated for automerged dependency PRs.
+
 *--add-automerge-patch-block-depname* NAME::
   Add dependency name that should be excluded from automerging of patch updates.
   Can be repeated.


### PR DESCRIPTION
Exposes the new cookiecutter arg for autorelease that was introduced in https://github.com/projectsyn/commodore-component-template/pull/110

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
