### PR TITLE
Add a prerequisite for the Go compiler for go-jsonnet

### DIFF
--- a/docs/modules/ROOT/pages/explanation/running-commodore.adoc
+++ b/docs/modules/ROOT/pages/explanation/running-commodore.adoc
@@ -22,6 +22,8 @@ We recommend that you install Python and the `venv` module with your preferred p
 * Additionally, a few of the Commodore Python package dependencies require a working C compiler, the Python 3 development package, and the FFI development package.
 On Linux distributions you'll want packages `python3-dev` or `python3-devel` and `libffi-dev` or `libffi-devel` respectively.
 Please refer to your operating system's documentation for instructions to setup a working C compiler.
+* Installing the `gojsonnet` Python package requires a working Go compiler.
+Please check your operating system's documentation for instructions to setup a working Go compiler.
 * On some Linux distributions, you may need to install the Python `wheel` package manually.
 * jsonnet-bundler from https://github.com/projectsyn/jsonnet-bundler/releases[projectsyn/jsonnet-bundler/releases] in your `$PATH` as `jb`.
 * Helm 3, https://helm.sh/docs/intro/install/[installation instructions]


### PR DESCRIPTION
The `gojsonnet` Python package requires a working Go compiler, since no wheels are published for that package. This commit updates the PyPI install instructions for Commodore with a prerequisite for a working Go compiler.

Follow-up for #1046 

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
