### PR TITLE
Make the backing `MultiDependency` for `Component` non-optional

### DIFF
--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -416,95 +416,40 @@ def test_component_get_library(tmp_path: P, libfiles: Iterable[str]):
         assert c.get_library(f) == tmp_path / "tc1" / "lib" / f
 
 
-def test_component_no_dep_get_dependency(tmp_path: P):
-    c = Component("test-component", None, directory=tmp_path)
-    with pytest.raises(ValueError) as e:
-        _ = c.dependency
-
-    assert (
-        str(e.value)
-        == "Dependency for component test-component hasn't been initialized"
-    )
-
-
-def test_component_no_dep_get_url(tmp_path: P):
-    c = Component("test-component", None, directory=tmp_path)
-    with pytest.raises(ValueError) as e:
-        _ = c.repo_url
-
-    assert (
-        str(e.value)
-        == "Dependency for component test-component hasn't been initialized"
-    )
-
-
-def test_component_no_dep_checkout(tmp_path: P):
-    c = Component("test-component", None, directory=tmp_path)
-    with pytest.raises(ValueError) as e:
-        c.checkout()
-
-    assert (
-        str(e.value)
-        == "Dependency for component test-component hasn't been initialized"
-    )
-
-
-@pytest.mark.parametrize("init_dep", [False, True])
-@pytest.mark.parametrize("new_dep", [False, True])
-def test_component_update_dependency(tmp_path: P, init_dep: bool, new_dep: bool):
+def test_component_update_dependency(tmp_path: P):
     r1 = _setup_existing_component(tmp_path / "tc1")
     r2 = _setup_existing_component(tmp_path / "tc2")
 
-    idep = None
-    if init_dep:
-        idep = MultiDependency(f"file://{r1.common_dir}", tmp_path / "dependencies")
+    idep = MultiDependency(f"file://{r1.common_dir}", tmp_path / "dependencies")
 
     c = Component("tc1", idep, tmp_path)
 
-    if init_dep:
-        c.checkout()
-        assert c.dependency == idep
-        assert c.repo_url == idep.url
-        assert c.repo.repo.head.commit.hexsha == r1.head.commit.hexsha
-    else:
-        with pytest.raises(ValueError) as exc:
-            _ = c.dependency
-        assert str(exc.value) == "Dependency for component tc1 hasn't been initialized"
+    c.checkout()
+    assert c.dependency == idep
+    assert c.repo_url == idep.url
+    assert c.repo.repo.head.commit.hexsha == r1.head.commit.hexsha
 
-    ndep = None
-    if new_dep:
-        ndep = MultiDependency(f"file://{r2.common_dir}", tmp_path / "dependencies")
-
+    ndep = MultiDependency(f"file://{r2.common_dir}", tmp_path / "dependencies")
     c.dependency = ndep
 
-    if ndep:
-        c.checkout()
-        assert c.dependency == ndep
-        assert c.repo_url == ndep.url
-        assert c.repo.repo.head.commit.hexsha == r2.head.commit.hexsha
-    else:
-        with pytest.raises(ValueError) as exc:
-            _ = c.dependency
-        assert str(exc.value) == "Dependency for component tc1 hasn't been initialized"
+    c.checkout()
+    assert c.dependency == ndep
+    assert c.repo_url == ndep.url
+    assert c.repo.repo.head.commit.hexsha == r2.head.commit.hexsha
 
 
-@pytest.mark.parametrize("dep", [True, False])
-def test_component_repo(tmp_path: P, dep: bool):
+def test_component_repo(tmp_path: P):
     u = Repo.init(tmp_path / "bare.git")
     (tmp_path / "bare.git" / "x").touch()
     u.index.add(["x"])
     u.index.commit("Initial commit")
 
-    if dep:
-        md = MultiDependency(f"file://{tmp_path}/bare.git", tmp_path)
-    else:
-        md = None
+    md = MultiDependency(f"file://{tmp_path}/bare.git", tmp_path)
 
     c = Component(
         "test-component", md, directory=tmp_path / "test-component", version="master"
     )
-    if md:
-        c.checkout()
+    c.checkout()
 
     assert c.repo.working_tree_dir == tmp_path / "test-component"
 
@@ -527,6 +472,5 @@ def test_checkout_is_dirty(tmp_path: P, config: Config):
 
     c = Component.clone(config, clone_url, "test-component")
     c.checkout()
-    c._dependency = None
 
     assert not c.checkout_is_dirty()


### PR DESCRIPTION
This simplifies a lot of the implementation for `Component` and only surfaces in a minor way in `component_compile` where we may need to create a fake `MultiDependency` if we compile a component outside a Git repo.

Split out from #1101 

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
