### PR TITLE
Run cleanup PR tag workflow on `merge_group` "destroyed" event

### DIFF
--- a/.github/workflows/cleanup-pr-tag.yml
+++ b/.github/workflows/cleanup-pr-tag.yml
@@ -5,6 +5,9 @@ name: Delete closed PR container image tag
   pull_request:
     types:
       - closed
+  merge_group:
+    types:
+      - destroyed
 
 permissions:
   packages: write
@@ -14,7 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set image version for PR to branch name
+        if: github.event_name == 'pull_request'
         run: echo "VERSION=${GITHUB_HEAD_REF//\//-}" >> ${GITHUB_ENV}
+      - name: Set image version for merge queue to branch name
+        if: github.event_name == 'merge_group'
+        run: echo "VERSION=${GITHUB_REF//\//-}" >> ${GITHUB_ENV}
 
       - name: Delete PR container image tag
         uses: dataaxiom/ghcr-cleanup-action@v1


### PR DESCRIPTION
This should delete the container image tags created by merge queue CI runs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
