### PR TITLE
Update Commodore install instructions for Kapitan 0.34.7

### DIFF
--- a/docs/modules/ROOT/pages/explanation/running-commodore.adoc
+++ b/docs/modules/ROOT/pages/explanation/running-commodore.adoc
@@ -22,7 +22,8 @@ We recommend that you use the Commodore Python package provided on PyPI to make 
 * `git`
 * A Python version between 3.10 and 3.12 as `python3` and the Python `venv` module.
 We recommend that you install Python and the `venv` module with your preferred package manager.
-* Additionally, a few of the Commodore Python package dependencies require a working C compiler, the Python 3 development package, and the FFI development package.
+* Installation may require a working C compiler, the Python 3 development package, and the FFI development package on some operating systems.
+For Commodore v1.29.1 and newer, all dependencies should be available as prebuilt wheels for Linux and macOS.
 On Linux distributions you'll want packages `python3-dev` or `python3-devel` and `libffi-dev` or `libffi-devel` respectively.
 Please refer to your operating system's documentation for instructions to setup a working C compiler.
 * Installing the `gojsonnet` Python package may require a working Go compiler on some operating systems.

--- a/docs/modules/ROOT/pages/how-to/installing-commodore.adoc
+++ b/docs/modules/ROOT/pages/how-to/installing-commodore.adoc
@@ -18,7 +18,8 @@ TIP: See the extended xref:explanation/running-commodore.adoc[Running Commodore]
 * `uv`.
 Please check the https://docs.astral.sh/uv/getting-started/installation/[uv installation instructions] for installing `uv` on your system.
 This installation guide uses  `uv` to install a `python3` version that's supported by Commodore if your system's default Python version isn't compatible with Commodore.
-* A few of the Commodore Python package dependencies require a working C compiler, the Python 3 development package, and the FFI development package.
+* Installation may require a working C compiler, the Python 3 development package, and the FFI development package on some operating systems.
+For Commodore v1.29.1 and newer, all dependencies should be available as prebuilt wheels for Linux and macOS.
 On Linux distributions you'll want packages `python3-dev` or `python3-devel` and `libffi-dev` or `libffi-devel` respectively.
 Please refer to your operating system's documentation for instructions to setup a working C compiler.
 * Installing the `gojsonnet` Python package may require a working Go compiler on some operating systems.


### PR DESCRIPTION
Note that all dependencies should now be available as prebuilt wheels for Linux and macOS.

Follow-up for #1198

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
