### PR TITLE
Update minimum required Python to 3.10

### DIFF
--- a/.github/workflows/build-virtualenv-caches.yml
+++ b/.github/workflows/build-virtualenv-caches.yml
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '3.11'
     - uses: Gr1N/setup-poetry@v9
     - name: Install tox
       run: |
@@ -42,8 +42,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '3.8'
-          - '3.9'
           - '3.10'
           - '3.11'
     steps:
@@ -90,8 +88,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '3.8'
-          - '3.9'
           - '3.10'
           - '3.11'
     steps:
@@ -120,7 +116,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '3.11'
     - uses: Gr1N/setup-poetry@v9
     - uses: actions/cache@v4
       with:
@@ -128,5 +124,5 @@ jobs:
         key: ${{ runner.os }}-poetry-${{ hashFiles('poetry.lock') }}
     - name: Install Poetry and setup Poetry virtualenv
       run: |
-        poetry env use python3.9
+        poetry env use python3.11
         poetry install

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '3.11'
     - uses: Gr1N/setup-poetry@v9
     - uses: actions/cache@v4
       with:
@@ -24,7 +24,7 @@ jobs:
         key: ${{ runner.os }}-poetry-${{ hashFiles('poetry.lock') }}
     - name: Install Poetry and setup Poetry virtualenv
       run: |
-        poetry env use python3.9
+        poetry env use python3.11
         poetry install
     - name: Install jsonnet-bundler
       run: |

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.11'
       - uses: Gr1N/setup-poetry@v9
       - uses: actions/cache@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '3.11'
     - uses: Gr1N/setup-poetry@v9
     - name: Install tox
       run: |
@@ -44,8 +44,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '3.8'
-          - '3.9'
           - '3.10'
           - '3.11'
     steps:
@@ -105,8 +103,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '3.8'
-          - '3.9'
           - '3.10'
           - '3.11'
     steps:
@@ -143,7 +139,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '3.11'
     - uses: Gr1N/setup-poetry@v9
     - uses: actions/cache@v4
       with:
@@ -151,7 +147,7 @@ jobs:
         key: ${{ runner.os }}-poetry-${{ hashFiles('poetry.lock') }}
     - name: Install Poetry, setup Poetry virtualenv, and build Kapitan helm bindings
       run: |
-        poetry env use python3.9
+        poetry env use python3.11
         poetry install
     - name: Install jsonnet-bundler
       run: |

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Commodore also supports additional processing on the output of Kapitan, such as 
 
 ## System Requirements
 
-* Python 3.8 - 3.11 with `python3-dev` and `python3-venv` updated
+* Python 3.10 - 3.11 with `python3-dev` and `python3-venv` updated
 * [jsonnet-bundler](https://github.com/jsonnet-bundler/jsonnet-bundler)
   * Our fork [projectsyn/jsonnet-bundler](https://github.com/projectsyn/jsonnet-bundler) is currently recommended.
     It parallelizes fetching of dependencies, which speeds up Commodore significantly, and has fixes to make the dependency fetching more deterministic.

--- a/docs/modules/ROOT/pages/explanation/running-commodore.adoc
+++ b/docs/modules/ROOT/pages/explanation/running-commodore.adoc
@@ -17,7 +17,7 @@ We recommend that you use the Commodore Python package provided on PyPI to make 
 
 === Prerequisites
 
-* A Python version between 3.8 and 3.11 as `python3` and the Python `venv` module.
+* A Python version between 3.10 and 3.11 as `python3` and the Python `venv` module.
 We recommend that you install Python and the `venv` module with your preferred package manager.
 * Additionally, a few of the Commodore Python package dependencies require a working C compiler, the Python 3 development package, and the FFI development package.
 On Linux distributions you'll want packages `python3-dev` or `python3-devel` and `libffi-dev` or `libffi-devel` respectively.
@@ -51,7 +51,7 @@ This command should report something like
 +
 [source]
 ----
-Python 3.8.10
+Python 3.11.9
 ----
 
 . Create a virtualenv in `~/.local/commodore-venv`

--- a/poetry.lock
+++ b/poetry.lock
@@ -210,10 +210,7 @@ files = [
 [package.dependencies]
 jmespath = ">=0.7.1,<2.0.0"
 python-dateutil = ">=2.1,<3.0.0"
-urllib3 = [
-    {version = ">=1.25.4,<1.27", markers = "python_version < \"3.10\""},
-    {version = ">=1.25.4,<2.2.0 || >2.2.0,<3", markers = "python_version >= \"3.10\""},
-]
+urllib3 = {version = ">=1.25.4,<2.2.0 || >2.2.0,<3", markers = "python_version >= \"3.10\""}
 
 [package.extras]
 crt = ["awscrt (==0.21.2)"]
@@ -919,28 +916,6 @@ perf = ["ipython"]
 test = ["flufl.flake8", "importlib-resources (>=1.3)", "jaraco.test (>=5.4)", "packaging", "pyfakefs", "pytest (>=6,!=8.1.*)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy", "pytest-perf (>=0.9.2)", "pytest-ruff (>=0.2.1)"]
 
 [[package]]
-name = "importlib-resources"
-version = "6.4.4"
-description = "Read resources from Python packages"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "importlib_resources-6.4.4-py3-none-any.whl", hash = "sha256:dda242603d1c9cd836c3368b1174ed74cb4049ecd209e7a1a0104620c18c5c11"},
-    {file = "importlib_resources-6.4.4.tar.gz", hash = "sha256:20600c8b7361938dc0bb2d5ec0297802e575df486f5a544fa414da65e13721f7"},
-]
-
-[package.dependencies]
-zipp = {version = ">=3.1.0", markers = "python_version < \"3.10\""}
-
-[package.extras]
-check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1)"]
-cover = ["pytest-cov"]
-doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-enabler = ["pytest-enabler (>=2.2)"]
-test = ["jaraco.test (>=5.4)", "pytest (>=6,!=8.1.*)", "zipp (>=3.17)"]
-type = ["pytest-mypy"]
-
-[[package]]
 name = "iniconfig"
 version = "2.0.0"
 description = "brain-dead simple config-ini parsing"
@@ -1030,9 +1005,7 @@ files = [
 
 [package.dependencies]
 attrs = ">=22.2.0"
-importlib-resources = {version = ">=1.4.0", markers = "python_version < \"3.9\""}
 jsonschema-specifications = ">=2023.03.6"
-pkgutil-resolve-name = {version = ">=1.3.10", markers = "python_version < \"3.9\""}
 referencing = ">=0.28.4"
 rpds-py = ">=0.7.1"
 
@@ -1052,7 +1025,6 @@ files = [
 ]
 
 [package.dependencies]
-importlib-resources = {version = ">=1.4.0", markers = "python_version < \"3.9\""}
 referencing = ">=0.31.0"
 
 [[package]]
@@ -1308,17 +1280,6 @@ python-versions = ">=3.8"
 files = [
     {file = "pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08"},
     {file = "pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712"},
-]
-
-[[package]]
-name = "pkgutil-resolve-name"
-version = "1.3.10"
-description = "Resolve a name to an object."
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "pkgutil_resolve_name-1.3.10-py3-none-any.whl", hash = "sha256:ca27cc078d25c5ad71a9de0a7a330146c4e014c2462d9af19c6b828280649c5e"},
-    {file = "pkgutil_resolve_name-1.3.10.tar.gz", hash = "sha256:357d6c9e6a755653cfd78893817c0853af365dd51ec97f3d358a819373bbd174"},
 ]
 
 [[package]]
@@ -1612,7 +1573,6 @@ mccabe = ">=0.6,<0.8"
 platformdirs = ">=2.2.0"
 tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
 tomlkit = ">=0.10.1"
-typing-extensions = {version = ">=3.10.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
 spelling = ["pyenchant (>=3.2,<4.0)"]
@@ -2096,7 +2056,6 @@ files = [
 [package.dependencies]
 markdown-it-py = ">=2.2.0"
 pygments = ">=2.13.0,<3.0.0"
-typing-extensions = {version = ">=4.0.0,<5.0", markers = "python_version < \"3.9\""}
 
 [package.extras]
 jupyter = ["ipywidgets (>=7.5.1,<9)"]
@@ -2358,7 +2317,6 @@ files = [
 ]
 
 [package.dependencies]
-importlib-metadata = {version = ">=3.6", markers = "python_version < \"3.10\""}
 typing-extensions = ">=4.10.0"
 
 [package.extras]
@@ -2439,22 +2397,6 @@ files = [
 
 [package.dependencies]
 six = "*"
-
-[[package]]
-name = "urllib3"
-version = "1.26.20"
-description = "HTTP library with thread-safe connection pooling, file post, and more."
-optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
-files = [
-    {file = "urllib3-1.26.20-py2.py3-none-any.whl", hash = "sha256:0ed14ccfbf1c30a9072c7ca157e4319b70d65f623e91e7b32fadb2853431016e"},
-    {file = "urllib3-1.26.20.tar.gz", hash = "sha256:40c2dc0c681e47eb8f90e7e27bf6ff7df2e677421fd46756da1161c39ca70d32"},
-]
-
-[package.extras]
-brotli = ["brotli (==1.0.9)", "brotli (>=1.0.9)", "brotlicffi (>=0.8.0)", "brotlipy (>=0.6.0)"]
-secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "pyOpenSSL (>=0.14)", "urllib3-secure-extra"]
-socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "urllib3"
@@ -2611,5 +2553,5 @@ type = ["pytest-mypy"]
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.8, <3.12"
-content-hash = "549a8de1efba5a029c742c01bfa69425e8420d5e4fa12a43972da60ec4c4e637"
+python-versions = ">=3.10, <3.12"
+content-hash = "c532abcfd0a1add3061aff37f6eb96ac9d527b095330fa6d4d525cee78704997"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ include = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.8, <3.12"
+python = ">=3.10, <3.12"
 # NOTE: We restrict boto3/botocore versions to reduce complexity of Poetry's
 # dependency resolution significantly, cf.
 # https://github.com/orgs/python-poetry/discussions/8165#discussioncomment-6387378

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist =
     bandit
     mypy
     black
-    py3{8,9,10,11}{,-bench}
+    py3{10,11}{,-bench}
     py311-reclass-rs
 
 [testenv]

--- a/tox.mk
+++ b/tox.mk
@@ -39,13 +39,7 @@ lintenv_mypy:
 lintenv_black:
 	$(TOX_COMMAND) -e black --notest
 
-.PHONY: test_py3.8 test_py3.9 test_py3.10 test_py3.11 test_py3.11_reclass_rs
-
-test_py3.8:
-	$(TOX_COMMAND) -e py38
-
-test_py3.9:
-	$(TOX_COMMAND) -e py39
+.PHONY: test_py3.10 test_py3.11 test_py3.11_reclass_rs
 
 test_py3.10:
 	$(TOX_COMMAND) -e py310
@@ -56,14 +50,7 @@ test_py3.11:
 test_py3.11_reclass_rs:
 	$(TOX_COMMAND) -e py311-reclass-rs
 
-.PHONY: testenv_py3.8 testenv_py3.9 testenv_py3.10 testenv_py3.11 testenv_py3.11_reclass_rs
-
-
-testenv_py3.8:
-	$(TOX_COMMAND) -e py38 --notest
-
-testenv_py3.9:
-	$(TOX_COMMAND) -e py39 --notest
+.PHONY: testenv_py3.10 testenv_py3.11 testenv_py3.11_reclass_rs
 
 testenv_py3.10:
 	$(TOX_COMMAND) -e py310 --notest
@@ -74,13 +61,7 @@ testenv_py3.11:
 testenv_py3.11_reclass_rs:
 	$(TOX_COMMAND) -e py311 --notest
 
-.PHONY: bench_py3.8 bench_py3.9 bench_py3.10 bench_py3.11
-
-bench_py3.8:
-	$(TOX_COMMAND) -e py38-bench
-
-bench_py3.9:
-	$(TOX_COMMAND) -e py39-bench
+.PHONY: bench_py3.10 bench_py3.11
 
 bench_py3.10:
 	$(TOX_COMMAND) -e py310-bench
@@ -88,13 +69,7 @@ bench_py3.10:
 bench_py3.11:
 	$(TOX_COMMAND) -e py311-bench
 
-.PHONY: benchenv_py3.8 benchenv_py3.9 benchenv_py3.10 benchenv_py3.11
-
-benchenv_py3.8:
-	$(TOX_COMMAND) -e py38-bench --notest
-
-benchenv_py3.9:
-	$(TOX_COMMAND) -e py39-bench --notest
+.PHONY: benchenv_py3.10 benchenv_py3.11
 
 benchenv_py3.10:
 	$(TOX_COMMAND) -e py310-bench --notest


### PR DESCRIPTION
This is necessary so that we can update to Kapitan >= 0.33.x which drops support for Python 3.8 and 3.9.

This PR also removes test and benchmark targets for Python 3.8 and 3.9.

Since Python 3.8 will be EOL in a month (2024-10) and Python 3.9 would only be supported for a further year until 2025-10 (cf. https://devguide.python.org/versions/), we're not going to release this breaking change as a new major version.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
