### PR TITLE
Remove libmagic1 from Docker image and from docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       curl \
       git \
       gpg \
-      libmagic1 \
       libnss-wrapper \
       openssh-client \
  && rm -rf /var/lib/apt/lists/* \

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ Commodore also supports additional processing on the output of Kapitan, such as 
 * [jsonnet-bundler](https://github.com/jsonnet-bundler/jsonnet-bundler)
   * Our fork [projectsyn/jsonnet-bundler](https://github.com/projectsyn/jsonnet-bundler) is currently recommended.
     It parallelizes fetching of dependencies, which speeds up Commodore significantly, and has fixes to make the dependency fetching more deterministic.
-* `libmagic` (install with `brew install libmagic` on macOS)
 
 ## Getting started
 

--- a/docs/modules/ROOT/pages/explanation/running-commodore.adoc
+++ b/docs/modules/ROOT/pages/explanation/running-commodore.adoc
@@ -77,13 +77,6 @@ source ~/.local/commodore-venv/bin/activate
 pip install syn-commodore
 ----
 
-. On MacOS you'll also need libmagic via brew
-+
-[source,bash]
-----
-brew install libmagic
-----
-
 . Check that `commodore` was installed correctly
 +
 [source,bash]


### PR DESCRIPTION
Kapitan 0.34.5 has switched to the Python `filetype` library instead of the `python-magic` library. This removes the dependency on `libmagic1` for Kapitan and therefore also for Commodore, since we don't use filetype detection ourselves.

See also https://github.com/kapicorp/kapitan/pull/1304 and #1126

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
