### PR TITLE
Fix component multi-version verification

### DIFF
--- a/commodore/compile.py
+++ b/commodore/compile.py
@@ -236,7 +236,7 @@ def setup_compile_environment(config: Config) -> tuple[dict[str, Any], Iterable[
     create_component_library_aliases(config, cluster_parameters)
 
     # Verify that all aliased components support instantiation
-    config.verify_component_aliases(cluster_parameters)
+    config.verify_component_aliases(inventory)
     config.register_component_deprecations(cluster_parameters)
     # Raise exception if component version override without URL is present in the
     # hierarchy.

--- a/commodore/component/compile.py
+++ b/commodore/component/compile.py
@@ -82,7 +82,7 @@ def compile_component(
 
         # Verify component alias
         nodes = kapitan_inventory(config)
-        config.verify_component_aliases(nodes[instance_name]["parameters"])
+        config.verify_component_aliases(nodes, bootstrap_target=instance_name)
 
         cluster_params = nodes[instance_name]["parameters"]
         create_component_library_aliases(config, cluster_params)


### PR DESCRIPTION
We need to check whether a component instance that sets a custom version supports per-instance versions by checking the instance's target's parameters. The bootstrap target ("cluster") doesn't have any instance-specific parameters, but since we do the validation after setting up all instance targets, we can use the instance's target to read `_metadata` of the alias's version to properly validate that both the base component and the alias are multi-version aware.

Additionally, because `component compile` doesn't have the regular bootstrap target (and generating it just for alias validation seems a bit overkill), we make the `bootstrap_target` key an optional parameter for `verify_component_aliases()` and set it to the component that's being compiled for `component compile` and fall back to `config.inventory.boostrap_target` when it's not set.

We also adjust all tests that cover `verify_component_aliases()` to pass a Kapitan/reclass inventory dict instead of just a parameters dict and update the test inputs to set the alias `_metadata` in the  component parameters key instead of the instance parameters key to replicate the structure that we generate for `catalog compile`.


## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
