### PR TITLE
Don't try to infer the dependencies directory in `component compile`

### DIFF
--- a/commodore/component/compile.py
+++ b/commodore/component/compile.py
@@ -143,7 +143,7 @@ def _setup_component(
         target_dir = P(cr.working_tree_dir)
         # compute subpath from Repo working tree dir and component path
         sub_path = str(component_path.absolute().relative_to(target_dir))
-        cdep = MultiDependency(cr.remote().url, target_dir.parent)
+        cdep = MultiDependency(cr.remote().url, config.inventory.dependencies_dir)
     except git.InvalidGitRepositoryError:
         click.echo(" > Couldn't determine Git repository for component")
         # Just treat `component_path` as a directory holding a component, don't care


### PR DESCRIPTION
We mount the component repo at `/<component-name>` in the Docker container when using `component compile` in the component template. In that case, the old code inferred `dependencies_dir` as `/` which isn't writable in the container environment.

This commit adjusts the implementation to use `config.inventory.dependencies_dir` which should always be writable. Since we don't actually use any functionality backed by `MultiDependency` in `component compile` it shouldn't matter whether we actually find the correct dependencies directory in all cases.

Fixes a bug introduced in #1102

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
