### PR TITLE
Fix dependency updater custom `.cruft.json` diffing

### DIFF
--- a/commodore/dependency_templater.py
+++ b/commodore/dependency_templater.py
@@ -50,19 +50,32 @@ def _ignore_cruft_json_commit_id(
             )
         )[3:]
         if (
-            # If the context-less diff has exactly 2 lines and both of them start with
-            # '[-+] "commit":', we omit the diff
-            len(minimal_diff) == 2
-            and minimal_diff[0].startswith('-  "commit":')
-            and minimal_diff[1].startswith('+  "commit":')
-        ) or (
-            # If the context-less diff has exactly 4 lines and the two pairs start with
-            # '[-+] "commit":' and '[-+] "checkout":', we omit the diff
-            len(minimal_diff) == 4
-            and minimal_diff[0].startswith('-  "commit":')
-            and minimal_diff[1].startswith('-  "checkout":')
-            and minimal_diff[2].startswith('+  "commit":')
-            and minimal_diff[3].startswith('+  "checkout":')
+            (
+                # If the context-less diff has exactly 2 lines and both of them start with
+                # '[-+] "commit":', we omit the diff
+                len(minimal_diff) == 2
+                and minimal_diff[0].startswith('-  "commit":')
+                and minimal_diff[1].startswith('+  "commit":')
+            )
+            or (
+                # If the context-less diff has exactly 4 lines and the two pairs start with
+                # '[-+] "commit":' and '[-+] "checkout":', we omit the diff
+                len(minimal_diff) == 4
+                and minimal_diff[0].startswith('-  "commit":')
+                and minimal_diff[1].startswith('-  "checkout":')
+                and minimal_diff[2].startswith('+  "commit":')
+                and minimal_diff[3].startswith('+  "checkout":')
+            )
+            or (
+                # If the context-less diff has exactly 5 lines and both diff pairs start
+                # with '[-+][ ]+"(_?)commit":' we omit the diff
+                len(minimal_diff) == 5
+                and minimal_diff[0].startswith('-  "commit":')
+                and minimal_diff[1].startswith('+  "commit":')
+                and minimal_diff[2].startswith("@@")
+                and minimal_diff[3].startswith('-      "_commit":')
+                and minimal_diff[4].startswith('+      "_commit":')
+            )
         ):
             omit = True
     # never suppress diffs in default difffunc

--- a/tests/test_component_template.py
+++ b/tests/test_component_template.py
@@ -1767,6 +1767,9 @@ def test_component_update_ignore_template_commit_id(
         tmp_path / "template",
     )
     cruft_json["commit"] = template_repo.head.commit.parents[0].hexsha
+    cruft_json["context"]["cookiecutter"]["_commit"] = (
+        template_repo.head.commit.parents[0].hexsha
+    )
     with open(component_path / ".cruft.json", "w", encoding="utf-8") as f:
         json.dump(cruft_json, f, indent=2)
         f.write("\n")


### PR DESCRIPTION
Cruft's config file layout has changed slightly in a way which requires an adjustment for the dependency updater's custom diffing which can ignore diffs where only the template commit id in the `.cruft.json` changes.

This commit adjusts the custom diffing to cover the new case (while keeping the old cases), so we don't get useless template updates.

Additionally, we adjust the corresponding test to correctly mock the new `.cruft.json` layout.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog


<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
