### PR TITLE
Use go-jsonnet in Commodore

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,15 @@
 FROM docker.io/python:3.11.5-slim-bullseye AS base
 
+ARG TARGETARCH
+ENV TARGETARCH=${TARGETARCH:-amd64}
+
 ENV HOME=/app
 
 WORKDIR ${HOME}
 
 FROM base AS builder
 
-ENV PATH=${PATH}:${HOME}/.local/bin
+ENV PATH=${PATH}:${HOME}/.local/bin:/usr/local/go/bin
 
 ARG POETRY_VERSION=1.8.4
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -16,6 +19,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
  && rm -rf /var/lib/apt/lists/* \
  && curl -sSL https://install.python-poetry.org | python - --version ${POETRY_VERSION} \
  && mkdir -p /app/.config
+
+
+RUN curl -fsSL -o go.tar.gz https://go.dev/dl/go1.23.2.linux-${TARGETARCH}.tar.gz \
+ && tar -C /usr/local -xzf go.tar.gz \
+ && rm go.tar.gz \
+ && go version
 
 COPY pyproject.toml poetry.lock ./
 

--- a/commodore/component/__init__.py
+++ b/commodore/component/__init__.py
@@ -4,7 +4,7 @@ from collections.abc import Iterable
 from pathlib import Path as P
 from typing import Optional
 
-import _jsonnet
+import _gojsonnet
 import click
 import git
 
@@ -216,7 +216,7 @@ class Component:
             except git.InvalidGitRepositoryError:
                 pass
             # pylint: disable=c-extension-no-member
-            output = _jsonnet.evaluate_file(
+            output = _gojsonnet.evaluate_file(
                 str(jsonnetfile_jsonnet),
                 ext_vars=component_params.get("jsonnetfile_parameters", {}),
             )

--- a/commodore/helpers.py
+++ b/commodore/helpers.py
@@ -269,6 +269,7 @@ def kapitan_compile(
         validate=False,
         schemas_path=config.work_dir / "schemas",
         jinja2_filters=defaults.DEFAULT_JINJA2_FILTERS_PATH,
+        use_go_jsonnet=True,
     )
 
 

--- a/commodore/postprocess/builtin_filters.py
+++ b/commodore/postprocess/builtin_filters.py
@@ -4,7 +4,8 @@ import json
 
 from pathlib import Path as P
 
-import _jsonnet
+import _gojsonnet
+
 import click
 
 from commodore import __install_dir__
@@ -42,7 +43,7 @@ def _builtin_filter_helm_namespace(
         component.name,
         instance,
         path,
-        _jsonnet.evaluate_file,
+        _gojsonnet.evaluate_file,
         __install_dir__ / "filters" / "helm_namespace.jsonnet",
         namespace=kwargs["namespace"],
         create_namespace=create_namespace,

--- a/commodore/postprocess/jsonnet.py
+++ b/commodore/postprocess/jsonnet.py
@@ -8,7 +8,7 @@ from collections.abc import Callable, Iterable
 from pathlib import Path as P
 from typing import Any
 
-import _jsonnet
+import _gojsonnet
 
 from commodore.config import Config
 from commodore.component import Component
@@ -149,7 +149,7 @@ def run_jsonnet_filter(
         component.name,
         instance,
         path,
-        _jsonnet.evaluate_file,
+        _gojsonnet.evaluate_file,
         filterfile,
         **filterargs,
     )

--- a/commodore/postprocess/jsonnet.py
+++ b/commodore/postprocess/jsonnet.py
@@ -30,9 +30,9 @@ def _try_path(basedir: P, rel: str):
         raise RuntimeError("Attempted to import a directory")
 
     if not full_path.is_file():
-        return full_path.name, None
+        return str(full_path), None
     with open(full_path, encoding="utf-8") as f:
-        return full_path.name, f.read().encode("utf-8")
+        return str(full_path), f.read().encode("utf-8")
 
 
 def _import_callback_with_searchpath(search: Iterable[P], basedir: P, rel: str):

--- a/poetry.lock
+++ b/poetry.lock
@@ -801,6 +801,16 @@ doc = ["sphinx (==4.3.2)", "sphinx-autodoc-typehints", "sphinx-rtd-theme", "sphi
 test = ["coverage[toml]", "ddt (>=1.1.1,!=1.4.3)", "mock", "mypy", "pre-commit", "pytest (>=7.3.1)", "pytest-cov", "pytest-instafail", "pytest-mock", "pytest-sugar", "typing-extensions"]
 
 [[package]]
+name = "gojsonnet"
+version = "0.20.0"
+description = "Python bindings for Jsonnet - The data templating language"
+optional = false
+python-versions = "*"
+files = [
+    {file = "gojsonnet-0.20.0.tar.gz", hash = "sha256:9aede3b5734dee1c99dbec75dee3b086baaae92bd262d93f9217e21bf19c9682"},
+]
+
+[[package]]
 name = "google-api-core"
 version = "2.22.0"
 description = "Google API client core library"
@@ -2820,4 +2830,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10, <3.13"
-content-hash = "3819bc428ebf44e6d915e687f57c16f5b7d063629d4fe9ccacef0f813579a884"
+content-hash = "338126c3d15c2138cf5d54c40cec50406a2ec5b147f2067e4af3ec66873e0ecd"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ oauthlib = "3.2.2"
 pyjwt = "2.9.0"
 PyGithub = "2.5.0"
 reclass-rs = "0.5.0"
+gojsonnet = "0.20.0"
 
 [tool.poetry.dev-dependencies]
 tox = "3.28.0"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ https://docs.pytest.org/en/latest/how-to/fixtures.html#scope-sharing-fixtures-ac
 
 from __future__ import annotations
 
+import multiprocessing
 import os
 
 from pathlib import Path
@@ -23,6 +24,14 @@ from commodore.gitrepo import GitRepo
 
 class RunnerFunc(Protocol):
     def __call__(self, args: list[str]) -> Result: ...
+
+
+# For gojsonnet we must use start_method "spawn" for multiprocessing so that the tests don't break
+# with pytest-xdist. Since we also use start_method "spawn" in Commodore, this should be fine. We
+# set this via a session-scoped autouse fixture, so it's set once when the PyTest session starts.
+@pytest.fixture(autouse=True, scope="session")
+def init_env():
+    multiprocessing.set_start_method("spawn")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_commodore_libjsonnet.py
+++ b/tests/test_commodore_libjsonnet.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from commodore.postprocess.jsonnet import _import_cb, _native_callbacks
 
-import _jsonnet
+import _gojsonnet
 import pytest
 import yaml
 
@@ -100,7 +100,7 @@ def render_jsonnet(tmp_path: Path, inputf: Path, invf: Path, **kwargs):
     _native_cb = _native_callbacks
     _native_cb["commodore_inventory"] = ((), _inventory)
 
-    resstr = _jsonnet.evaluate_file(
+    resstr = _gojsonnet.evaluate_file(
         str(inputf),
         import_callback=functools.partial(_import_cb, tmp_path),
         native_callbacks=_native_cb,

--- a/tests/test_postprocess.py
+++ b/tests/test_postprocess.py
@@ -398,7 +398,7 @@ def test_postprocess_jsonnet_try_path(tmp_path, full_rel):
 
     path, contents = jsonnet_pp._try_path(tmp_path, rel)
 
-    assert path == testf.name
+    assert path == str(testf)
     assert contents == b"Test"
 
 
@@ -429,7 +429,7 @@ def test_postprocess_jsonnet_import_cb(tmp_path, basedir, floc):
     bdir = str((tmp_path / basedir).absolute())
     path, contents = jsonnet_pp._import_cb(tmp_path, bdir, "test.txt")
 
-    assert path == "test.txt"
+    assert path == str(testf)
     assert contents == f"Test {tmp_path / floc}".encode("utf-8")
 
 


### PR DESCRIPTION
We add go-jsonnet as a dependency, set `use_go_jsonnet=True` when calling `kapitan.targets.render_targets()` and replace our direct usages of jsonnet for rendering jsonnetfile.jsonnet for components and for postprocessing with go-jsonnet.

Additionally, we fix an oversight in the Jsonnet import callback used by the Commodore postprocessing where we should return a full path to the imported file but instead returned the filename only. With go-jsonnet this leads to an import loop for `lib/kube.libjsonnet` for the builtin `helm_namespace` filter. Interestingly, the same issue doesn't occur when using the same include in a Jsonnet postprocessing filter. Note that with C++ jsonnet we never had any issues with the previous import callback implementation. Additionally, note that Kapitan returns the full path in the import callback, cf. https://github.com/kapicorp/kapitan/blob/dfa5d33bd3e74db5fad84086c833402bc892da6f/kapitan/resources.py#L211-L257

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
