### PR TITLE
Fix permissions for `/app/.cache/` in the container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,8 +79,10 @@ RUN ln -s \
 
 COPY ./tools/entrypoint.sh /usr/local/bin/
 
-RUN chgrp 0 /app/ \
+RUN chgrp -R 0 /app/ \
  && chmod g+rwX /app/ \
+ && chmod g+rwX /app/.cache \
+ && chmod g+rwX /app/.cache/commodore \
  && mkdir /app/.gnupg \
  && chmod ug+w /app/.gnupg
 


### PR DESCRIPTION
We now populate `/app/.cache/commodore/tools` with the required external tools, but other tooling (e.g. Helm) also needs to be able to write to `/app/.cache` (and commodore itself needs to be able to write to `/app/.cache/commodore/token`). While refactoring the Dockerfile, we forgot to extend the permission adjustments for `/app` to also cover existing directories in `/app/.cache`.

This commit ensures that everything in `/app` has group 0 and that directories `/app/.cache/` and `/app/.cache/commodore` are writable by group 0.

Follow-up to #1174 

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
