### PR TITLE
Correctly abort `catalog compile` for local changes in tenant repo

### DIFF
--- a/commodore/compile.py
+++ b/commodore/compile.py
@@ -219,7 +219,7 @@ def _abort_on_local_changes(cfg: Config, cluster: Cluster):
         )
 
     tr = GitRepo(None, cfg.inventory.tenant_config_dir(cluster.tenant_id))
-    if tr.has_local_changes() or gr.has_local_branches() or gr.is_ahead_of_remote():
+    if tr.has_local_changes() or tr.has_local_branches() or tr.is_ahead_of_remote():
         raise click.ClickException(
             "Tenant repo has local (uncommitted or unpushed) changes. "
             + "Please specify `--force` to discard them."


### PR DESCRIPTION
We incorrectly used `gr.has_local_branches()` and
`gr.is_ahead_of_remote()` when checking whether the tenant repo has local branches or is ahead of the tracking branch.

NOTE: we don't need to fetch first when checking if we're ahead of the tracking branch, since the cases we want to cover are 1) forgot to push and 2) push failed but got overlooked before running `catalog compile`.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [ ] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
