### PR TITLE
Add envsubst dependency to commodore image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ FROM base AS builder
 ENV PATH=${PATH}:${HOME}/.local/bin:/usr/local/go/bin
 
 ARG POETRY_VERSION=2.4.1
+ARG ENVSUBST_VERSION=v1.4.3
 RUN apt-get update && apt-get install -y --no-install-recommends \
       build-essential \
       curl \
@@ -21,6 +22,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       libffi-dev \
  && rm -rf /var/lib/apt/lists/* \
  && curl -sSL https://install.python-poetry.org | python - --version ${POETRY_VERSION} \
+ && curl -L https://github.com/a8m/envsubst/releases/download/${ENVSUBST_VERSION}/envsubst-`uname -s`-`uname -m` -o envsubst \
+ && chmod +x envsubst \
+ && mv envsubst /usr/local/bin/ \
  && mkdir -p /app/.config
 
 COPY --from=golang /usr/local/go /usr/local/go
@@ -69,6 +73,7 @@ COPY --from=builder \
 COPY --from=builder \
       /usr/local/bin/kapitan* \
       /usr/local/bin/commodore* \
+      /usr/local/bin/envsubst \
       /usr/local/bin/
 
 COPY --from=builder \


### PR DESCRIPTION
This PR adds the `envsubst` dependency from https://github.com/a8m/envsubst to the docker image, so it can be used in the CI pipelines of commodore components. The following PRs are dependent on this change:

- https://github.com/projectsyn/component-capi-core/pull/1
- https://github.com/vshn/component-capi-provider-cloudscale/pull/1
- https://github.com/vshn/component-capi-provider-talos/pull/1

NOTE: Check if it would be better to integrate this dependency in the `commodore tools` command and whether this would be out of scope for ALDE-262

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [ ] Update the documentation.
- [ ] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
