### PR TITLE
Ensure that we can update components that have been rendered from old template versions

### DIFF
--- a/commodore/component/template.py
+++ b/commodore/component/template.py
@@ -107,9 +107,11 @@ class ComponentTemplater(Templater):
         self.library = cookiecutter_args["add_lib"] == "y"
         self.post_process = cookiecutter_args["add_pp"] == "y"
         self.matrix_tests = cookiecutter_args["add_matrix"] == "y"
-        self.automerge_patch = cookiecutter_args["automerge_patch"] == "y"
-        self.automerge_patch_v0 = cookiecutter_args["automerge_patch_v0"] == "y"
-        self.autorelease = cookiecutter_args["auto_release"] == "y"
+        self.automerge_patch = cookiecutter_args.get("automerge_patch", "y") == "y"
+        self.automerge_patch_v0 = (
+            cookiecutter_args.get("automerge_patch_v0", "n") == "y"
+        )
+        self.autorelease = cookiecutter_args.get("auto_release", "y") == "y"
 
         self._initialize_automerge_pattern_lists_from_cookiecutter_args(
             cookiecutter_args


### PR DESCRIPTION
`component update` fails with Commodore ==1.22.0 for components that were generated with a template version that didn't include the automerge options. For example, we can no longer onboard components to the template sync if they were generated without automerge options now that the template sync uses Commodore 1.22.0.

This PR ensures that `component update` will use the default values for the automerge options if they're not present in the component's `.cruft.json`.

Follow-up to #974 #981 #982 #983 #984

See https://github.com/projectsyn/commodore-component-template/actions/runs/9518725022/job/26240261257 for an example failure.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
