### PR TITLE
Fix tests to match that patch automerge now also automerges digest updates

### DIFF
--- a/tests/test_component_template.py
+++ b/tests/test_component_template.py
@@ -126,7 +126,7 @@ def _validate_renovatejson_packagerules(
             expected_keys.add("excludePackagePatterns")
 
         assert set(patch_rule.keys()) == expected_keys
-        assert patch_rule["matchUpdateTypes"] == ["patch"]
+        assert patch_rule["matchUpdateTypes"] == ["patch", "digest"]
         assert patch_rule["automerge"] is True
         assert patch_rule["platformAutomerge"] is False
         assert patch_rule["labels"] == ["dependency", "automerge", "bump:patch"]


### PR DESCRIPTION
We've updated the component template in https://github.com/projectsyn/commodore-component-template/pull/115. This PR updates the Commodore component template tests to match that change.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog


<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
