### PR TITLE
Support environment variable `COMMODORE_PROCESSES` to set the `--processes` flag for `catalog compile`

### DIFF
--- a/commodore/cli/catalog.py
+++ b/commodore/cli/catalog.py
@@ -166,6 +166,8 @@ def _complete_clusters(ctx: click.Context, _, incomplete: str) -> list[str]:
 )
 @click.option(
     "--processes",
+    envvar="COMMODORE_PROCESSES",
+    metavar="COUNT",
     type=int,
     default=0,
     show_default=True,


### PR DESCRIPTION
Follow-up for #1377.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
