### PR TITLE
Fix alias worktree creation for GitPython >= 3.1.48

### DIFF
--- a/commodore/dependency_mgmt/__init__.py
+++ b/commodore/dependency_mgmt/__init__.py
@@ -141,16 +141,11 @@ def _setup_component_aliases(
                 f"Component alias {alias} has uncommitted changes. "
                 + "Please specify `--force` to discard them"
             )
-        if adep.url in component_urls:
-            # NOTE(sg): if we already processed the dependency URL in the previous fetch
-            # stage, we can create all instance worktrees in parallel. We do so by using
-            # the alias name as the key for our "parallelization" dict.
-            aliases[alias] = [(alias, c)]
-        else:
-            # Otherwise, we use adep.url as the parallelization key to avoid any race
-            # conditions when creating multiple worktrees from a not-yet-cloned
-            # dependency URL.
-            aliases.setdefault(adep.url, []).append((alias, c))
+        # NOTE(sg): Starting from gitpython 3.1.48, we intermittently run into locking errors and
+        # similar if we try to create multiple worktrees in parallel from a single bare checkout, so
+        # we unconditionally use adep.url as the parallelization key to avoid any race conditions
+        # when creating multiple worktrees from a single dependency URL.
+        aliases.setdefault(adep.url, []).append((alias, c))
 
     do_parallel(setup_alias, cfg, aliases.values())
 

--- a/tests/test_dependency_mgmt.py
+++ b/tests/test_dependency_mgmt.py
@@ -197,6 +197,42 @@ def test_fetch_components(patch_discover, patch_read, config: Config, tmp_path: 
 
 @patch("commodore.dependency_mgmt._read_components")
 @patch("commodore.dependency_mgmt._discover_components")
+def test_fetch_components_aliases(
+    patch_discover, patch_read, config: Config, tmp_path: Path
+):
+    components = ["component-one", "component-two"]
+    aliases = {
+        "alias-one-a": "component-one",
+        "alias-one-b": "component-one",
+        "alias-one-c": "component-one",
+        "alias-one-d": "component-one",
+        "alias-two-a": "component-two",
+        "alias-two-b": "component-two",
+        "alias-two-c": "component-two",
+        "alias-two-d": "component-two",
+    }
+    patch_discover.return_value = (components, aliases)
+    patch_read.return_value = setup_components_upstream(
+        tmp_path, components, aliases=aliases
+    )
+
+    dependency_mgmt.fetch_components(config)
+
+    for alias, component in aliases.items():
+        assert component in config._components
+        assert alias in config._component_aliases
+        assert config._component_aliases[alias] == component
+        assert (
+            tmp_path / "inventory" / "classes" / "components" / f"{alias}.yml"
+        ).is_symlink()
+        assert (
+            tmp_path / "inventory" / "classes" / "defaults" / f"{alias}.yml"
+        ).is_symlink()
+        assert (tmp_path / "dependencies" / alias).is_dir()
+
+
+@patch("commodore.dependency_mgmt._read_components")
+@patch("commodore.dependency_mgmt._discover_components")
 def test_fetch_components_with_alias_version(
     patch_discover, patch_read, config: Config, tmp_path: Path
 ):


### PR DESCRIPTION
Starting from GitPython 3.1.48, we intermittently run into locking errors and similar if we try to create multiple worktrees in parallel from a single bare checkout, so we change the implementation to always use the repo URL as the parallelization key to avoid any race conditions when creating multiple worktrees from a single dependency URL / bare checkout.

The PR also adds a new test case for `fetch_dependencies()` with a bunch of component aliases, but locally I've not been able to make the test case fail with the old code.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
