### PR TITLE
Let Kapitan decide how many targets to compile in parallel

### DIFF
--- a/commodore/helpers.py
+++ b/commodore/helpers.py
@@ -255,7 +255,7 @@ def kapitan_compile(
         search_paths=search_paths,
         output_path=output_dir,
         desired_targets=targets,
-        parallelism=4,
+        parallelism=None,
         labels=None,
         ref_controller=refController,
         prune=False,


### PR DESCRIPTION
We update the call to Kapitan's `compile_targets()` to set `parallelism=None` which enables Kapitan's new auto-parallelism logic which will detect the number of CPUs of the system and compile that many targets in parallel.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
