### PR TITLE
Only discard changes in alias checkouts when catalog compilation called with `--force`

### DIFF
--- a/commodore/component/__init__.py
+++ b/commodore/component/__init__.py
@@ -244,6 +244,25 @@ class Component:
         else:
             return False
 
+    def alias_checkout_is_dirty(self, alias: str) -> bool:
+        if alias not in self._aliases:
+            raise ValueError(
+                f"alias {alias} is not registered on component {self.name}"
+            )
+        adep = self._aliases[alias][2]
+        dep_repo = adep.bare_repo
+        author_name = dep_repo.author.name
+        author_email = dep_repo.author.email
+        worktree = adep.get_component(alias)
+
+        if worktree and worktree.is_dir():
+            r = GitRepo(
+                None, worktree, author_name=author_name, author_email=author_email
+            )
+            return r.repo.is_dirty()
+        else:
+            return False
+
     def render_jsonnetfile_json(self, component_params):
         """
         Render jsonnetfile.json from jsonnetfile.jsonnet

--- a/commodore/component/__init__.py
+++ b/commodore/component/__init__.py
@@ -29,6 +29,7 @@ class Component:
             name,
             cdep,
             directory=component_dir(cfg.work_dir, name),
+            work_dir=cfg.work_dir,
             version=version,
         )
         c.checkout()

--- a/commodore/dependency_mgmt/__init__.py
+++ b/commodore/dependency_mgmt/__init__.py
@@ -126,6 +126,11 @@ def fetch_components(cfg: Config):
         if aspec.url != c.repo_url:
             adep = cfg.register_dependency_repo(aspec.url)
         c.register_alias(alias, aspec.version, adep, aspec.path)
+        if c.alias_checkout_is_dirty(alias) and not cfg.force:
+            raise click.ClickException(
+                f"Component alias {alias} has uncommitted changes. "
+                + "Please specify `--force` to discard them"
+            )
         if adep.url in deps:
             # NOTE(sg): if we already processed the dependency URL in the previous fetch
             # stage, we can create all instance worktrees in parallel. We do so by using

--- a/commodore/dependency_mgmt/__init__.py
+++ b/commodore/dependency_mgmt/__init__.py
@@ -14,7 +14,7 @@ from commodore.package import Package, package_dependency_dir
 from .component_library import validate_component_library_name
 from .discovery import _discover_components, _discover_packages
 from .tools import format_component_list
-from .version_parsing import _read_components, _read_packages
+from .version_parsing import _read_components, _read_packages, DependencySpec
 
 
 def create_component_symlinks(cfg, component: Component):
@@ -112,8 +112,16 @@ def fetch_components(cfg: Config):
         deps.setdefault(cdep.url, []).append(c)
     do_parallel(fetch_component, cfg, deps.values())
 
-    components = cfg.get_components()
+    _setup_component_aliases(cfg, component_aliases, cspecs, set(deps.keys()))
 
+
+def _setup_component_aliases(
+    cfg: Config,
+    component_aliases: dict[str, str],
+    cspecs: dict[str, DependencySpec],
+    component_urls: set[str],
+):
+    components = cfg.get_components()
     aliases: dict[str, list] = {}
     for alias, component in component_aliases.items():
         if alias == component:
@@ -131,7 +139,7 @@ def fetch_components(cfg: Config):
                 f"Component alias {alias} has uncommitted changes. "
                 + "Please specify `--force` to discard them"
             )
-        if adep.url in deps:
+        if adep.url in component_urls:
             # NOTE(sg): if we already processed the dependency URL in the previous fetch
             # stage, we can create all instance worktrees in parallel. We do so by using
             # the alias name as the key for our "parallelization" dict.


### PR DESCRIPTION
This ensures that `commodore catalog compile` doesn't silently discard local changes in a component instance worktree (the same as catalog compilation is already aborted when a component worktree with local changes is encountered).
## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
