### PR TITLE
Add support for custom template versions for dependency update and sync

### DIFF
--- a/commodore/cli/component.py
+++ b/commodore/cli/component.py
@@ -291,12 +291,7 @@ def component_group(config: Config, verbose):
     show_default=True,
     help="The URL of the component cookiecutter template.",
 )
-@click.option(
-    "--template-version",
-    default="main",
-    show_default=True,
-    help="The component template version (Git tree-ish) to use.",
-)
+@options.template_version("main")
 @new_update_options(new_cmd=True)
 @options.verbosity
 @options.pass_config
@@ -430,6 +425,7 @@ def component_new(
     default=True,
     help="Whether to commit the rendered template changes.",
 )
+@options.template_version(None)
 @options.verbosity
 @options.pass_config
 def component_update(
@@ -437,6 +433,7 @@ def component_update(
     verbose: int,
     component_path: str,
     copyright_holder: str,
+    template_version: Optional[str],
     golden_tests: Optional[bool],
     matrix_tests: Optional[bool],
     lib: Optional[bool],
@@ -492,6 +489,8 @@ def component_update(
         t.automerge_patch_v0 = automerge_patch_v0
     if autorelease is not None:
         t.autorelease = autorelease
+    if template_version is not None:
+        t.template_version = template_version
 
     test_cases = t.test_cases
     test_cases.extend(additional_test_case)
@@ -625,6 +624,7 @@ def component_compile(
 @options.pr_batch_size
 @options.github_pause
 @options.dependency_filter
+@options.template_version(None)
 def component_sync(
     config: Config,
     verbose: int,
@@ -636,6 +636,7 @@ def component_sync(
     pr_batch_size: int,
     github_pause: int,
     filter: str,
+    template_version: Optional[str],
 ):
     """This command processes all components listed in the provided `COMPONENT_LIST`
     YAML file.
@@ -672,4 +673,5 @@ def component_sync(
         pr_batch_size,
         timedelta(seconds=github_pause),
         filter,
+        template_version,
     )

--- a/commodore/cli/options.py
+++ b/commodore/cli/options.py
@@ -1,5 +1,7 @@
 """Click options which are reused for multiple commands"""
 
+from typing import Optional
+
 import click
 
 from commodore.config import Config
@@ -123,6 +125,22 @@ dependency_filter = click.option(
     + "If the option isn't given, all dependencies listed in the provided YAML "
     + "are synced.",
 )
+
+
+def template_version(default: Optional[str]):
+    help_str = "The component template version (Git tree-ish) to use."
+    if default is None:
+        help_str = (
+            help_str
+            + " If not provided, the currently active template version will be used."
+        )
+
+    return click.option(
+        "--template-version",
+        default=default,
+        show_default=default is not None,
+        help=help_str,
+    )
 
 
 def local(help: str):

--- a/commodore/cli/package.py
+++ b/commodore/cli/package.py
@@ -61,12 +61,7 @@ def package_group(config: Config, verbose: int):
     show_default=True,
     help="The URL of the package cookiecutter template.",
 )
-@click.option(
-    "--template-version",
-    default="main",
-    show_default=True,
-    help="The package template version (Git tree-ish) to use.",
-)
+@options.template_version("main")
 @click.option(
     "--output-dir",
     default="",
@@ -167,6 +162,7 @@ def package_new(
     default=True,
     help="Whether to commit the rendered template changes.",
 )
+@options.template_version(None)
 @options.verbosity
 @options.pass_config
 # pylint: disable=too-many-arguments
@@ -180,6 +176,7 @@ def package_update(
     additional_test_case: Iterable[str],
     remove_test_case: Iterable[str],
     commit: bool,
+    template_version: Optional[str],
 ):
     """This command updates the package at PACKAGE_PATH to the latest version of the
     template which was originally used to create it, if the template version is given as
@@ -201,6 +198,9 @@ def package_update(
         t.golden_tests = golden_tests
     if update_copyright_year:
         t.copyright_year = None
+    if template_version is not None:
+        t.template_version = template_version
+
     test_cases = t.test_cases
     test_cases.extend(additional_test_case)
     t.test_cases = [tc for tc in test_cases if tc not in remove_test_case]
@@ -278,6 +278,7 @@ def package_compile(
 @options.pr_batch_size
 @options.github_pause
 @options.dependency_filter
+@options.template_version(None)
 def package_sync(
     config: Config,
     verbose: int,
@@ -289,6 +290,7 @@ def package_sync(
     pr_batch_size: int,
     github_pause: int,
     filter: str,
+    template_version: Optional[str],
 ):
     """This command processes all packages listed in the provided `PACKAGE_LIST` YAML file.
 
@@ -324,4 +326,5 @@ def package_sync(
         pr_batch_size,
         timedelta(seconds=github_pause),
         filter,
+        template_version,
     )

--- a/commodore/dependency_syncer.py
+++ b/commodore/dependency_syncer.py
@@ -48,8 +48,6 @@ def sync_dependencies(
         )
         dry_run = True
 
-    deptype_str = deptype.__name__.lower()
-
     deps = read_dependency_list(dependency_list, depfilter)
     dep_count = len(deps)
 
@@ -57,40 +55,17 @@ def sync_dependencies(
     # Keep track of how many PRs we've created to better avoid running into rate limits
     update_count = 0
     for i, dn in enumerate(deps, start=1):
-        click.secho(f"Synchronizing {dn}", bold=True)
-        _, dreponame = dn.split("/")
-        dname = dreponame.replace(f"{deptype_str}-", "", 1)
-
-        # Clone dependency
-        try:
-            gr = gh.get_repo(dn)
-        except github.UnknownObjectException:
-            click.secho(f" > Repository {dn} doesn't exist, skipping...", fg="yellow")
-            continue
-
-        if gr.archived:
-            click.secho(f" > Repository {dn} is archived, skipping...", fg="yellow")
-            continue
-
-        d = deptype.clone(config, gr.clone_url, dname, version=gr.default_branch)
-
-        if not (d.target_dir / ".cruft.json").is_file():
-            click.echo(f" > Skipping repo {dn} which doesn't have `.cruft.json`")
-            continue
-
-        # Update the dependency
-        t = templater.from_existing(config, d.target_dir)
-        if template_version is not None:
-            t.template_version = template_version
-        changed = t.update(
-            print_completion_message=False,
-            commit=not dry_run,
-            ignore_template_commit=True,
+        changed = sync_dependency(
+            config,
+            gh,
+            dn,
+            deptype,
+            templater,
+            template_version,
+            dry_run,
+            pr_branch,
+            pr_label,
         )
-
-        # Create or update PR if there were updates
-        comment = render_pr_comment(d)
-        create_or_update_pr(d, dn, gr, changed, pr_branch, pr_label, dry_run, comment)
         if changed:
             update_count += 1
         if not dry_run and i < dep_count:
@@ -98,6 +73,56 @@ def sync_dependencies(
             # we're not in dry run mode, and we've not yet processed the last
             # dependency.
             _maybe_pause(update_count, pr_batch_size, pause)
+
+
+def sync_dependency(
+    config: Config,
+    gh: github.Github,
+    depname: str,
+    deptype: Type[Union[Component, Package]],
+    templater,
+    template_version: Optional[str],
+    dry_run: bool,
+    pr_branch: str,
+    pr_label: Iterable[str],
+):
+    deptype_str = deptype.__name__.lower()
+
+    click.secho(f"Synchronizing {depname}", bold=True)
+    _, dreponame = depname.split("/")
+    dname = dreponame.replace(f"{deptype_str}-", "", 1)
+
+    # Clone dependency
+    try:
+        gr = gh.get_repo(depname)
+    except github.UnknownObjectException:
+        click.secho(f" > Repository {depname} doesn't exist, skipping...", fg="yellow")
+        return
+
+    if gr.archived:
+        click.secho(f" > Repository {depname} is archived, skipping...", fg="yellow")
+        return
+
+    d = deptype.clone(config, gr.clone_url, dname, version=gr.default_branch)
+
+    if not (d.target_dir / ".cruft.json").is_file():
+        click.echo(f" > Skipping repo {depname} which doesn't have `.cruft.json`")
+        return
+
+    # Update the dependency
+    t = templater.from_existing(config, d.target_dir)
+    if template_version is not None:
+        t.template_version = template_version
+    changed = t.update(
+        print_completion_message=False,
+        commit=not dry_run,
+        ignore_template_commit=True,
+    )
+
+    # Create or update PR if there were updates
+    comment = render_pr_comment(d)
+    create_or_update_pr(d, depname, gr, changed, pr_branch, pr_label, dry_run, comment)
+    return changed
 
 
 def read_dependency_list(dependency_list: Path, depfilter: str) -> list[str]:

--- a/commodore/dependency_templater.py
+++ b/commodore/dependency_templater.py
@@ -49,12 +49,20 @@ def _ignore_cruft_json_commit_id(
                 n=0,
             )
         )[3:]
-        # If the context-less diff has exactly 2 lines and both of them start with
-        # '[-+] "commit":', we omit the diff
         if (
+            # If the context-less diff has exactly 2 lines and both of them start with
+            # '[-+] "commit":', we omit the diff
             len(minimal_diff) == 2
             and minimal_diff[0].startswith('-  "commit":')
             and minimal_diff[1].startswith('+  "commit":')
+        ) or (
+            # If the context-less diff has exactly 4 lines and the two pairs start with
+            # '[-+] "commit":' and '[-+] "checkout":', we omit the diff
+            len(minimal_diff) == 4
+            and minimal_diff[0].startswith('-  "commit":')
+            and minimal_diff[1].startswith('-  "checkout":')
+            and minimal_diff[2].startswith('+  "commit":')
+            and minimal_diff[3].startswith('+  "checkout":')
         ):
             omit = True
     # never suppress diffs in default difffunc

--- a/docs/modules/ROOT/pages/reference/cli.adoc
+++ b/docs/modules/ROOT/pages/reference/cli.adoc
@@ -308,6 +308,10 @@ NOTE: If autorelease is enabled, new releases will be generated for automerged d
 *--commit / --no-commit*::
   Whether to commit the rendered template changes.
 
+*--template-version* TEXT::
+  The component template version (Git tree-ish) to use.
+  If not provided, the currently active template version will be used.
+
 *--automerge-patch / --no-automerge-patch*::
   Enable automerging of patch-level dependency PRs.
 
@@ -440,6 +444,10 @@ However, labels added by previous runs can't be removed since we've got no easy 
     Regex to select which dependencies to sync.
     If the option isn't given, all dependencies listed in the provided YAML are synced.
 
+*--template-version* TEXT::
+  The component template version (Git tree-ish) to use.
+  If not provided, the currently active template version will be used.
+
 == Inventory Components / Packages / Show
 
 *-f, --values*::
@@ -549,6 +557,10 @@ However, labels added by previous runs can't be removed since we've got no easy 
 *--commit / --no-commit*::
   Whether to commit the rendered template changes.
 
+*--template-version* TEXT::
+  The component template version (Git tree-ish) to use.
+  If not provided, the currently active template version will be used.
+
 == Package Compile
 
 *-f, --values* FILE::
@@ -638,3 +650,7 @@ However, labels added by previous runs can't be removed since we've got no easy 
 *--filter* REGEX::
     Regex to select which dependencies to sync.
     If the option isn't given, all dependencies listed in the provided YAML are synced.
+
+*--template-version* TEXT::
+  The component template version (Git tree-ish) to use.
+  If not provided, the currently active template version will be used.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -141,3 +141,24 @@ class MockMultiDependency:
 @pytest.fixture
 def mockdep(tmp_path):
     return MockMultiDependency(Repo.init(tmp_path / "repo.git"))
+
+
+class MockTemplater:
+    def __init__(self):
+        self.template_version = None
+        self.test_cases = []
+
+    def update(self, *args, **kwargs):
+        pass
+
+
+def make_mock_templater(mock_templater, expected_path):
+    mt = MockTemplater()
+
+    def mock_from_existing(_config: Config, path: Path):
+        assert path == expected_path
+        return mt
+
+    mock_templater.from_existing = mock_from_existing
+
+    return mt


### PR DESCRIPTION
We make use of the native support for specifying a template version in Cruft to pass through a custom version in dependency update and sync.

We introduce flag `--template-version` for the component and package `update` and `sync` commands.

Resolves #618 

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
